### PR TITLE
fix(menu & tooltip): 修复部分示例不生效

### DIFF
--- a/src/menu/_example/multi-side.jsx
+++ b/src/menu/_example/multi-side.jsx
@@ -1,15 +1,7 @@
 // @ts-nocheck
 import React, { Fragment, useState } from 'react';
 import { Menu } from 'tdesign-react';
-import {
-  AppIcon,
-  CodeIcon,
-  FileIcon,
-  UserIcon,
-  ViewListIcon,
-  MailIcon,
-  RollbackIcon,
-} from 'tdesign-icons-react';
+import { AppIcon, CodeIcon, FileIcon, UserIcon, ViewListIcon, MailIcon, RollbackIcon } from 'tdesign-icons-react';
 
 const { SubMenu, MenuItem } = Menu;
 
@@ -81,7 +73,9 @@ function MultiSide() {
         expanded={darkExpands}
         onExpand={(values) => setDarkExpands(values)}
         onChange={(v) => setDarkActive(v)}
-        operations={<ViewListIcon className="t-menu__operations-icon" onClick={() => setDarkCollapsed(!collapsed)} />}
+        operations={
+          <ViewListIcon className="t-menu__operations-icon" onClick={() => setDarkCollapsed(!darkCollapsed)} />
+        }
       >
         <MenuItem value="0" icon={<AppIcon />}>
           仪表盘

--- a/src/tooltip/_example/trigger.jsx
+++ b/src/tooltip/_example/trigger.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Tooltip, Input } from 'tdesign-react';
+import { Button, Tooltip } from 'tdesign-react';
 
 export default function Cumstomize() {
   return (
@@ -13,7 +13,7 @@ export default function Cumstomize() {
       <Tooltip content="文字提示仅展示文本内容" trigger="click">
         <Button variant="outline">点击时触发</Button>
       </Tooltip>
-      <Tooltip content="文字提示仅展示文本内容" trigger="contextMenu">
+      <Tooltip content="文字提示仅展示文本内容" trigger="context-menu">
         <Button variant="outline">右击时触发</Button>
       </Tooltip>
     </div>


### PR DESCRIPTION
1. `menu`组件[demo](https://tdesign.tencent.com/react/components/menu#%E5%B9%B3%E9%93%BA%E5%BC%8F%E4%BE%A7%E8%BE%B9%E5%AF%BC%E8%88%AA)暗黑模式 收起后无法展开
2. `tooltip`组件[demo](https://tdesign.tencent.com/react/components/tooltip#%E4%B8%8D%E5%90%8C%E8%A7%A6%E5%8F%91%E6%96%B9%E5%BC%8F%E7%9A%84%E6%96%87%E5%AD%97%E6%8F%90%E7%A4%BA)鼠标右键事件不生效