### PR TITLE
fix(popup): fix popup wrong display logic when using hover mode

### DIFF
--- a/src/popup/hooks/useTriggerProps.ts
+++ b/src/popup/hooks/useTriggerProps.ts
@@ -50,7 +50,10 @@ export default function useTriggerProps(
         show(e, 'trigger-element-hover');
         onMouseEnter && onMouseEnter(e);
       };
-      popupProps.onMouseEnter = (e) => show(e, 'trigger-element-hover'); // 兼容鼠标移入弹出框
+      popupProps.onMouseEnter = (e) => {
+        // 如果当前弹出框本身没有展示 hover时不应该展示
+        visible && show(e, 'trigger-element-hover');
+      }; // 兼容鼠标移入弹出框
       triggerProps.onMouseLeave = (e) => {
         hide(e, 'trigger-element-hover');
         onMouseLeave && onMouseLeave(e);


### PR DESCRIPTION
修复`popup`的错误展示逻辑。具体如下：
#### 目前表现
设置`trigger`为`hover`模式，当hover展示一次之后，再hover到弹出窗的位置，弹出层将会展示。
#### 预期表现
只在`triggerNode`时触发展示
![Kapture 2021-12-24 at 16 13 41](https://user-images.githubusercontent.com/32590310/147333882-8bb8fbe4-86b3-49da-a283-9146f07084bc.gif)

