### PR TITLE
refactor: 统一 React 导入方式

### DIFF
--- a/src/avatar/AvatarContext.tsx
+++ b/src/avatar/AvatarContext.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 const AvatarContext = React.createContext('default');
 

--- a/src/dialog/plugin.tsx
+++ b/src/dialog/plugin.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import DialogComponent, { DialogProps } from './Dialog';
 
 import { getAttach } from '../_util/dom';

--- a/src/input-number/InputNumber.tsx
+++ b/src/input-number/InputNumber.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useCallback, useMemo, FocusEventHandler, KeyboardEventHandler, useEffect } from 'react';
+import React, {
+  forwardRef,
+  useState,
+  useCallback,
+  useMemo,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  useEffect,
+} from 'react';
 import classNames from 'classnames';
 
 import { StyledProps } from '../common';
@@ -16,7 +24,7 @@ export type InputNumberInternalValue = number | string;
 export type ChangeContext = TdChangeContext & { value?: number };
 export interface InputNumberProps extends TdInputNumberProps, StyledProps {}
 
-const InputNumber = React.forwardRef((props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
+const InputNumber = forwardRef((props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
   const {
     className,
     style,

--- a/src/input-number/StepHandler.tsx
+++ b/src/input-number/StepHandler.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 import { ChevronUpIcon, ChevronDownIcon, RemoveIcon, AddIcon } from 'tdesign-icons-react';

--- a/src/notification/Notification.tsx
+++ b/src/notification/Notification.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import { CheckCircleFilledIcon, CloseIcon, InfoCircleFilledIcon } from 'tdesign-icons-react';
 import noop from '../_util/noop';
 import useConfig from '../_util/useConfig';
@@ -12,7 +12,7 @@ export interface NotificationProps extends TdNotificationProps {
   style?: Styles;
 }
 
-export const NotificationComponent = React.forwardRef<any, NotificationProps>((props, ref) => {
+export const NotificationComponent = forwardRef<any, NotificationProps>((props, ref) => {
   const {
     title = null,
     content = null,

--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React, { forwardRef } from 'react';
+import ReactDOM from 'react-dom';
 import useConfig from '../_util/useConfig';
 import {
   NotificationInfoOptions,
@@ -36,7 +36,7 @@ let seed = 0;
 
 export const listMap: Map<NotificationPlacementList, NotificationListInstance> = new Map();
 
-const NotificationList = React.forwardRef<NotificationListInstance, NotificationListProps>((props, ref) => {
+const NotificationList = forwardRef<NotificationListInstance, NotificationListProps>((props, ref) => {
   const { attach, placement, zIndex } = props;
   const { classPrefix } = useConfig();
   const [list, dispatchList] = React.useReducer(


### PR DESCRIPTION
来源此：https://github.com/Tencent/tdesign-react/pull/83#issuecomment-1001113226 ，统一了 React 导入形式，保证代码风格统一