### PR TITLE
feat: cascader inputwidth

### DIFF
--- a/src/cascader/Cascader.tsx
+++ b/src/cascader/Cascader.tsx
@@ -170,6 +170,7 @@ const Cascader: React.FC<CascaderProps> = (props) => {
 
   return (
     <Popup
+      className={`${name}__popup`}
       placement="bottom-left"
       visible={visible}
       overlayClassName={`${name}__dropdown`}

--- a/src/cascader/__tests__/__snapshots__/cascader.test.tsx.snap
+++ b/src/cascader/__tests__/__snapshots__/cascader.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`base.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -48,7 +48,7 @@ exports[`check-strictly.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -81,7 +81,7 @@ exports[`check-strictly.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -154,7 +154,7 @@ exports[`collapsed.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -205,7 +205,7 @@ exports[`collapsed.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -274,7 +274,7 @@ exports[`collapsed.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -332,7 +332,7 @@ exports[`disabled.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -365,7 +365,7 @@ exports[`disabled.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -407,7 +407,7 @@ exports[`ellipsis.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -449,7 +449,7 @@ exports[`filterable.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -482,7 +482,7 @@ exports[`filterable.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -537,7 +537,7 @@ exports[`keys.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -579,7 +579,7 @@ exports[`load.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -621,7 +621,7 @@ exports[`max.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -663,7 +663,7 @@ exports[`multiple.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -718,7 +718,7 @@ exports[`show-all-levels.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -760,7 +760,7 @@ exports[`size.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -793,7 +793,7 @@ exports[`size.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -826,7 +826,7 @@ exports[`size.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -868,7 +868,7 @@ exports[`trigger.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -901,7 +901,7 @@ exports[`trigger.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -943,7 +943,7 @@ exports[`value-mode.jsx 1`] = `
     class="tdesign-demo-block-column"
   >
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -976,7 +976,7 @@ exports[`value-mode.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"
@@ -1009,7 +1009,7 @@ exports[`value-mode.jsx 1`] = `
       </span>
     </div>
     <div
-      class="t-popup__reference"
+      class="t-popup__reference t-cascader__popup"
     >
       <span
         class="t-trigger"


### PR DESCRIPTION
 use input full width

before

![image](https://user-images.githubusercontent.com/35833812/148156927-84dab6b0-047a-4f8f-8c64-15836229a2c0.png)


after

![image](https://user-images.githubusercontent.com/35833812/148156978-a92717dd-a8ac-4e4b-a97f-2ac973d4adf3.png)
