### PR TITLE
fix(dialog): fix dialog example can't be closed when using plugin mode

### DIFF
--- a/src/dialog/_example/plugin.jsx
+++ b/src/dialog/_example/plugin.jsx
@@ -12,6 +12,11 @@ export default function PluginModalExample() {
         console.log('confirm clicked', e);
         mydialog.hide();
       },
+      onClose: ({ e, trigger }) => {
+        console.log('e: ', e);
+        console.log('trigger: ', trigger);
+        mydialog.hide();
+      },
     });
   };
   const handleDN = () => {
@@ -27,6 +32,11 @@ export default function PluginModalExample() {
         console.log('e: ', e);
         dialogNode.hide();
         dialogNode.destroy();
+      },
+      onClose: ({ e, trigger }) => {
+        console.log('e: ', e);
+        console.log('trigger: ', trigger);
+        dialogNode.hide();
       },
     });
   };


### PR DESCRIPTION
`dialog`组件的`plugin`调用时，示例无法正常关闭。[refer](https://tdesign.tencent.com/react/components/dialog#%E6%8F%92%E4%BB%B6%E5%87%BD%E6%95%B0%E5%BC%8F%E8%B0%83%E7%94%A8)