### PR TITLE
fix(popup.tsx): 大幅减少了选择框闪烁的几率,可以作为彻底解决bug前的折中方案

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -88,31 +88,12 @@ const Popup = forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
     [],
   );
 
-  const popperOptions = useMemo(() => {
-    if (!visible) return { padding: 0 };
-    const childElement = contentRef.current?.firstElementChild as HTMLElement;
-    const height = childElement?.offsetHeight ?? 0;
-    const width = childElement?.offsetWidth ?? 0;
-    return {
-      padding: {
-        top: height,
-        left: width,
-        right: width,
-        bottom: height,
-      },
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, overlayRef]);
-
   const { styles, attributes, update } = usePopper(triggerRef, overlayRef, {
     placement: placementMap[placement],
     onFirstUpdate: onPopperFirstUpdate,
     modifiers: [
       {
         name: 'flip',
-        options: {
-          ...popperOptions,
-        },
       },
     ],
   });


### PR DESCRIPTION
fix #222

删去了赋予popper插件的padding属性，使选择框上下闪烁的概率从稳定复现下降到偶尔可以复现，可以作为彻底解决问题前的中间方案。