### PR TITLE
fix(site): spell fault

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -37,8 +37,8 @@ function Components(props) {
 
   function changeVersion(version) {
     if (version === currentVersion) return;
-    const histryUrl = `//${version}-tdesign-react.surge.sh`;
-    window.open(histryUrl, '_blank');
+    const historyUrl = `//${version}-tdesign-react.surge.sh`;
+    window.open(historyUrl, '_blank');
   }
 
   function initHistoryVersions() {


### PR DESCRIPTION
当我给tdesign-vue修复一个版本选择的bug的时候( https://github.com/Tencent/tdesign-vue/pull/239 )，参考了tdesign-react的处理，看了版本切换的源码部分，发现了这个拼写错误，tdesign-vue和这里的代码基本是一致的，只是tdesing-vue这里拼的是正确的，所以有统一拼写的考虑