### PR TITLE
fix(icon): medium size

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "raf": "~3.4.1",
     "react-popper": "~2.2.5",
     "react-transition-group": "~4.4.1",
-    "tdesign-icons-react": "~0.0.7",
+    "tdesign-icons-react": "~0.0.8",
     "tslib": "~2.3.1",
     "use-resize-observer": "^8.0.0",
     "uuid": "~8.3.2",


### PR DESCRIPTION
icon size的枚举`middle` 应该为`medium`