### PR TITLE
fix: 修复 form reset 后首次更改值不触发校验

### DIFF
--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -250,7 +250,6 @@ const FormItem = forwardRef<HTMLDivElement, FormItemProps>((props, ref) => {
       name && onFormItemValueChange({ [name]: formValue });
     }
 
-    console.log('shouldValidate.current', shouldValidate.current);
     // 首次渲染不触发校验 后续判断是否检验也通过此字段控制
     if (!shouldValidate.current || !isMounted.current) {
       isMounted.current = true;

--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -205,15 +205,14 @@ const FormItem = forwardRef<HTMLDivElement, FormItemProps>((props, ref) => {
 
   function resetField(type: string) {
     if (!name) return;
-    shouldValidate.current = false;
 
     const resetType = type || resetTypeFromContext;
-    if (resetType === 'empty') {
-      setFormValue(getEmptyValue());
+    const resetValue = resetType === 'initial' ? initialData : getEmptyValue();
+    // 防止触发校验
+    if (resetValue !== formValue) {
+      shouldValidate.current = false;
     }
-    if (resetType === 'initial') {
-      setFormValue(initialData);
-    }
+    setFormValue(resetValue);
 
     if (resetValidating) {
       setNeedResetField(true);
@@ -251,6 +250,7 @@ const FormItem = forwardRef<HTMLDivElement, FormItemProps>((props, ref) => {
       name && onFormItemValueChange({ [name]: formValue });
     }
 
+    console.log('shouldValidate.current', shouldValidate.current);
     // 首次渲染不触发校验 后续判断是否检验也通过此字段控制
     if (!shouldValidate.current || !isMounted.current) {
       isMounted.current = true;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [ ] 是关于什么的改动？

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
