### PR TITLE
fix: 修复requestMethod返回fail时，图片依然回显问题

### DIFF
--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -112,8 +112,7 @@ const Upload: React.ForwardRefRenderFunction<unknown, UploadProps> = (props, ref
 
       setErrorMsg(res?.error || '上传失败');
       const context = { e: event, file };
-      const nextFileList = updateFileList(file, fileList);
-      // setFileList((prevFileList) => updateFileList(file, prevFileList));
+      const nextFileList = updateFileList(file, fileList, true);
       onChange?.(nextFileList, { trigger: 'upload fail' });
       onFail?.(context);
     },

--- a/src/upload/util.ts
+++ b/src/upload/util.ts
@@ -20,6 +20,7 @@ export function getCurrentDate() {
   month = month < 10 ? `0${month}` : month;
   return `${d.getFullYear()}-${month}-${d.getDate()} ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`;
 }
+
 /**
  * 缩略文件名 ABCDEFG => ABC...FG
  * @param inputName 文件名
@@ -43,13 +44,23 @@ export function abridgeName(inputName = '', leftCount = 5, rightcount = 7): stri
   return name.replace(new RegExp(`^(.{${leftLength}})(.+)(.{${rightLength}})$`), '$1…$3');
 }
 
-export function updateFileList(file: TdUploadFile, fileList: TdUploadFile[]) {
+/**
+ * 更新文件列表
+ * @param {TdUploadFile} file 待操作文件
+ * @param {TdUploadFile[]}fileList  已有文件列表
+ * @param {boolean=false} deleteFile 是否删除文件
+ */
+export function updateFileList(file: TdUploadFile, fileList: TdUploadFile[], deleteFile = false) {
   const nextFileList = [...fileList];
   const fileIndex = nextFileList.findIndex(({ uid }: TdUploadFile) => uid === file.uid);
-  if (fileIndex === -1) {
+  if (deleteFile) {
+    if (fileIndex !== -1) {
+      nextFileList.splice(fileIndex, 1);
+    }
+  } else if (fileIndex === -1) {
     nextFileList.push(file);
   } else {
-    nextFileList[fileIndex] = file;
+    nextFileList.splice(fileIndex, 1, file);
   }
 
   return nextFileList;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/353

### 💡 需求背景和解决方案

1.  修复requestMethod返回fail时，图片依然回显问题

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 修复requestMethod返回fail时，图片依然回显问题

- [x] 本条 PR 需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
