### PR TITLE
fix: notification 组件临时修复特殊用法下的报错问题

### DIFF
--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -112,14 +112,6 @@ const NotificationList = forwardRef<NotificationListInstance, NotificationListPr
     removeAll,
   }));
 
-  useEffect(() => {
-    if (list.length === 0 && notificationMap.current.size === 0) {
-      listMap.delete(placement);
-      ReactDOM.unmountComponentAtNode(attach);
-      attach.remove();
-    }
-  }, [list, attach, placement, notificationMap]);
-
   return (
     <div className={`${classPrefix}-notification__show--${placement}`} style={{ zIndex }}>
       {list.map((props) => {

--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useRef, useImperativeHandle } from 'react';
+import React, { forwardRef, useCallback, useRef, useImperativeHandle } from 'react';
 import ReactDOM from 'react-dom';
 import useConfig from '../_util/useConfig';
 import {
@@ -35,7 +35,7 @@ let seed = 0;
 export const listMap: Map<NotificationPlacementList, NotificationListInstance> = new Map();
 
 const NotificationList = forwardRef<NotificationListInstance, NotificationListProps>((props, ref) => {
-  const { attach, placement, zIndex } = props;
+  const { placement, zIndex } = props;
   const { classPrefix } = useConfig();
   const [list, dispatchList] = React.useReducer(
     (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？
日常 bug 修复.
修复 notification 在 https://codesandbox.io/s/tdesign-react-demo-forked-69g589?file=/src/demo.jsx:0-1062 环境下的使用异常问题
当前修复为临时修复版本，notification 组件将尽量在本周末进行重构以避免未来有类似奇怪的问题发生。
<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 是关于什么的改动？
notification 组件，删除部分代码。
删除代码的功能为: 
notification 根据位置（左上 左下 ...） 分为九个区块，每个区块会存在一个容器以放置 notification 。当前代码的作用为，当存在部分数据变动时，检测每个容器内是否依然存在正在展示的 notification，如不存在则将容器一起销毁（容器销毁后，会在新增对应 notification 时重新创建）。

删除代码后：
容器一经创建将不会被销毁（极端情况下页面上会多出九个空 div 标签）

删除代码的原因：
 https://codesandbox.io/s/tdesign-react-demo-forked-69g589?file=/src/demo.jsx:0-1062
 在上述场景下，会出现控制台异常，暂未排查出异常的具体代码原因，但测试发现只要容器不销毁就不会发生。

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
