### PR TITLE
docs: 修复 form api 文档样式错乱

### DIFF
--- a/site/plugin-tdoc/md-to-react.js
+++ b/site/plugin-tdoc/md-to-react.js
@@ -170,7 +170,7 @@ function customRender({ source, file, md }) {
 
   apiMd = apiMd.replace(/`([^`]+)`/g, (str, codeStr) => {
     codeStr = codeStr.replace(/\|/g, '\\|');
-    return `<td-code text="${codeStr}"></td-code>`;
+    return `\`${codeStr}\``;
   });
 
   const mdSegment = {


### PR DESCRIPTION

<img width="651" alt="image" src="https://user-images.githubusercontent.com/24469546/154897676-a492db2c-7f41-49be-a038-ce1706a18843.png">

=> 

<img width="384" alt="image" src="https://user-images.githubusercontent.com/24469546/154897627-ff3bcdb4-5cc0-4b34-976a-2773382a1a0a.png">
