### PR TITLE
fix(slider): 修复拖拽 slider 按钮时 tooltip 位置不跟随滑动的问题

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   useCallback,
   useRef,
+  useImperativeHandle,
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
@@ -25,11 +26,14 @@ export interface PopupProps extends TdPopupProps, StyledProps {
   // 是否触发展开收起动画，内部下拉式组件使用
   expandAnimation?: boolean;
 }
+export interface PopupRefInterface extends React.RefObject<unknown> {
+  updatePopper: () => void;
+}
 
 function getPopperPlacement(placement: TdPopupProps['placement']) {
   return placement.replace(/-(left|top)$/, '-start').replace(/-(right|bottom)$/, '-end') as Placement;
 }
-const Popup = forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
+const Popup = forwardRef((props: PopupProps, ref: PopupRefInterface) => {
   const {
     trigger = 'hover',
     content = null,
@@ -98,6 +102,11 @@ const Popup = forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
     placement: getPopperPlacement(placement),
     onFirstUpdate: onPopperFirstUpdate,
   });
+
+  // 外部更新 popper 样式
+  useImperativeHandle(ref, () => ({
+    updatePopper: () => popperRef.current?.update?.(),
+  }));
 
   const { styles, attributes } = popperRef.current;
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -2,7 +2,7 @@ import _Popup from './Popup';
 
 import './style/index.js';
 
-export type { PopupProps } from './Popup';
+export type { PopupProps, PopupRefInterface } from './Popup';
 export * from './type';
 
 export const Popup = _Popup;

--- a/src/slider/SliderHandleButton.tsx
+++ b/src/slider/SliderHandleButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import Tooltip from '../tooltip/Tooltip';
 import { TdTooltipProps } from '../tooltip/type';
@@ -13,9 +13,11 @@ interface SliderHandleButtonProps {
 const SliderHandleButton: React.FC<SliderHandleButtonProps> = ({ onChange, style, classPrefix, toolTipProps }) => {
   const [popupVisible, setPopupVisible] = useState(false);
   const [isDragging, toggleIsDragging] = useState(false);
+  const tooltipRef = useRef(null);
 
   const onSliderDragging = (e: MouseEvent) => {
     toggleIsDragging(true);
+    tooltipRef.current.updatePopper();
     onChange(e);
   };
 
@@ -54,7 +56,7 @@ const SliderHandleButton: React.FC<SliderHandleButtonProps> = ({ onChange, style
       onMouseEnter={(e) => handleSliderEnter(e)}
       onMouseLeave={(e) => handleSliderLeave(e)}
     >
-      <Tooltip visible={popupVisible} placement="top" {...toolTipProps}>
+      <Tooltip ref={tooltipRef} visible={popupVisible} placement="top" {...toolTipProps}>
         <div
           className={classNames(`${classPrefix}-slider__button`, {
             [`${classPrefix}-slider__button--dragging`]: isDragging,

--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -1,17 +1,17 @@
 import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Popup from '../popup';
+import Popup, { PopupRefInterface } from '../popup';
 import useConfig from '../_util/useConfig';
 import { TdTooltipProps } from './type';
 
 export type TooltipProps = TdTooltipProps;
 
-interface RefProps {
+export interface TooltipRefInterface extends PopupRefInterface {
   setVisible?: (v: boolean) => void;
 }
 
-const Tooltip = forwardRef((props: TdTooltipProps, ref) => {
+const Tooltip = forwardRef((props: TdTooltipProps, ref: TooltipRefInterface) => {
   const {
     theme,
     showArrow = true,
@@ -57,12 +57,10 @@ const Tooltip = forwardRef((props: TdTooltipProps, ref) => {
     };
   }, [duration, timeup]);
 
-  useImperativeHandle(
-    ref,
-    (): RefProps => ({
-      setVisible,
-    }),
-  );
+  useImperativeHandle(ref, () => ({
+    setVisible,
+    ...popupRef.current,
+  }));
 
   return (
     <Popup


### PR DESCRIPTION

### 🤔 这个 PR 的性质是？

bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/369

### 💡 需求背景和解决方案

问题：拖拽 slider 按钮时 tooltip 位置不跟随滑动
解决：拖拽时触发 tooltip 样式计算

### 📝 更新日志

- fix(slider): 修复拖拽 slider 按钮时 tooltip 位置不跟随滑动的问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
