### PR TITLE
fix(checkbox): 修复checkbox组件options为空数组时的问题

### DIFF
--- a/src/checkbox/CheckboxGroup.tsx
+++ b/src/checkbox/CheckboxGroup.tsx
@@ -39,7 +39,7 @@ export function CheckboxGroup(props: CheckboxGroupProps) {
   const intervalOptions =
     Array.isArray(options) && options.length > 0
       ? options
-      : React.Children.map(children, (child) => (child as ReactElement).props);
+      : React.Children.map(children, (child) => (child as ReactElement).props) || [];
 
   const optionsWithoutCheckAll = intervalOptions.filter((t) => typeof t !== 'object' || !t.checkAll);
   const optionsWithoutCheckAllValues = [];


### PR DESCRIPTION
修复checkbox组件options为空数组时的报错