### PR TITLE
chore: eslint test fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "gray-matter": "^4.0.3",
     "husky": "^7.0.4",


### PR DESCRIPTION
eslint-plugin-react 7.29.0 修改了jsx-key的规则导致lint检查失败 先处理一下 避免阻塞PR