### PR TITLE
feat(dialog): dialog 支持Esc关闭

### DIFF
--- a/src/_util/useDialogEsc.ts
+++ b/src/_util/useDialogEsc.ts
@@ -1,0 +1,31 @@
+import { useEffect, MutableRefObject } from 'react';
+
+const dialogSet: Set<MutableRefObject<HTMLDivElement>> = new Set();
+
+const useDialogEsc = (visible: boolean, dialog: MutableRefObject<HTMLDivElement>) => {
+  useEffect(() => {
+    if (visible) {
+      // 将dialog添加至Set对象
+      if (dialog?.current) {
+        dialogSet.add(dialog);
+        dialog?.current?.focus();
+      }
+    } else if (dialogSet.has(dialog)) {
+      // 将dialog从Set对象删除
+      dialogSet.delete(dialog);
+      const dialogList = [...dialogSet];
+      // 将Set对象中最后一个dialog设置为 focus
+      dialogList[dialogList.length - 1]?.current?.focus();
+    }
+    return () => {
+      // 从Set对象删除无效的 dialog
+      dialogSet.forEach((item) => {
+        if (item.current === null) {
+          dialogSet.delete(item);
+        }
+      });
+    };
+  }, [visible, dialog]);
+};
+
+export default useDialogEsc;

--- a/src/dialog/RenderDialog.tsx
+++ b/src/dialog/RenderDialog.tsx
@@ -5,6 +5,7 @@ import Portal from '../common/Portal';
 import noop from '../_util/noop';
 import useLayoutEffect from '../_util/useLayoutEffect';
 import { DialogProps } from './Dialog';
+import useDialogEsc from '../_util/useDialogEsc';
 
 enum KeyCode {
   ESC = 27,
@@ -44,6 +45,7 @@ const RenderDialog: React.FC<RenderDialogProps> = (props) => {
     onOverlayClick = noop,
     preventScrollThrough,
     closeBtn,
+    closeOnEscKeydown = true,
   } = props;
   const wrap = useRef<HTMLDivElement>();
   const dialog = useRef<HTMLDivElement>();
@@ -53,6 +55,7 @@ const RenderDialog: React.FC<RenderDialogProps> = (props) => {
   const isModal = mode === 'modal';
   const canDraggable = props.draggable && mode === 'modeless';
   const dialogOpenClass = `${prefixCls}__open`;
+  useDialogEsc(visible, wrap);
 
   useEffect(() => {
     bodyOverflow.current = document.body.style.overflow;
@@ -135,7 +138,9 @@ const RenderDialog: React.FC<RenderDialogProps> = (props) => {
     if (+e.code === KeyCode.ESC || e.keyCode === KeyCode.ESC) {
       e.stopPropagation();
       onEscKeydown({ e });
-      onClose({ e, trigger: 'esc' });
+      if (closeOnEscKeydown) {
+        onClose({ e, trigger: 'esc' });
+      }
     }
   };
 
@@ -276,7 +281,7 @@ const RenderDialog: React.FC<RenderDialogProps> = (props) => {
       visible ? dialogOpenClass : '',
     );
     const dialog = (
-      <div ref={wrap} className={wrapClass} style={wrapStyle} onKeyDown={handleKeyDown}>
+      <div ref={wrap} className={wrapClass} style={wrapStyle} onKeyDown={handleKeyDown} tabIndex={0}>
         {mode === 'modal' && renderMask()}
         {dialogBody}
       </div>


### PR DESCRIPTION
dialog 支持Esc关闭

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [ ] 是关于什么的改动？
dialog  新特性提交,
### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
支持Esc关闭, 支持嵌套的dialog逐个按ESC关闭  
将打开的dialog逐个存到Set对象中，将最后打开的dialog设置为focus, 即可接收到按下ESC的键盘事件  

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dialog): 支持Esc关闭, 支持嵌套的dialog逐个按ESC关闭

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
