### PR TITLE
fix: 优化 select 多余padding

### DIFF
--- a/src/select/base/Select.tsx
+++ b/src/select/base/Select.tsx
@@ -349,7 +349,10 @@ const Select = forwardRefWithStatics(
           }}
           minCollapsedNum={minCollapsedNum}
           collapsedItems={renderCollapsedItems}
-          popupProps={popupProps}
+          popupProps={{
+            overlayClassName: `${name}__dropdown`,
+            ...popupProps,
+          }}
           popupVisible={showPopup}
           onPopupVisibleChange={handleShowPopup}
           onTagChange={onTagChange}


### PR DESCRIPTION
before:
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/24469546/157225732-aec30185-7109-4638-8245-b20ac24f6f65.png">

after:
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/24469546/157225597-14ef4fc9-27e7-4a6d-8670-ca4ef440e402.png">
