### PR TITLE
chore: remove extra position style

### DIFF
--- a/src/_util/useRipple.ts
+++ b/src/_util/useRipple.ts
@@ -141,28 +141,14 @@ export default function useRipple(ref: RefObject<HTMLElement>, fixedRippleColor?
     [classPrefix, ref, fixedRippleColor, rippleContainer, keepRipple],
   );
 
-  // 重置一些属性 为动画做准备 reset the node which uses the ripple animation
-  const initRippleElement = useCallback(() => {
-    const el = ref?.current;
-
-    if (!el) return;
-
-    const initPosition = el.style?.position || getComputedStyle(el).position;
-    if (['', 'static'].includes(initPosition)) {
-      el.style.position = 'relative';
-    }
-  }, [ref]);
-
   useEffect(() => {
     const el = ref?.current;
     if (!el) return;
-
-    initRippleElement();
 
     el.addEventListener('pointerdown', handleAddRipple, false);
 
     return () => {
       el.removeEventListener('pointerdown', handleAddRipple, false);
     };
-  }, [initRippleElement, handleAddRipple, fixedRippleColor, ref]);
+  }, [handleAddRipple, fixedRippleColor, ref]);
 }

--- a/src/affix/__tests__/__snapshots__/affix.test.tsx.snap
+++ b/src/affix/__tests__/__snapshots__/affix.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`base.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -32,7 +31,6 @@ exports[`container.jsx 1`] = `
         <div>
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span

--- a/src/badge/__tests__/__snapshots__/badge.test.tsx.snap
+++ b/src/badge/__tests__/__snapshots__/badge.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`base.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-size-l"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -209,7 +208,6 @@ exports[`number.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-size-l"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -229,7 +227,6 @@ exports[`number.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-size-l"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -249,7 +246,6 @@ exports[`number.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-size-l"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -274,7 +270,6 @@ exports[`offset.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -294,7 +289,6 @@ exports[`offset.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -315,7 +309,6 @@ exports[`offset.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -336,7 +329,6 @@ exports[`offset.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -357,7 +349,6 @@ exports[`offset.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -383,7 +374,6 @@ exports[`shape.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -403,7 +393,6 @@ exports[`shape.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -433,7 +422,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -453,7 +441,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -473,7 +460,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -498,7 +484,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -518,7 +503,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -538,7 +522,6 @@ exports[`size.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span

--- a/src/button/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/button/__tests__/__snapshots__/button.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Button 组件测试 icon 1`] = `
 <DocumentFragment>
   <button
     class="t-button t-button--theme-primary t-button--variant-base"
-    style="position: relative;"
     type="button"
   >
     <svg
@@ -28,7 +27,6 @@ exports[`base.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -39,7 +37,6 @@ exports[`base.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -50,7 +47,6 @@ exports[`base.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -61,7 +57,6 @@ exports[`base.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -87,7 +82,6 @@ exports[`block.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-full-width"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -98,7 +92,6 @@ exports[`block.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-size-full-width"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -109,7 +102,6 @@ exports[`block.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-size-full-width"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -120,7 +112,6 @@ exports[`block.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-size-full-width"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -144,7 +135,6 @@ exports[`ghost.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -155,7 +145,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -166,7 +155,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -181,7 +169,6 @@ exports[`ghost.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-outline t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -192,7 +179,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-dashed t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -203,7 +189,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-text t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -218,7 +203,6 @@ exports[`ghost.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-success t-button--variant-outline t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -229,7 +213,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-success t-button--variant-dashed t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -240,7 +223,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-success t-button--variant-text t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -255,7 +237,6 @@ exports[`ghost.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-warning t-button--variant-outline t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -266,7 +247,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-warning t-button--variant-dashed t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -277,7 +257,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-warning t-button--variant-text t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -292,7 +271,6 @@ exports[`ghost.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-danger t-button--variant-outline t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -303,7 +281,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-danger t-button--variant-dashed t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -314,7 +291,6 @@ exports[`ghost.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-danger t-button--variant-text t-button--ghost"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -335,7 +311,6 @@ exports[`icon.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -359,7 +334,6 @@ exports[`icon.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-default t-button--variant-outline"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -388,7 +362,6 @@ exports[`icon.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-button--shape-circle"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -414,7 +387,6 @@ exports[`icon.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-button--shape-circle"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -438,7 +410,6 @@ exports[`icon.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-default t-button--variant-outline"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -474,7 +445,6 @@ exports[`shape.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -485,7 +455,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -508,7 +477,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-button--shape-round"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -519,7 +487,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-button--shape-circle"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -546,7 +513,6 @@ exports[`shape.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -557,7 +523,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -580,7 +545,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-button--shape-round"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -591,7 +555,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-button--shape-circle"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -618,7 +581,6 @@ exports[`shape.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -629,7 +591,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -652,7 +613,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-button--shape-round"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -663,7 +623,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-button--shape-circle"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -690,7 +649,6 @@ exports[`shape.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -701,7 +659,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -724,7 +681,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-button--shape-round"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -735,7 +691,6 @@ exports[`shape.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-button--shape-circle"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -771,7 +726,6 @@ exports[`size.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -782,7 +736,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -793,7 +746,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -804,7 +756,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -819,7 +770,6 @@ exports[`size.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -830,7 +780,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -841,7 +790,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -852,7 +800,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -867,7 +814,6 @@ exports[`size.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-l"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -878,7 +824,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-size-l"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -889,7 +834,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed t-size-l"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -900,7 +844,6 @@ exports[`size.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text t-size-l"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -922,7 +865,6 @@ exports[`status.jsx 1`] = `
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-is-disabled"
       disabled=""
-      style="position: relative;"
       type="button"
     >
       <span
@@ -934,7 +876,6 @@ exports[`status.jsx 1`] = `
     <button
       class="t-button t-button--theme-primary t-button--variant-base t-is-loading t-is-disabled"
       disabled=""
-      style="position: relative;"
       type="button"
     >
       <div
@@ -980,7 +921,6 @@ exports[`theme.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-default t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -991,7 +931,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1002,7 +941,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1013,7 +951,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-default t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1028,7 +965,6 @@ exports[`theme.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1039,7 +975,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1050,7 +985,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1061,7 +995,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1076,7 +1009,6 @@ exports[`theme.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-danger t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1087,7 +1019,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-danger t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1098,7 +1029,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-danger t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1109,7 +1039,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-danger t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1124,7 +1053,6 @@ exports[`theme.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-warning t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1135,7 +1063,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-warning t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1146,7 +1073,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-warning t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1157,7 +1083,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-warning t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1172,7 +1097,6 @@ exports[`theme.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-success t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1183,7 +1107,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-success t-button--variant-outline"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1194,7 +1117,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-success t-button--variant-dashed"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1205,7 +1127,6 @@ exports[`theme.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-success t-button--variant-text"
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/calendar/__tests__/__snapshots__/calendar.test.tsx.snap
+++ b/src/calendar/__tests__/__snapshots__/calendar.test.tsx.snap
@@ -182,7 +182,6 @@ exports[`base.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -710,7 +709,7 @@ exports[`card.jsx 1`] = `
       </div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-left: 12px; position: relative;"
+        style="margin-left: 12px;"
         type="button"
       >
         <span
@@ -1547,7 +1546,6 @@ exports[`cell.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -2400,7 +2398,6 @@ exports[`cell-append.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -3436,7 +3433,6 @@ exports[`controller-config.jsx 1`] = `
             >
               <button
                 class="t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -4113,7 +4109,6 @@ exports[`event-props-api.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -4806,7 +4801,6 @@ exports[`events.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -5481,7 +5475,6 @@ exports[`filter.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -6189,7 +6182,6 @@ exports[`first-day-of-week.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -6781,7 +6773,6 @@ exports[`head.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -7433,7 +7424,6 @@ exports[`mode.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -7799,7 +7789,6 @@ exports[`range.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -8457,7 +8446,6 @@ exports[`slot-props-api.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -9310,7 +9298,6 @@ exports[`value.jsx 1`] = `
       >
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -9967,7 +9954,6 @@ exports[`week.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span

--- a/src/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
+++ b/src/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
@@ -712,7 +712,6 @@ exports[`link.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -723,7 +722,7 @@ exports[`link.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-left: 16px; position: relative;"
+      style="margin-left: 16px;"
       type="button"
     >
       <span
@@ -748,7 +747,6 @@ exports[`max.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-is-disabled t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -779,7 +777,6 @@ exports[`max.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg

--- a/src/comment/__tests__/__snapshots__/comment.test.tsx.snap
+++ b/src/comment/__tests__/__snapshots__/comment.test.tsx.snap
@@ -653,7 +653,6 @@ exports[`reply-form.jsx 1`] = `
             </div>
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="position: relative;"
               type="button"
             >
               <span

--- a/src/dialog/__tests__/__snapshots__/modal.test.tsx.snap
+++ b/src/dialog/__tests__/__snapshots__/modal.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`async.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -23,7 +22,7 @@ exports[`attach.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -34,7 +33,7 @@ exports[`attach.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -45,7 +44,7 @@ exports[`attach.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -63,7 +62,6 @@ exports[`base.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -81,7 +79,7 @@ exports[`custom.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -92,7 +90,7 @@ exports[`custom.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -103,7 +101,7 @@ exports[`custom.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -121,7 +119,6 @@ exports[`icon.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -139,7 +136,6 @@ exports[`modal.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -171,7 +167,7 @@ exports[`plugin.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -182,7 +178,7 @@ exports[`plugin.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -193,7 +189,7 @@ exports[`plugin.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -204,7 +200,7 @@ exports[`plugin.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -215,7 +211,7 @@ exports[`plugin.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -235,7 +231,7 @@ exports[`position.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -246,7 +242,7 @@ exports[`position.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 16px; position: relative;"
+        style="margin-right: 16px;"
         type="button"
       >
         <span
@@ -257,7 +253,6 @@ exports[`position.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -276,7 +271,7 @@ exports[`warning.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -287,7 +282,7 @@ exports[`warning.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -298,7 +293,7 @@ exports[`warning.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span
@@ -309,7 +304,7 @@ exports[`warning.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="margin-right: 16px; position: relative;"
+      style="margin-right: 16px;"
       type="button"
     >
       <span

--- a/src/drawer/__tests__/__snapshots__/drawer.test.tsx.snap
+++ b/src/drawer/__tests__/__snapshots__/drawer.test.tsx.snap
@@ -143,7 +143,6 @@ exports[`attach-parent.jsx 1`] = `
       <div>
         <button
           class="t-button t-button--theme-primary t-button--variant-base"
-          style="position: relative;"
           type="button"
         >
           <span
@@ -202,7 +201,6 @@ exports[`attach-parent.jsx 1`] = `
               >
                 <button
                   class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                  style="position: relative;"
                   type="button"
                 >
                   <span
@@ -213,7 +211,6 @@ exports[`attach-parent.jsx 1`] = `
                 </button>
                 <button
                   class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                  style="position: relative;"
                   type="button"
                 >
                   <span
@@ -237,7 +234,6 @@ exports[`base.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -295,7 +291,6 @@ exports[`base.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -306,7 +301,6 @@ exports[`base.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -329,7 +323,6 @@ exports[`custom.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -386,7 +379,6 @@ exports[`custom.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -408,7 +400,6 @@ exports[`destroy.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -461,7 +452,6 @@ exports[`destroy.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -472,7 +462,6 @@ exports[`destroy.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -495,7 +484,6 @@ exports[`no-mask.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -550,7 +538,6 @@ exports[`no-mask.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -561,7 +548,6 @@ exports[`no-mask.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -584,7 +570,6 @@ exports[`operation.jsx 1`] = `
   <div>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -709,7 +694,6 @@ exports[`operation.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -720,7 +704,6 @@ exports[`operation.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -821,7 +804,7 @@ exports[`placement.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-top: 20px; position: relative;"
+        style="margin-top: 20px;"
         type="button"
       >
         <span
@@ -875,7 +858,6 @@ exports[`placement.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -886,7 +868,6 @@ exports[`placement.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -958,7 +939,6 @@ exports[`popup.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1093,7 +1073,6 @@ exports[`size.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1147,7 +1126,6 @@ exports[`size.jsx 1`] = `
             >
               <button
                 class="t-drawer__confirm t-button t-button--theme-primary t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span
@@ -1158,7 +1136,6 @@ exports[`size.jsx 1`] = `
               </button>
               <button
                 class="t-drawer__cancel t-button t-button--theme-default t-button--variant-base"
-                style="position: relative;"
                 type="button"
               >
                 <span

--- a/src/form/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/form/__tests__/__snapshots__/form.test.tsx.snap
@@ -427,7 +427,6 @@ exports[`base.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="submit"
           >
             <span
@@ -438,7 +437,7 @@ exports[`base.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="margin-left: 12px; position: relative;"
+            style="margin-left: 12px;"
             type="reset"
           >
             <span
@@ -926,7 +925,7 @@ exports[`clear-validate.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="margin-right: 10px; position: relative;"
+            style="margin-right: 10px;"
             type="submit"
           >
             <span
@@ -937,7 +936,7 @@ exports[`clear-validate.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="margin-right: 10px; position: relative;"
+            style="margin-right: 10px;"
             type="reset"
           >
             <span
@@ -948,7 +947,7 @@ exports[`clear-validate.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="margin-right: 10px; position: relative;"
+            style="margin-right: 10px;"
             type="button"
           >
             <span
@@ -959,7 +958,6 @@ exports[`clear-validate.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -1092,7 +1090,6 @@ exports[`custom-validator.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="position: relative;"
               type="submit"
             >
               <span
@@ -1103,7 +1100,7 @@ exports[`custom-validator.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="margin: 0px 12px; position: relative;"
+              style="margin: 0px 12px;"
               type="reset"
             >
               <span
@@ -1114,7 +1111,6 @@ exports[`custom-validator.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -1835,7 +1831,7 @@ exports[`disabled.jsx 1`] = `
             <button
               class="t-button t-button--theme-primary t-button--variant-base t-is-disabled"
               disabled=""
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -1847,7 +1843,6 @@ exports[`disabled.jsx 1`] = `
             <button
               class="t-button t-button--theme-default t-button--variant-base t-is-disabled"
               disabled=""
-              style="position: relative;"
               type="reset"
             >
               <span
@@ -2402,7 +2397,7 @@ exports[`error-message.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -2413,7 +2408,7 @@ exports[`error-message.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="reset"
             >
               <span
@@ -2424,7 +2419,6 @@ exports[`error-message.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -2693,7 +2687,6 @@ exports[`login.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base t-size-full-width"
-              style="position: relative;"
               type="submit"
             >
               <span
@@ -2934,7 +2927,7 @@ exports[`reset.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -2945,7 +2938,6 @@ exports[`reset.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="position: relative;"
               type="reset"
             >
               <span
@@ -3271,7 +3263,7 @@ exports[`size.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -3282,7 +3274,6 @@ exports[`size.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-default t-button--variant-base"
-              style="position: relative;"
               type="reset"
             >
               <span
@@ -3721,7 +3712,7 @@ exports[`validate-complicated-data.jsx 1`] = `
                 >
                   <button
                     class="t-button t-button--theme-primary t-button--variant-base"
-                    style="margin-right: 10px; position: relative;"
+                    style="margin-right: 10px;"
                     type="submit"
                   >
                     <span
@@ -3732,7 +3723,6 @@ exports[`validate-complicated-data.jsx 1`] = `
                   </button>
                   <button
                     class="t-button t-button--theme-default t-button--variant-base"
-                    style="position: relative;"
                     type="reset"
                   >
                     <span
@@ -4013,7 +4003,7 @@ exports[`validate-complicated-data.jsx 1`] = `
                 >
                   <button
                     class="t-button t-button--theme-primary t-button--variant-base"
-                    style="margin-right: 10px; position: relative;"
+                    style="margin-right: 10px;"
                     type="submit"
                   >
                     <span
@@ -4024,7 +4014,6 @@ exports[`validate-complicated-data.jsx 1`] = `
                   </button>
                   <button
                     class="t-button t-button--theme-default t-button--variant-base"
-                    style="position: relative;"
                     type="reset"
                   >
                     <span
@@ -4193,7 +4182,7 @@ exports[`validate-message.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="margin-right: 10px; position: relative;"
+            style="margin-right: 10px;"
             type="submit"
           >
             <span
@@ -4204,7 +4193,7 @@ exports[`validate-message.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="margin-right: 10px; position: relative;"
+            style="margin-right: 10px;"
             type="reset"
           >
             <span
@@ -4215,7 +4204,6 @@ exports[`validate-message.jsx 1`] = `
           </button>
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -4582,7 +4570,7 @@ exports[`validator.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -4593,7 +4581,6 @@ exports[`validator.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="position: relative;"
               type="reset"
             >
               <span
@@ -4985,7 +4972,7 @@ exports[`validator-status.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="margin-right: 10px; position: relative;"
+              style="margin-right: 10px;"
               type="submit"
             >
               <span
@@ -4996,7 +4983,6 @@ exports[`validator-status.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-primary t-button--variant-base"
-              style="position: relative;"
               type="reset"
             >
               <span

--- a/src/input-number/__tests__/__snapshots__/input-number.test.tsx.snap
+++ b/src/input-number/__tests__/__snapshots__/input-number.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`align.jsx 1`] = `
     >
       <button
         class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -41,7 +40,6 @@ exports[`align.jsx 1`] = `
       </div>
       <button
         class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -64,7 +62,6 @@ exports[`align.jsx 1`] = `
     >
       <button
         class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -95,7 +92,6 @@ exports[`align.jsx 1`] = `
       </div>
       <button
         class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -118,7 +114,6 @@ exports[`align.jsx 1`] = `
     >
       <button
         class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -149,7 +144,6 @@ exports[`align.jsx 1`] = `
       </div>
       <button
         class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-        style="position: relative;"
         type="button"
       >
         <svg
@@ -226,7 +220,6 @@ exports[`center.jsx 1`] = `
   >
     <button
       class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -257,7 +250,6 @@ exports[`center.jsx 1`] = `
     </div>
     <button
       class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -285,7 +277,6 @@ exports[`default.jsx 1`] = `
   >
     <button
       class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -316,7 +307,6 @@ exports[`default.jsx 1`] = `
     </div>
     <button
       class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -345,7 +335,6 @@ exports[`format.jsx 1`] = `
   >
     <button
       class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -376,7 +365,6 @@ exports[`format.jsx 1`] = `
     </div>
     <button
       class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -404,7 +392,6 @@ exports[`left.jsx 1`] = `
   >
     <button
       class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -435,7 +422,6 @@ exports[`left.jsx 1`] = `
     </div>
     <button
       class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -490,7 +476,6 @@ exports[`size.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -521,7 +506,6 @@ exports[`size.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -544,7 +528,6 @@ exports[`size.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -575,7 +558,6 @@ exports[`size.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -598,7 +580,6 @@ exports[`size.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -629,7 +610,6 @@ exports[`size.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -656,7 +636,6 @@ exports[`size.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -687,7 +666,6 @@ exports[`size.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -710,7 +688,6 @@ exports[`size.jsx 1`] = `
       >
         <button
           class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -741,7 +718,6 @@ exports[`size.jsx 1`] = `
         </div>
         <button
           class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-          style="position: relative;"
           type="button"
         >
           <svg
@@ -771,7 +747,6 @@ exports[`step.jsx 1`] = `
   >
     <button
       class="t-input-number__decrease t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg
@@ -802,7 +777,6 @@ exports[`step.jsx 1`] = `
     </div>
     <button
       class="t-input-number__increase t-button t-button--theme-default t-button--variant-outline t-button--shape-square"
-      style="position: relative;"
       type="button"
     >
       <svg

--- a/src/layout/__tests__/__snapshots__/layout.test.tsx.snap
+++ b/src/layout/__tests__/__snapshots__/layout.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`aside.jsx 1`] = `
           >
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -43,7 +42,6 @@ exports[`aside.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -53,7 +51,6 @@ exports[`aside.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -63,7 +60,6 @@ exports[`aside.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -73,7 +69,6 @@ exports[`aside.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -296,7 +291,6 @@ exports[`combine.jsx 1`] = `
             >
               <li
                 class="t-menu__item t-is-active t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -306,7 +300,6 @@ exports[`combine.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -316,7 +309,6 @@ exports[`combine.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -326,7 +318,6 @@ exports[`combine.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-is-disabled t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -409,7 +400,6 @@ exports[`combine.jsx 1`] = `
               >
                 <li
                   class="t-menu__item t-is-active"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-dashboard"
@@ -442,7 +432,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-server"
@@ -475,7 +464,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item t-menu__item--plain"
-                  style="position: relative;"
                 >
                   <span
                     class="t-menu__content"
@@ -505,7 +493,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-control-platform"
@@ -529,7 +516,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-precise-monitor"
@@ -552,7 +538,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-mail"
@@ -575,7 +560,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-user-circle"
@@ -604,7 +588,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-play-circle"
@@ -634,7 +617,6 @@ exports[`combine.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <svg
                     class="t-icon t-icon-edit-1"
@@ -713,7 +695,6 @@ exports[`top.jsx 1`] = `
           >
             <li
               class="t-menu__item t-is-active t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -723,7 +704,6 @@ exports[`top.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -733,7 +713,6 @@ exports[`top.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -743,7 +722,6 @@ exports[`top.jsx 1`] = `
             </li>
             <li
               class="t-menu__item t-is-disabled t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"

--- a/src/loading/__tests__/__snapshots__/Loading.test.tsx.snap
+++ b/src/loading/__tests__/__snapshots__/Loading.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`delay.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -85,7 +84,6 @@ exports[`delay.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -168,7 +166,7 @@ exports[`service.jsx 1`] = `
     <div>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin-right: 20px; position: relative;"
+        style="margin-right: 20px;"
         type="button"
       >
         <span
@@ -179,7 +177,6 @@ exports[`service.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -368,7 +365,7 @@ exports[`wrap.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-        style="margin-right: 10px; position: relative;"
+        style="margin-right: 10px;"
         type="button"
       >
         <span
@@ -379,7 +376,6 @@ exports[`wrap.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/menu/__tests__/__snapshots__/menu.test.tsx.snap
+++ b/src/menu/__tests__/__snapshots__/menu.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`closable-side.jsx 1`] = `
       >
         <li
           class="t-menu__item"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-app"
@@ -94,7 +93,6 @@ exports[`closable-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-is-disabled t-is-active t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -159,7 +157,6 @@ exports[`closable-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -171,7 +168,6 @@ exports[`closable-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -236,7 +232,6 @@ exports[`closable-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -248,7 +243,6 @@ exports[`closable-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -263,7 +257,6 @@ exports[`closable-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-rollback"
@@ -336,7 +329,6 @@ exports[`closable-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -348,7 +340,6 @@ exports[`closable-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -407,7 +398,6 @@ exports[`custom-header.jsx 1`] = `
       >
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -419,7 +409,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -431,7 +420,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -443,7 +431,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -486,7 +473,6 @@ exports[`custom-header.jsx 1`] = `
       >
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -498,7 +484,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -510,7 +495,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -522,7 +506,6 @@ exports[`custom-header.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -570,7 +553,6 @@ exports[`custom-side.jsx 1`] = `
       >
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -582,7 +564,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -594,7 +575,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -606,7 +586,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -618,7 +597,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -630,7 +608,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -642,7 +619,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -676,7 +652,6 @@ exports[`custom-side.jsx 1`] = `
       >
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -688,7 +663,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -700,7 +674,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -712,7 +685,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -724,7 +696,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -736,7 +707,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -748,7 +718,6 @@ exports[`custom-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -790,7 +759,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item t-is-active"
-            style="position: relative;"
           >
             <span>
               菜单1
@@ -802,7 +770,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单2
@@ -814,7 +781,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单3
@@ -826,7 +792,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单4
@@ -875,7 +840,6 @@ exports[`double.jsx 1`] = `
                   >
                     <div
                       class="t-tabs__nav-item-wrapper"
-                      style="position: relative;"
                     >
                       <span
                         class="t-tabs__nav-item-text-wrapper"
@@ -889,7 +853,6 @@ exports[`double.jsx 1`] = `
                   >
                     <div
                       class="t-tabs__nav-item-wrapper"
-                      style="position: relative;"
                     >
                       <span
                         class="t-tabs__nav-item-text-wrapper"
@@ -936,7 +899,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item t-is-active"
-            style="position: relative;"
           >
             <span>
               菜单1
@@ -948,7 +910,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单2
@@ -960,7 +921,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单3
@@ -972,7 +932,6 @@ exports[`double.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               菜单4
@@ -1021,7 +980,6 @@ exports[`double.jsx 1`] = `
                   >
                     <div
                       class="t-tabs__nav-item-wrapper"
-                      style="position: relative;"
                     >
                       <span
                         class="t-tabs__nav-item-text-wrapper"
@@ -1035,7 +993,6 @@ exports[`double.jsx 1`] = `
                   >
                     <div
                       class="t-tabs__nav-item-wrapper"
-                      style="position: relative;"
                     >
                       <span
                         class="t-tabs__nav-item-text-wrapper"
@@ -1093,7 +1050,6 @@ exports[`group-side.jsx 1`] = `
           </div>
           <li
             class="t-menu__item t-is-active"
-            style="position: relative;"
           >
             <svg
               class="t-icon t-icon-chart"
@@ -1130,7 +1086,6 @@ exports[`group-side.jsx 1`] = `
           </div>
           <li
             class="t-menu__item t-menu__item--plain"
-            style="position: relative;"
           >
             <span
               class="t-menu__content"
@@ -1140,7 +1095,6 @@ exports[`group-side.jsx 1`] = `
           </li>
           <li
             class="t-menu__item t-menu__item--plain"
-            style="position: relative;"
           >
             <span
               class="t-menu__content"
@@ -1159,7 +1113,6 @@ exports[`group-side.jsx 1`] = `
           </div>
           <li
             class="t-menu__item t-menu__item--plain"
-            style="position: relative;"
           >
             <span
               class="t-menu__content"
@@ -1205,7 +1158,6 @@ exports[`multi-side.jsx 1`] = `
       >
         <li
           class="t-menu__item"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-app"
@@ -1275,7 +1227,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-is-disabled t-is-active t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1368,7 +1319,6 @@ exports[`multi-side.jsx 1`] = `
               >
                 <li
                   class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                  style="position: relative;"
                 >
                   <span
                     class="t-menu__content"
@@ -1378,7 +1328,6 @@ exports[`multi-side.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                  style="position: relative;"
                 >
                   <span
                     class="t-menu__content"
@@ -1388,7 +1337,6 @@ exports[`multi-side.jsx 1`] = `
                 </li>
                 <li
                   class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                  style="position: relative;"
                 >
                   <span
                     class="t-menu__content"
@@ -1400,7 +1348,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1461,7 +1408,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1473,7 +1419,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1487,7 +1432,6 @@ exports[`multi-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-rollback"
@@ -1557,7 +1501,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1569,7 +1512,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1613,7 +1555,6 @@ exports[`multi-side.jsx 1`] = `
       >
         <li
           class="t-menu__item"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-app"
@@ -1683,7 +1624,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-is-disabled t-is-active t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1744,7 +1684,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1756,7 +1695,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1817,7 +1755,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1829,7 +1766,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1843,7 +1779,6 @@ exports[`multi-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-rollback"
@@ -1913,7 +1848,6 @@ exports[`multi-side.jsx 1`] = `
           >
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1925,7 +1859,6 @@ exports[`multi-side.jsx 1`] = `
             </li>
             <li
               class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-              style="position: relative;"
             >
               <span
                 class="t-menu__content"
@@ -1986,7 +1919,6 @@ exports[`multiple.jsx 1`] = `
         >
           <div
             class="t-menu__item t-is-active"
-            style="position: relative;"
           >
             <span>
               电器
@@ -2019,7 +1951,6 @@ exports[`multiple.jsx 1`] = `
               >
                 <div
                   class="t-menu__item"
-                  style="position: relative;"
                 >
                   <span>
                     电视
@@ -2050,7 +1981,6 @@ exports[`multiple.jsx 1`] = `
                   >
                     <li
                       class="t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2060,7 +1990,6 @@ exports[`multiple.jsx 1`] = `
                     </li>
                     <li
                       class="t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2070,7 +1999,6 @@ exports[`multiple.jsx 1`] = `
                     </li>
                     <li
                       class="t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2083,7 +2011,6 @@ exports[`multiple.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2098,7 +2025,6 @@ exports[`multiple.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -2111,7 +2037,6 @@ exports[`multiple.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               水果蔬菜
@@ -2141,7 +2066,6 @@ exports[`multiple.jsx 1`] = `
             >
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2153,7 +2077,6 @@ exports[`multiple.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2166,7 +2089,6 @@ exports[`multiple.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -2201,7 +2123,6 @@ exports[`multiple.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               电器
@@ -2231,7 +2152,6 @@ exports[`multiple.jsx 1`] = `
             >
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2243,7 +2163,6 @@ exports[`multiple.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2258,7 +2177,6 @@ exports[`multiple.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -2271,7 +2189,6 @@ exports[`multiple.jsx 1`] = `
         >
           <div
             class="t-menu__item"
-            style="position: relative;"
           >
             <span>
               水果蔬菜
@@ -2301,7 +2218,6 @@ exports[`multiple.jsx 1`] = `
             >
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2313,7 +2229,6 @@ exports[`multiple.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2326,7 +2241,6 @@ exports[`multiple.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -2354,7 +2268,6 @@ exports[`popup-side.jsx 1`] = `
       >
         <li
           class="t-menu__item"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-app"
@@ -2427,7 +2340,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-is-disabled t-is-active t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2528,7 +2440,6 @@ exports[`popup-side.jsx 1`] = `
                   >
                     <li
                       class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2538,7 +2449,6 @@ exports[`popup-side.jsx 1`] = `
                     </li>
                     <li
                       class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2548,7 +2458,6 @@ exports[`popup-side.jsx 1`] = `
                     </li>
                     <li
                       class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                      style="position: relative;"
                     >
                       <span
                         class="t-menu__content"
@@ -2561,7 +2470,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2626,7 +2534,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2638,7 +2545,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2653,7 +2559,6 @@ exports[`popup-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-rollback"
@@ -2726,7 +2631,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2738,7 +2642,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2783,7 +2686,6 @@ exports[`popup-side.jsx 1`] = `
       >
         <li
           class="t-menu__item"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-app"
@@ -2856,7 +2758,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-is-disabled t-is-active t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2921,7 +2822,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2933,7 +2833,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -2998,7 +2897,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -3010,7 +2908,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -3025,7 +2922,6 @@ exports[`popup-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled"
-          style="position: relative;"
         >
           <svg
             class="t-icon t-icon-rollback"
@@ -3098,7 +2994,6 @@ exports[`popup-side.jsx 1`] = `
             >
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -3110,7 +3005,6 @@ exports[`popup-side.jsx 1`] = `
               </li>
               <li
                 class="t-menu__item--plain t-submenu__item t-submenu__item--icon t-menu__item t-menu__item--plain"
-                style="position: relative;"
               >
                 <span
                   class="t-menu__content"
@@ -3169,7 +3063,6 @@ exports[`single.jsx 1`] = `
       >
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3181,7 +3074,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3193,7 +3085,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3205,7 +3096,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3280,7 +3170,6 @@ exports[`single.jsx 1`] = `
       >
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3292,7 +3181,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3304,7 +3192,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3316,7 +3203,6 @@ exports[`single.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3397,7 +3283,6 @@ exports[`single-side.jsx 1`] = `
       >
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3409,7 +3294,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3421,7 +3305,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3433,7 +3316,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3445,7 +3327,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3457,7 +3338,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3469,7 +3349,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3503,7 +3382,6 @@ exports[`single-side.jsx 1`] = `
       >
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3515,7 +3393,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-active t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3527,7 +3404,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3539,7 +3415,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-is-disabled t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3551,7 +3426,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3563,7 +3437,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"
@@ -3575,7 +3448,6 @@ exports[`single-side.jsx 1`] = `
         </li>
         <li
           class="t-menu__item t-menu__item--plain"
-          style="position: relative;"
         >
           <span
             class="t-menu__content"

--- a/src/notification/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/src/notification/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`close-all.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -62,7 +61,6 @@ exports[`close-all.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -384,7 +382,6 @@ exports[`operation.jsx 1`] = `
           <div>
             <button
               class="t-button t-button--theme-primary t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -440,7 +437,6 @@ exports[`operation.jsx 1`] = `
           <div>
             <button
               class="t-button t-button--theme-primary t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -503,7 +499,6 @@ exports[`operation.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-default t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -564,7 +559,6 @@ exports[`operation.jsx 1`] = `
           <div>
             <button
               class="t-button t-button--theme-default t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -575,7 +569,6 @@ exports[`operation.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-primary t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -631,7 +624,6 @@ exports[`operation.jsx 1`] = `
           <div>
             <button
               class="t-button t-button--theme-default t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -642,7 +634,6 @@ exports[`operation.jsx 1`] = `
             </button>
             <button
               class="t-button t-button--theme-primary t-button--variant-text"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -701,7 +692,6 @@ exports[`placement.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -712,7 +702,6 @@ exports[`placement.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -727,7 +716,6 @@ exports[`placement.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -738,7 +726,6 @@ exports[`placement.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -759,7 +746,6 @@ exports[`plugin.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -770,7 +756,6 @@ exports[`plugin.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -781,7 +766,6 @@ exports[`plugin.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -792,7 +776,6 @@ exports[`plugin.jsx 1`] = `
     </button>
     <button
       class="t-button t-button--theme-primary t-button--variant-base"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -809,7 +792,6 @@ exports[`toggle.jsx 1`] = `
 <DocumentFragment>
   <button
     class="t-button t-button--theme-primary t-button--variant-base"
-    style="position: relative;"
     type="button"
   >
     <span

--- a/src/steps/__tests__/__snapshots__/steps.test.tsx.snap
+++ b/src/steps/__tests__/__snapshots__/steps.test.tsx.snap
@@ -535,7 +535,6 @@ exports[`extra.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-default t-button--variant-text t-size-s"
-              style="position: relative;"
               type="button"
             >
               <span
@@ -549,7 +548,6 @@ exports[`extra.jsx 1`] = `
             >
               <button
                 class="t-button t-button--theme-primary t-button--variant-base t-size-s"
-                style="position: relative;"
                 type="button"
               >
                 <span

--- a/src/swiper/__tests__/__snapshots__/swiper.test.tsx.snap
+++ b/src/swiper/__tests__/__snapshots__/swiper.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`current-props.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -21,7 +20,6 @@ exports[`current-props.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -32,7 +30,6 @@ exports[`current-props.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -43,7 +40,6 @@ exports[`current-props.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/src/table/__tests__/__snapshots__/table.test.tsx.snap
@@ -2468,7 +2468,6 @@ exports[`filter-controlled.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/tabs/__tests__/__snapshots__/tabs.test.tsx.snap
+++ b/src/tabs/__tests__/__snapshots__/tabs.test.tsx.snap
@@ -89,7 +89,6 @@ exports[`ban.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -103,7 +102,6 @@ exports[`ban.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -117,7 +115,6 @@ exports[`ban.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -188,7 +185,6 @@ exports[`base.jsx 1`] = `
               >
                 <div
                   class="t-tabs__nav-item-wrapper"
-                  style="position: relative;"
                 >
                   <span
                     class="t-tabs__nav-item-text-wrapper"
@@ -202,7 +198,6 @@ exports[`base.jsx 1`] = `
               >
                 <div
                   class="t-tabs__nav-item-wrapper"
-                  style="position: relative;"
                 >
                   <span
                     class="t-tabs__nav-item-text-wrapper"
@@ -216,7 +211,6 @@ exports[`base.jsx 1`] = `
               >
                 <div
                   class="t-tabs__nav-item-wrapper"
-                  style="position: relative;"
                 >
                   <span
                     class="t-tabs__nav-item-text-wrapper"
@@ -337,7 +331,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -351,7 +344,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -365,7 +357,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -379,7 +370,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -393,7 +383,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -407,7 +396,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -421,7 +409,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -435,7 +422,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -449,7 +435,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -463,7 +448,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -477,7 +461,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -491,7 +474,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -505,7 +487,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -519,7 +500,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -533,7 +513,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -547,7 +526,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -561,7 +539,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -575,7 +552,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -589,7 +565,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -603,7 +578,6 @@ exports[`combination.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -837,7 +811,6 @@ exports[`icon.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -871,7 +844,6 @@ exports[`icon.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -898,7 +870,6 @@ exports[`icon.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1147,7 +1118,6 @@ exports[`position.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1161,7 +1131,6 @@ exports[`position.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1175,7 +1144,6 @@ exports[`position.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1250,7 +1218,6 @@ exports[`size.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1264,7 +1231,6 @@ exports[`size.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1329,7 +1295,6 @@ exports[`size.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1343,7 +1308,6 @@ exports[`size.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1417,7 +1381,6 @@ exports[`theme.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"
@@ -1431,7 +1394,6 @@ exports[`theme.jsx 1`] = `
                 >
                   <div
                     class="t-tabs__nav-item-wrapper"
-                    style="position: relative;"
                   >
                     <span
                       class="t-tabs__nav-item-text-wrapper"

--- a/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -227,7 +227,6 @@ exports[`duration.jsx 1`] = `
     </div>
     <button
       class="t-button t-button--theme-default t-button--variant-outline"
-      style="position: relative;"
       type="button"
     >
       <span

--- a/src/transfer/__tests__/__snapshots__/transfer.test.tsx.snap
+++ b/src/transfer/__tests__/__snapshots__/transfer.test.tsx.snap
@@ -438,7 +438,6 @@ exports[`base.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -462,7 +461,6 @@ exports[`base.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1010,7 +1008,6 @@ exports[`checked.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1034,7 +1031,6 @@ exports[`checked.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1574,7 +1570,6 @@ exports[`custom.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -1586,7 +1581,6 @@ exports[`custom.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -2191,7 +2185,6 @@ exports[`custom-render.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -2215,7 +2208,6 @@ exports[`custom-render.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -2348,7 +2340,6 @@ exports[`empty.jsx 1`] = `
         <button
           class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
           disabled=""
-          style="position: relative;"
           type="button"
         >
           <span
@@ -2372,7 +2363,6 @@ exports[`empty.jsx 1`] = `
         <button
           class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
           disabled=""
-          style="position: relative;"
           type="button"
         >
           <span
@@ -2497,7 +2487,6 @@ exports[`empty.jsx 1`] = `
         <button
           class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
           disabled=""
-          style="position: relative;"
           type="button"
         >
           <span
@@ -2521,7 +2510,6 @@ exports[`empty.jsx 1`] = `
         <button
           class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
           disabled=""
-          style="position: relative;"
           type="button"
         >
           <span
@@ -2934,7 +2922,6 @@ exports[`pagination.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -2958,7 +2945,6 @@ exports[`pagination.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -3611,7 +3597,6 @@ exports[`search.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -3635,7 +3620,6 @@ exports[`search.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -3794,7 +3778,6 @@ exports[`tree.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span
@@ -3818,7 +3801,6 @@ exports[`tree.jsx 1`] = `
       <button
         class="t-button t-button--theme-default t-button--variant-outline t-is-disabled"
         disabled=""
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/tree/__tests__/__snapshots__/tree.test.tsx.snap
+++ b/src/tree/__tests__/__snapshots__/tree.test.tsx.snap
@@ -1019,7 +1019,7 @@ exports[`operations.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1030,7 +1030,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1041,7 +1041,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1052,7 +1052,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1063,7 +1063,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1074,7 +1074,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1085,7 +1085,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1096,7 +1096,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1107,7 +1107,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1118,7 +1118,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1129,7 +1129,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1140,7 +1140,7 @@ exports[`operations.jsx 1`] = `
       </button>
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="margin: 0px 10px 10px 0px; position: relative;"
+        style="margin: 0px 10px 10px 0px;"
         type="button"
       >
         <span
@@ -1179,7 +1179,6 @@ exports[`state.jsx 1`] = `
     >
       <button
         class="t-button t-button--theme-primary t-button--variant-base"
-        style="position: relative;"
         type="button"
       >
         <span

--- a/src/upload/__tests__/__snapshots__/upload.test.tsx.snap
+++ b/src/upload/__tests__/__snapshots__/upload.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`base.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-default t-button--variant-outline"
-            style="position: relative;"
             type="button"
           >
             <svg
@@ -64,7 +63,6 @@ exports[`custom-drag.jsx 1`] = `
   >
     <button
       class="t-button t-button--theme-default t-button--variant-outline"
-      style="position: relative;"
       type="button"
     >
       <span
@@ -108,7 +106,6 @@ exports[`custom-drag.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -242,7 +239,6 @@ exports[`file-flow-list.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-default t-button--variant-outline"
-              style="position: relative;"
               type="button"
             >
               <svg
@@ -314,7 +310,6 @@ exports[`file-flow-list.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -326,7 +321,6 @@ exports[`file-flow-list.jsx 1`] = `
           <button
             class="t-button t-button--theme-primary t-button--variant-base t-is-disabled"
             disabled=""
-            style="position: relative;"
             type="button"
           >
             <span
@@ -554,7 +548,6 @@ exports[`img-flow-list.jsx 1`] = `
           >
             <button
               class="t-button t-button--theme-default t-button--variant-outline"
-              style="position: relative;"
               type="button"
             >
               <svg
@@ -602,7 +595,6 @@ exports[`img-flow-list.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-default t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span
@@ -614,7 +606,6 @@ exports[`img-flow-list.jsx 1`] = `
           <button
             class="t-button t-button--theme-primary t-button--variant-base t-is-disabled"
             disabled=""
-            style="position: relative;"
             type="button"
           >
             <span
@@ -697,7 +688,6 @@ exports[`request-method.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-default t-button--variant-outline"
-            style="position: relative;"
             type="button"
           >
             <svg
@@ -755,7 +745,6 @@ exports[`single-custom.jsx 1`] = `
         >
           <button
             class="t-button t-button--theme-primary t-button--variant-base"
-            style="position: relative;"
             type="button"
           >
             <span


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- 日常 bug 修复, 组件样式/交互改进

### 🔗 相关 Issue

- fix https://github.com/Tencent/tdesign-react/issues/461
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

- 此前实现斜八度动画做了一个提前改动元素position的处理 移动到点击事件之后可以少去不必要的渲染 同时避免类似issue中的异常 

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(inputnumber): dialog中使用样式异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
