### PR TITLE
fix: remove dialog duplicated header dom

### DIFF
--- a/src/dialog/RenderDialog.tsx
+++ b/src/dialog/RenderDialog.tsx
@@ -153,7 +153,7 @@ const RenderDialog: React.FC<RenderDialogProps> = (props) => {
 
     const footer = props.footer ? <div className={`${prefixCls}__footer`}>{props.footer}</div> : null;
 
-    const header = <div className={`${prefixCls}__header`}>{props.header}</div>;
+    const { header } = props;
 
     const body = <div className={`${prefixCls}__body`}>{props.body || props.children}</div>;
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
before:
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/7600149/160081118-529cc930-02c8-4d7b-ad9b-28bf20033b89.png">
Dialog header 渲染重复包裹了 `t-dialog__header` DOM 结构，修复后 header 将只有一层：

after:
![image](https://user-images.githubusercontent.com/7600149/160081292-1c5dd858-0478-44c4-9c95-081a6d513bff.png)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog):  修复 Dialog Header 渲染了多余 DOM 层级的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
