### PR TITLE
fix(Select): stop trigger onSearch when focus

### DIFF
--- a/src/select/_example/remote-search.jsx
+++ b/src/select/_example/remote-search.jsx
@@ -7,7 +7,20 @@ const RemoteSearchSelect = () => {
   const [value, setValue] = useState();
 
   const [loading, setLoading] = useState(false);
-  const [options, setOptions] = useState([]);
+  const [options, setOptions] = useState([
+    {
+      value: `test1`,
+      label: `Test1`,
+    },
+    {
+      value: `test2`,
+      label: `Test2`,
+    },
+    {
+      value: `test3`,
+      label: `Test3`,
+    },
+  ]);
 
   const onChange = (value) => {
     setValue(value);

--- a/src/select/base/Select.tsx
+++ b/src/select/base/Select.tsx
@@ -236,6 +236,7 @@ const Select = forwardRefWithStatics(
 
     // 处理输入框逻辑
     const handleInputChange = (value: string) => {
+      if (selectedLabel === value) return;
       onInputChange(value);
 
       if (isFunction(onSearch)) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复 修复onSearch触发时机的错误 



### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- #555 

### 💡 需求背景和解决方案

每次focus在select上的同时 filterable的情况下，会清空SelectInput的value 进而触发onInputChange 携带参数为原来的selectLabel 所以加一下判断是否是原来的值 如果是就不要触发onSearch 
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 修复onSearch触发时机的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
