### PR TITLE
fix(cascader): 定制数据字段别名 label 不展示问题

### DIFF
--- a/src/cascader/Cascader.tsx
+++ b/src/cascader/Cascader.tsx
@@ -93,15 +93,21 @@ const Cascader: React.FC<CascaderProps> = (props) => {
   /**
    * build tree
    */
-  const { disabled, options = [], keys, checkStrictly = false, lazy = true, load, valueMode = 'onlyLeaf' } = props;
+  const { disabled, options = [], keys = {}, checkStrictly = false, lazy = true, load, valueMode = 'onlyLeaf' } = props;
 
   useEffect(() => {
     if (!options.length) return;
     if (!treeStore) {
       const createStore = (onLoad: () => void) => {
+        const treePropsKeys = {
+          ...keys,
+          children: typeof keys.children === 'string' ? keys.children : 'children',
+        };
+
         const treeProps = {
           onLoad,
           options,
+          keys: treePropsKeys,
         };
         const store = new TreeStore(treeProps);
         store.append(options);
@@ -119,7 +125,7 @@ const Cascader: React.FC<CascaderProps> = (props) => {
       treeStoreExpendEffect(treeStore, value, []);
       treeNodesEffect(inputVal, treeStore, setTreeNodes);
     }
-  }, [inputVal, options, value, treeStore]);
+  }, [inputVal, options, value, treeStore, keys]);
 
   useEffect(() => {
     if (!treeStore) return;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
修复 #581 

### 💡 需求背景和解决方案
tree node 的 label 和 value 只在初始化的时候会被赋值，原本是想改 tree node，在update的时候，更新 label 和 value，但是也会涉及到 children的变更，所以干脆在 key or options 变更时，去重新构建 treeStore.nodes

不过涉及到 tree-store 的 removeAll 方法，我的理解是 removeAll 应该联通 children 一并清除，不清楚这算不算之前设计的一个小缺陷
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->


- fix(cascader): 定制数据字段别名时数据展示问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
