### PR TITLE
fix(cascader): 多选或筛选时文本过长的展示

### DIFF
--- a/src/cascader/_example/ellipsis.jsx
+++ b/src/cascader/_example/ellipsis.jsx
@@ -48,7 +48,7 @@ export default function Example() {
 
   return (
     <div className="tdesign-demo-block-column">
-      <Cascader style={itemStyle} options={options} value={value1} onChange={onChange1} />
+      <Cascader style={itemStyle} options={options} value={value1} onChange={onChange1} filterable />
     </div>
   );
 }

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -25,6 +25,13 @@ import { CheckboxProps } from '../../checkbox';
 const RenderLabelInner = (name: string, node: TreeNode, cascaderContext: CascaderContextType) => {
   const { filterActive, inputVal } = cascaderContext;
   const labelText = filterActive ? getFullPathLabel(node) : node.label;
+  const isEllipsis = getLabelIsEllipsis(labelText, cascaderContext.size);
+  const EllipsisNode = isEllipsis ? (
+    <div className={`${name}-label--ellipsis`}>
+      <Tooltip content={labelText} placement="top-left" />
+    </div>
+  ) : null;
+
   if (filterActive) {
     const texts = labelText.split(inputVal);
     const doms = [];
@@ -37,9 +44,19 @@ const RenderLabelInner = (name: string, node: TreeNode, cascaderContext: Cascade
         </span>,
       );
     }
-    return doms;
+    return (
+      <>
+        {doms}
+        {EllipsisNode}
+      </>
+    );
   }
-  return labelText;
+  return (
+    <>
+      {labelText}
+      {EllipsisNode}
+    </>
+  );
 };
 
 const RenderLabelContent = (node: TreeNode, cascaderContext: CascaderContextType) => {
@@ -47,19 +64,12 @@ const RenderLabelContent = (node: TreeNode, cascaderContext: CascaderContextType
   const name = `${prefix}-cascader__item`;
 
   const label = RenderLabelInner(name, node, cascaderContext);
-  const isEllipsis = getLabelIsEllipsis(node, cascaderContext.size);
 
-  if (isEllipsis) {
-    return (
-      <span className={`${name}-label`} role="label">
-        {label}
-        <div className={`${name}-label--ellipsis`}>
-          <Tooltip content={node.label} placement="top-left" />
-        </div>
-      </span>
-    );
-  }
-  return <span className={`${name}-label`}>{label}</span>;
+  return (
+    <span className={`${name}-label`} role="label">
+      {label}
+    </span>
+  );
 };
 
 const RenderCheckBox = (node: TreeNode, cascaderContext: CascaderContextType, handleChange) => {

--- a/src/cascader/utils/item.ts
+++ b/src/cascader/utils/item.ts
@@ -2,17 +2,17 @@ import { CascaderContextType, TreeNode, TreeNodeValue } from '../interface';
 
 /**
  * 是否显示省略计算方法
- * @param node
+ * @param label
  * @param size
  * @returns
  */
-export function getLabelIsEllipsis(node: TreeNode, size: CascaderContextType['size']) {
+export function getLabelIsEllipsis(label: string, size: CascaderContextType['size']) {
   const sizeMap = {
     small: 11,
     medium: 9,
     large: 8,
   };
-  return sizeMap[size] < node.label.length;
+  return sizeMap[size] < label.length;
 }
 
 export function getNodeStatusClass(node: TreeNode, CLASSNAMES: any, cascaderContext: CascaderContextType) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#604 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 多选或筛选时，文本过长展示提示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
