### PR TITLE
feat(dialog): 修复 dialog destroy 功能

### DIFF
--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useMemo } from 'react';
+import React, { forwardRef, useEffect, useMemo, useRef } from 'react';
 import isString from 'lodash/isString';
 import { CloseIcon, InfoCircleFilledIcon, CheckCircleFilledIcon } from 'tdesign-icons-react';
 import { useLocaleReceiver } from '../locale/LocalReceiver';
@@ -19,6 +19,7 @@ export interface DialogProps extends TdDialogProps, StyledProps {
 
 const Dialog = forwardRef((props: DialogProps, ref: React.Ref<DialogInstance>) => {
   const { classPrefix } = useConfig();
+  const dialogDom = useRef<HTMLDivElement>();
   const [state, setState] = useSetState<DialogProps>({
     width: 520,
     visible: false,
@@ -75,7 +76,9 @@ const Dialog = forwardRef((props: DialogProps, ref: React.Ref<DialogInstance>) =
     hide() {
       setState({ visible: false });
     },
-    destroy: noop,
+    destroy() {
+      setState({ visible: false, destroyOnClose: true });
+    },
     update(newOptions) {
       setState((prevState) => ({
         ...prevState,
@@ -161,6 +164,7 @@ const Dialog = forwardRef((props: DialogProps, ref: React.Ref<DialogInstance>) =
       classPrefix={classPrefix}
       onClose={onClose}
       footer={footer === undefined ? defaultFooter() : footer}
+      ref={dialogDom}
     />
   );
 });

--- a/src/dialog/plugin.tsx
+++ b/src/dialog/plugin.tsx
@@ -14,6 +14,7 @@ const createDialog: DialogPlugin = (props: DialogOptions): DialogInstance => {
   const dialogRef = React.createRef<DialogInstance>();
   const options = { ...props };
   const div = document.createElement('div');
+
   ReactDOM.render(
     <DialogComponent {...(options as DialogProps)} visible={true} ref={dialogRef} isPlugin />,
     div,
@@ -30,16 +31,19 @@ const createDialog: DialogPlugin = (props: DialogOptions): DialogInstance => {
 
   const dialogNode: DialogInstance = {
     show: () => {
+      container.appendChild(div);
       dialogRef.current?.show();
     },
     hide: () => {
+      div?.parentNode?.removeChild(div);
       dialogRef.current?.hide();
     },
     update: (updateOptions: DialogOptions) => {
       dialogRef.current?.update(updateOptions);
     },
     destroy: () => {
-      container.contains(div) && container.removeChild(div);
+      dialogRef.current?.destroy();
+      div?.parentNode?.removeChild(div);
     },
   };
   return dialogNode;


### PR DESCRIPTION
修复 dialog destroy 功能
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
解决destroy时重复创建portal的问题
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
解决destroy时重复创建portal的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dialog): 修复 dialog destroy 功能

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
