### PR TITLE
fix(cascader):  filterable visible

### DIFF
--- a/src/cascader/utils/helper.ts
+++ b/src/cascader/utils/helper.ts
@@ -35,6 +35,14 @@ export const getTreeValue = (value: CascaderContextType['value']) => {
   return treeValue;
 };
 
+/**
+ * 判断node是否在页面上
+ * @param node Node
+ */
+export function isInPage(node: Node) {
+  return node === document.body ? false : document.body.contains(node);
+}
+
 export default {
   getFullPathLabel,
 };

--- a/src/cascader/utils/inputContent.ts
+++ b/src/cascader/utils/inputContent.ts
@@ -1,6 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import isEmpty from 'lodash/isEmpty';
 import { TreeNode, CascaderContextType, TreeNodeValue, CascaderProps } from '../interface';
+import { isInPage } from './helper';
 
 /**
  * icon Class
@@ -147,13 +148,10 @@ export function outerClickListenerEffect(
   event: MouseEvent | TouchEvent,
 ) {
   const { visible, setVisible } = cascaderContext;
-  if (!ref || ref.contains(event.target as Node)) {
-    return;
-  }
-
-  if (visible) {
-    setVisible(false);
-  }
+  const target = event.target as Node;
+  // 可能点击的dom在判断的时候已经被移除了
+  if (!visible || !ref || ref.contains(target) || !isInPage(target)) return;
+  setVisible(false);
 }
 
 /**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#622 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

原因是点击 inputContent时触发 setVisible(true)，后面执行 outerClick 判断时 inputContent已经被移除，所以又判断为 true
目前的做法是，在判断outerClick时加多个判断当前触发的element 是否存在 body 中。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): filterable情况下，点击非空白区域展示问题修复

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
