### PR TITLE
fix(table): getBoundingClientRect attribute is null

### DIFF
--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -386,8 +386,8 @@ export default function useFixed(props: TdBaseTableProps) {
       setIsWidthOverflow(tRef.scrollWidth > tRef.clientWidth);
       const pos = tRef?.getBoundingClientRect?.();
       setVirtualScrollHeaderPos({
-        top: pos.top,
-        left: pos.left,
+        top: pos?.top,
+        left: pos?.left,
       });
       clearTimeout(timer);
     }, 0);
@@ -407,7 +407,7 @@ export default function useFixed(props: TdBaseTableProps) {
     // 存在纵向滚动条，且固定表头时，需去除滚动条宽度
     const reduceWidth = isFixedHeader ? scrollbarWidth : 0;
     const fixedBordered = isFixedRightColumn ? 1 : 2;
-    setTableWidth(rect.width - reduceWidth - (props.bordered ? fixedBordered : 0));
+    setTableWidth(rect?.width - reduceWidth - (props.bordered ? fixedBordered : 0));
   };
 
   const updateThWidthList = (trList: HTMLCollection) => {
@@ -441,7 +441,7 @@ export default function useFixed(props: TdBaseTableProps) {
   const onDocumentScroll = () => {
     const pos = tableContentRef.current?.getBoundingClientRect?.();
     // eslint-disable-next-line no-unsafe-optional-chaining
-    const r = affixHeaderRef.current?.offsetHeight - pos.top < pos.height;
+    const r = affixHeaderRef.current?.offsetHeight - pos?.top < pos?.height;
     setShowAffixHeader(r);
   };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复 处理table hooks在node环境中存在`getBoundingClientRect`为null的场景

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
