### PR TITLE
fix: unable to input demical

### DIFF
--- a/src/input-number/InputNumber.tsx
+++ b/src/input-number/InputNumber.tsx
@@ -79,7 +79,7 @@ const InputNumber = forwardRef((props: InputNumberProps, ref: React.Ref<HTMLInpu
 
   let decimalValue: number = internalInputValue as number;
   if (typeof internalInputValue === 'string') {
-    decimalValue = numberUtils.strToNumber(internalInputValue) || 0;
+    decimalValue = Number(numberUtils.strToNumber(internalInputValue)) || 0;
   }
 
   const setInputValue = (inputStr: string) => {
@@ -152,7 +152,7 @@ const InputNumber = forwardRef((props: InputNumberProps, ref: React.Ref<HTMLInpu
 
     setInputValue(filteredInputStr.toString());
     if (!checkInput(filteredInputStr)) return;
-    triggerValueUpdate({ type: 'input', value: filteredInputStr, e });
+    triggerValueUpdate({ type: 'input', value: Number(filteredInputStr), e });
   };
 
   const onInternalStep = (action: ChangeContext) => {

--- a/src/input-number/utils/numberUtils.ts
+++ b/src/input-number/utils/numberUtils.ts
@@ -1,3 +1,5 @@
+import { InputNumberInternalValue } from "../InputNumber";
+
 export const isInvalidNumber = (number: number | string) => {
   if (typeof number === 'number') {
     return Number.isNaN(number);
@@ -31,7 +33,7 @@ const multiNegative = (s: string) => {
   const m = s.match(/[-]/g);
   return m === null ? false : m.length > 1;
 };
-export const strToNumber = (s: string): number => {
+export const strToNumber = (s: string): InputNumberInternalValue => {
   if (['', undefined].includes(s)) {
     return 0;
   }
@@ -40,5 +42,5 @@ export const strToNumber = (s: string): number => {
     filterVal = filterVal.substr(0, filterVal.length - 1);
   }
 
-  return Number(filterVal);
+  return filterVal
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-react/issues/727
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
**问题背景**
因为`internalInputValue`这个状态是组件内用于储存输入框展示的，它是 `string | number` 类型。但是在输入时会调用`strToNumber` 尝试把输入数字，所以 0.0 这样的输入就直接被转化成0然后展示到输入框里了

**解决方案**
参考vue侧的实现，`strToNumber`返回类型改为 `string | number`。emit值时再用`Number`转换为`number`（这样应该是安全的，在emit之前会调用`checkInput`检查数字合法性）
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(input-number): 无法输入小数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
