### PR TITLE
fix(timepicker): fix range focus style

### DIFF
--- a/src/time-picker/TimeRangePicker.tsx
+++ b/src/time-picker/TimeRangePicker.tsx
@@ -10,6 +10,7 @@ import TimePickerPanel from './panel/TimePickerPanel';
 
 import { useTimePickerTextConfig } from './hooks/useTimePickerTextConfig';
 import { formatInputValue, validateInputValue } from '../_common/js/time-picker/utils';
+import { TIME_PICKER_EMPTY } from '../_common/js/time-picker/const';
 
 import { TdTimeRangePickerProps, TimeRangeValue, TimeRangePickerPartial } from './type';
 import { StyledProps } from '../common';
@@ -43,7 +44,7 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (props) => {
 
   const { classPrefix } = useConfig();
   const [isPanelShowed, setPanelShow] = useState(false);
-  const [currentPanelIdx, setCurrentPanelIdx] = useState(0);
+  const [currentPanelIdx, setCurrentPanelIdx] = useState(undefined);
   const [currentValue, setCurrentValue] = useState(['', '']);
 
   const name = `${classPrefix}-time-picker`;
@@ -109,7 +110,8 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (props) => {
   };
 
   useEffect(() => {
-    setCurrentValue(isPanelShowed ? value ?? defaultArrVal : defaultArrVal);
+    setCurrentValue(isPanelShowed ? value ?? TIME_PICKER_EMPTY : defaultArrVal);
+    if (!isPanelShowed) setCurrentPanelIdx(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPanelShowed]);
 
@@ -140,6 +142,7 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (props) => {
           onFocus: handleFocus,
           onBlur: handleInputBlur,
           readonly: !allowInput,
+          activeIndex: currentPanelIdx,
           ...props.rangeInputProps,
         }}
         panel={


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

修复前
<img width="440" alt="image" src="https://user-images.githubusercontent.com/26377630/170619461-be77b8a1-528a-4693-bde1-9454bcc8b4cc.png">

修复后
<img width="459" alt="image" src="https://user-images.githubusercontent.com/26377630/170619430-64d08b0f-2ebe-4404-8177-70bb7c5d306d.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TimePicker): 修复`RangePicker`的聚焦样式丢失的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
