### PR TITLE
fix: fix anchor & affix props type error

### DIFF
--- a/src/affix/Affix.tsx
+++ b/src/affix/Affix.tsx
@@ -7,7 +7,7 @@ import useConfig from '../_util/useConfig';
 import { affixDefaultProps } from './defaultProps';
 
 export interface AffixProps extends TdAffixProps, StyledProps {
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }
 
 export interface AffixRef {

--- a/src/anchor/anchor.md
+++ b/src/anchor/anchor.md
@@ -7,7 +7,7 @@
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
-affixProps | Object | - | 透传 Affix 组件属性，即让 Anchor 组件支持所有 Affix 组件特性。TS 类型：`AffixProps`，[Affix API Documents](./affix?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/anchor/type.ts) | N
+affixProps | Object | - | 透传 Affix 组件属性，即让 Anchor 组件支持所有 Affix 组件特性。TS 类型：`Omit<AffixProps, 'children'>`，[Affix API Documents](./affix?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/anchor/type.ts) | N
 bounds | Number | 5 | 锚点区域边界 | N
 container | String / Function | () => (() => window) | 指定滚动的容器。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body。TS 类型：`ScrollContainer` | N
 cursor | TElement | - | 用于自定义选中项左侧游标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N

--- a/src/anchor/type.ts
+++ b/src/anchor/type.ts
@@ -12,7 +12,7 @@ export interface TdAnchorProps {
   /**
    * 透传 Affix 组件属性，即让 Anchor 组件支持所有 Affix 组件特性
    */
-  affixProps?: AffixProps;
+  affixProps?: Omit<AffixProps, 'children'>;
   /**
    * 锚点区域边界
    * @default 5


### PR DESCRIPTION


<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
-  #880

### 💡 需求背景和解决方案
修复`Anchor ` `Affix`组件类型定义问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Anchor): 修复affix参数类型问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
