### PR TITLE
Feature/处理space空元素

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
   "dependencies": {
     "@babel/runtime": "~7.17.2",
     "@popperjs/core": "~2.11.2",
+    "@types/react-is": "^17.0.3",
     "@types/sortablejs": "^1.10.7",
     "@types/tinycolor2": "^1.4.3",
     "classnames": "~2.3.1",

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "hoist-non-react-statics": "~3.3.2",
     "lodash": "~4.17.15",
     "raf": "~3.4.1",
+    "rc-util": "^5.22.5",
     "react-popper": "~2.2.5",
     "react-transition-group": "~4.4.1",
     "sortablejs": "^1.15.0",

--- a/src/space/Space.tsx
+++ b/src/space/Space.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useMemo } from 'react';
 import classNames from 'classnames';
+import toArray from 'rc-util/lib/Children/toArray';
 import useConfig from '../_util/useConfig';
 import { TdSpaceProps } from './type';
 import { StyledProps } from '../common';
@@ -10,7 +11,7 @@ export interface SpaceProps extends TdSpaceProps, StyledProps {
 }
 
 const Space = forwardRef((props: SpaceProps, ref: React.Ref<HTMLDivElement>) => {
-  const { className, style, align, direction, size, breakLine, separator, children } = props;
+  const { className, style, align, direction, size, breakLine, separator } = props;
   const { classPrefix } = useConfig();
 
   const renderStyle = useMemo(() => {
@@ -39,6 +40,7 @@ const Space = forwardRef((props: SpaceProps, ref: React.Ref<HTMLDivElement>) => 
   }, [style, size, breakLine]) as React.CSSProperties;
 
   function renderChildren() {
+    const children = toArray(props.children);
     const childCount = React.Children.count(children);
     return React.Children.map(children, (child, index) => {
       // filter last child

--- a/src/space/Space.tsx
+++ b/src/space/Space.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useMemo } from 'react';
 import classNames from 'classnames';
-import toArray from 'rc-util/lib/Children/toArray';
+import { isFragment } from 'react-is';
 import useConfig from '../_util/useConfig';
 import { TdSpaceProps } from './type';
 import { StyledProps } from '../common';
@@ -9,6 +9,26 @@ import { spaceDefaultProps } from './defaultProps';
 export interface SpaceProps extends TdSpaceProps, StyledProps {
   children?: React.ReactElement;
 }
+
+const toArray = (children: React.ReactNode): React.ReactElement[] => {
+  let ret: React.ReactElement[] = [];
+
+  React.Children.forEach(children, (child: any) => {
+    if (child === undefined || child === null) {
+      return;
+    }
+
+    if (Array.isArray(child)) {
+      ret = ret.concat(toArray(child));
+    } else if (isFragment(child) && child.props) {
+      ret = ret.concat(toArray(child.props.children));
+    } else {
+      ret.push(child);
+    }
+  });
+
+  return ret;
+};
 
 const Space = forwardRef((props: SpaceProps, ref: React.Ref<HTMLDivElement>) => {
   const { className, style, align, direction, size, breakLine, separator } = props;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在从 antdesign 切换到 tdesign 的过程中，发现了 antd 的 Space 和 td的 Space 对空标签处理不一致，导致样式错误。后面我对比了其他主流的组件库，例如 semi 都会对空元素进行处理。
例如以下代码， antd 显示效果一样，而tdesign则不一样
* 包裹空元素
```tsx
const BaseSpace = () => (
  <Space>
    <>
      <Button>Button</Button>
      <Button>Button</Button>
    </>
      <Button>Button</Button>
  </Space>
);

```
* 没有空元素
```tsx
const BaseSpace = () => (
  <Space>
    <Button>Button</Button>
    <Button>Button</Button>
    <Button>Button</Button>
  </Space>
);
```
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
