### PR TITLE
fix: 修复 React 18 useEffect触发两次导致表单自动校验问题

### DIFF
--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -76,8 +76,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((props, ref) => {
 
   const currentFormItemRef = useRef<FormItemInstance>(); // 当前 formItem 实例
   const innerFormItemsRef = useRef([]);
-  const shouldValidate = useRef(null);
-  const isMounted = useRef(false);
+  const shouldValidate = useRef(false);
 
   const errorMessages = useMemo(() => errorMessage ?? globalFormConfig.errorMessage, [errorMessage, globalFormConfig]);
 
@@ -252,10 +251,8 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((props, ref) => {
 
     const resetType = type || resetTypeFromContext;
     const resetValue = getResetValue(resetType);
-    // 防止触发校验
-    if (resetValue !== formValue) {
-      shouldValidate.current = false;
-    }
+    // reset 不校验
+    shouldValidate.current = false;
     setFormValue(resetValue);
 
     if (resetValidating) {
@@ -274,15 +271,15 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((props, ref) => {
 
   function setField(field: { value?: string; status?: ValidateStatus }) {
     const { value, status } = field;
-    // 手动设置 status 则不需要校验 交给用户判断
     if (typeof status !== 'undefined') {
-      shouldValidate.current = false;
       setErrorList([]);
       setSuccessList([]);
       setNeedResetField(false);
       setVerifyStatus(status);
     }
     if (typeof value !== 'undefined') {
+      // 手动设置 status 则不需要校验 交给用户判断
+      shouldValidate.current = typeof status === 'undefined' ? true : false;
       setFormValue(value);
     }
   }
@@ -299,12 +296,8 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((props, ref) => {
   }
 
   useEffect(() => {
-    // 首次渲染不触发校验 后续判断是否检验也通过此字段控制
-    if (!shouldValidate.current || !isMounted.current) {
-      isMounted.current = true;
-      shouldValidate.current = true;
-      return;
-    }
+    // 控制是否需要校验
+    if (!shouldValidate.current) return;
 
     // value change event
     if (typeof name !== 'undefined') {
@@ -406,6 +399,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((props, ref) => {
                 [ctrlKey]: formValue,
                 onChange: (value: any, ...args: any[]) => {
                   onChangeFromProps.call(null, value, ...args);
+                  shouldValidate.current = true;
                   setFormValue(value);
                 },
                 onBlur: (value: any, ...args: any[]) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-react/issues/850

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(`Form`): 修复 React 18 useEffect触发两次导致表单自动校验问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
