### PR TITLE
列宽拖拽调整到边界时无法重新调整；多级表头场景下的列配置，无法全选

### DIFF
--- a/src/table/hooks/useColumnController.tsx
+++ b/src/table/hooks/useColumnController.tsx
@@ -85,7 +85,8 @@ export default function useColumnController(props: TdPrimaryTableProps) {
 
   const handleClickAllShowColumns = (checked: boolean, ctx: { e: ChangeEvent<HTMLDivElement> }) => {
     if (checked) {
-      const newData = columns?.map((t) => t.colKey) || [];
+      const checkboxOptions = getCheckboxOptions(columns);
+      const newData = checkboxOptions?.map((t) => t.value) || [];
       columnCheckboxKeys.current = newData;
       props.onColumnChange?.({ type: 'check', columns: newData, e: ctx.e });
     } else {

--- a/src/table/hooks/useColumnResize.tsx
+++ b/src/table/hooks/useColumnResize.tsx
@@ -58,9 +58,9 @@ export default function useColumnResize(tableContentRef: MutableRefObject<HTMLDi
     const tableBoundRect = tableContentRef.current?.getBoundingClientRect();
     const resizeLinePos = targetBoundRect.right - tableBoundRect.left;
     const colLeft = targetBoundRect.left - tableBoundRect.left;
-    const minColLen = col.resize?.minWidth || DEFAULT_MIN_WIDTH;
+    const minColWidth = col.resize?.minWidth || DEFAULT_MIN_WIDTH;
     const maxColWidth = col.resize?.maxWidth || DEFAULT_MAX_WIDTH;
-    const minResizeLineLeft = colLeft + minColLen;
+    const minResizeLineLeft = colLeft + minColWidth;
     const maxResizeLineLeft = colLeft + maxColWidth;
 
     // 开始拖拽，记录下鼠标起始位置
@@ -99,10 +99,15 @@ export default function useColumnResize(tableContentRef: MutableRefObject<HTMLDi
     const onDragEnd = () => {
       if (resizeLineParams.isDragging) {
         // 结束拖拽，更新列宽
-        const width = parseInt(resizeLineLeft, 10) - colLeft;
-
+        let width = Math.ceil(parseInt(resizeLineLeft, 10) - colLeft) || 0;
+        // 为了避免精度问题，导致 width 宽度超出 [minColWidth, maxColWidth] 的范围，需要对比目标宽度和最小/最大宽度
+        if (width <= minColWidth) {
+          width = minColWidth;
+        } else if (width >= maxColWidth) {
+          width = maxColWidth;
+        }
         // eslint-disable-next-line
-        col.width = `${Math.floor(width)}px`;
+        col.width = `${width}px`;
 
         // 恢复设置
         resizeLineParams.isDragging = false;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 列宽拖拽调整到边界时无法重新调整
- fix(table): 多级表头场景下的列配置，无法全选

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
