### PR TITLE
fix(drawer): 修复开启 destroyOnClose 时多次打开关闭时动效丢失问题

### DIFF
--- a/src/drawer/Drawer.tsx
+++ b/src/drawer/Drawer.tsx
@@ -194,11 +194,20 @@ const Drawer = forwardRef((props: DrawerProps, ref: React.Ref<HTMLDivElement>) =
     `${prefixCls}__content-wrapper--${placement}`,
   );
 
-  const contentWrapperStyle = {
-    transform: visible ? 'translateX(0)' : undefined,
-    width: ['left', 'right'].includes(placement) ? getSizeValue(size) : '',
-    height: ['top', 'bottom'].includes(placement) ? getSizeValue(size) : '',
-  };
+  const getContentWrapperStyle = useCallback(
+    () => ({
+      transform: visible ? 'translateX(0)' : undefined,
+      width: ['left', 'right'].includes(placement) ? getSizeValue(size) : '',
+      height: ['top', 'bottom'].includes(placement) ? getSizeValue(size) : '',
+    }),
+    [visible, placement, size, getSizeValue],
+  );
+
+  const [contentWrapperStyle, setContentWrapperStyle] = useState(getContentWrapperStyle());
+
+  useEffect(() => {
+    setContentWrapperStyle(getContentWrapperStyle());
+  }, [getContentWrapperStyle]);
 
   function getFooter(): React.ReactNode {
     if (footer !== true) return footer;


### PR DESCRIPTION

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-react/issues/1115

### 💡 需求背景和解决方案

原逻辑：开启destroyOnClose时，初次visible为false时，加载了dom且translateX为100%，当visible设置为true时style的translateX更改为0，所以初次有动效；当再次visible设置为false时，dom完全清除，再次visible设置为true，导致dom和translateX(0)同时生效（因为style计算逻辑直接写在了fc内，没有使用setState），所以动效消失

解决：在visible生效后，使用setState更新translateX，时间上先渲染dom，后设置样式

### 📝 更新日志


- fix(drawer): 修复开启 destroyOnClose 时多次打开关闭时动效丢失问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
