### PR TITLE
fix(Table): fullRow and empty render logic

### DIFF
--- a/src/table/TBody.tsx
+++ b/src/table/TBody.tsx
@@ -63,7 +63,6 @@ export default function TBody(props: TableBodyProps) {
   const { skipSpansMap } = useRowspanAndColspan(data, columns, rowKey, props.rowspanAndColspan);
 
   const tbodyClasses = useMemo(() => [tableBaseClass.body], [tableBaseClass.body]);
-  const hasFullRowConfig = useMemo(() => firstFullRow || lastFullRow, [firstFullRow, lastFullRow]);
 
   const renderEmpty = (columns: TableBodyProps['columns']) => (
     <tr className={classNames([tableBaseClass.emptyRow, { [tableFullRowClasses.base]: props.isWidthOverflow }])}>
@@ -152,14 +151,7 @@ export default function TBody(props: TableBodyProps) {
     }
   });
 
-  const list = (
-    <>
-      {getFullRow(columnLength, 'first-full-row')}
-      {trNodeList}
-      {getFullRow(columnLength, 'last-full-row')}
-    </>
-  );
-  const isEmpty = !data?.length && !props.loading && !hasFullRowConfig;
+  const isEmpty = !data?.length && !props.loading;
 
   const translate = `translate(0, ${props.translateY}px)`;
   const posStyle = {
@@ -171,7 +163,9 @@ export default function TBody(props: TableBodyProps) {
 
   return (
     <tbody className={classNames(tbodyClasses)} style={props.isVirtual && { ...posStyle }}>
-      {isEmpty ? renderEmpty(columns) : list}
+      {getFullRow(columnLength, 'first-full-row')}
+      {isEmpty ? renderEmpty(columns) : trNodeList}
+      {getFullRow(columnLength, 'last-full-row')}
     </tbody>
   );
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): `fullRow`渲染与正常表格分开 修复存在`fullRow`不渲染空数据的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
