### PR TITLE
Fix/cascader

### DIFF
--- a/src/input/Input.tsx
+++ b/src/input/Input.tsx
@@ -100,6 +100,7 @@ const Input = forwardRefWithStatics(
     const [isHover, toggleIsHover] = useState(false);
     const [isFocused, toggleIsFocused] = useState(false);
     const [renderType, setRenderType] = useState(type);
+    const [inputSize, setInputSize] = useState<number>();
 
     const [composingValue, setComposingValue] = useState<string>('');
     const isShowClearIcon = ((clearable && value && !disabled) || showClearIconOnEmpty) && isHover;
@@ -125,8 +126,9 @@ const Input = forwardRefWithStatics(
 
     useEffect(() => {
       if (!autoWidth) return;
+      setInputSize(inputPreRef.current.offsetWidth);
       if (inputRef.current) inputRef.current.style.width = `${inputPreRef.current?.offsetWidth}px`;
-    }, [autoWidth, value, placeholder, inputRef]);
+    }, [autoWidth, value, placeholder, inputRef, inputSize]);
 
     useEffect(() => {
       setRenderType(type);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[相关Issue](https://github.com/Tencent/tdesign-react/issues/1091)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1、Cascader使用input组件实现，当multiple属性为true时，会渲染一个新的span组件，内容为placeholder，此次commit为[#229](https://github.com/Tencent/tdesign-react/pull/229/files)，目的是用于获取input组件的placeholder宽度。但在useEffect执行时，rerender未完成时，useRef获取DOM失败，因此width宽度为0，导致input的placeholder像是被挡住了。因此，等待rerender完成再获得useRef即可。
2.解决办法：1、setTimeout，此方法受性能影响，不够稳定；2、赋值useState
<img width="733" alt="截屏2022-07-26 20 31 59" src="https://user-images.githubusercontent.com/25198901/181006447-f9f6440d-d423-401b-aaf2-d3e130cb85db.png">

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
等待useEffect的rerender完成时，获取useRef的引用
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
