### PR TITLE
feat(hooks): update useControlled hook types

### DIFF
--- a/src/color-picker/components/panel/index.tsx
+++ b/src/color-picker/components/panel/index.tsx
@@ -110,14 +110,9 @@ const Panel = forwardRef((props: ColorPickerProps, ref: MutableRefObject<HTMLDiv
   const formatRef = useRef<TdColorPickerProps['format']>(colorInstanceRef.current.isGradient ? 'CSS' : 'RGB');
 
   const { onRecentColorsChange } = props;
-  const [recentlyUsedColors, setRecentlyUsedColors] = useControlled<TdColorPickerProps['recentColors'], any>(
-    props,
-    'recentColors',
-    onRecentColorsChange,
-    {
-      defaultRecentColors: colorPickerDefaultProps.recentColors,
-    },
-  );
+  const [recentlyUsedColors, setRecentlyUsedColors] = useControlled(props, 'recentColors', onRecentColorsChange, {
+    defaultRecentColors: colorPickerDefaultProps.recentColors,
+  });
 
   const baseProps = {
     color: colorInstanceRef.current,

--- a/src/date-picker/hooks/useSingleValue.tsx
+++ b/src/date-picker/hooks/useSingleValue.tsx
@@ -6,7 +6,7 @@ import { TdDatePickerProps } from '../type';
 import { extractTimeFormat } from '../../_common/js/date-picker/utils';
 
 export default function useSingleValue(props: TdDatePickerProps) {
-  const [value, onChange] = useControlled<string, any>(props, 'value', props.onChange);
+  const [value, onChange] = useControlled(props, 'value', props.onChange);
 
   const { format, valueType, timeFormat } = getDefaultFormat({
     mode: props.mode,

--- a/src/hooks/useControlled.ts
+++ b/src/hooks/useControlled.ts
@@ -6,18 +6,27 @@ export interface ChangeHandler<T, P extends any[]> {
   (value: T, ...args: P);
 }
 
-export default function useControlled<T, P extends any[]>(
-  props: object = {},
-  valueKey: string,
-  onChange: ChangeHandler<T, P>,
-  defaultOptions: object = {},
-): [T, ChangeHandler<T, P>] {
+type Defaultoptions<T extends string> = `default${Capitalize<T>}`;
+
+type ToString<T extends string | number | symbol> = T extends string ? T : `${Extract<T, number>}`;
+
+const useControlled: <P extends any[], R extends object, K extends keyof R>(
+  props: R,
+  valueKey: K,
+  onChange: ChangeHandler<R[K], P>,
+  defaultOptions?:
+    | {
+        [key in Defaultoptions<ToString<K>>]: R[K];
+      }
+    | object,
+) => [R[K], ChangeHandler<R[K], P>] = (props = {} as any, valueKey, onChange, defaultOptions = {}) => {
   // 外部设置 props，说明希望受控
   const controlled = Reflect.has(props, valueKey);
   // 受控属性
   const value = props[valueKey];
   // 约定受控属性的非受控 key 为 defaultXxx，某些条件下要在运行时确定 defaultXxx 则通过 defaultOptions 来覆盖
-  const defaultValue = defaultOptions[`default${upperFirst(valueKey)}`] || props[`default${upperFirst(valueKey)}`];
+  const defaultValue =
+    defaultOptions[`default${upperFirst(valueKey as string)}`] || props[`default${upperFirst(valueKey as string)}`];
 
   // 无论是否受控，都要维护一个内部变量，默认值由 defaultValue 控制
   const [internalValue, setInternalValue] = useState(defaultValue);
@@ -33,4 +42,6 @@ export default function useControlled<T, P extends any[]>(
       onChange?.(newValue, ...args);
     },
   ];
-}
+};
+
+export default useControlled;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
更新`useControlled`方法类型定义，更多类型自动推导

```ts
type A = {
  popupVisible: boolean;
  onPopupVisible: (visible: boolean, ctx: any) => void;
};

const props: A = {
  popupVisible: false,
  onPopupVisible: () => {},
};

const [visible, setVisible] = useControlled(props, 'popupVisible', props.onPopupVisible, {
  defaultPopupVisible: false,
  a: '123',
});

```


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
