### PR TITLE
fix: cascader getFullPath robust

### DIFF
--- a/src/cascader/core/helper.ts
+++ b/src/cascader/core/helper.ts
@@ -45,10 +45,12 @@ export function getMultipleContent(cascaderContext: CascaderContextType) {
   const node = treeStore && treeStore.getNodes(value as TreeNodeValue | TreeNode);
   if (!node) return [];
 
-  return (value as TreeNodeValue[]).map((item: TreeNodeValue) => {
-    const node = treeStore.getNodes(item);
-    return showAllLevels ? getFullPathLabel(node[0]) : node[0].label;
-  });
+  return (value as TreeNodeValue[])
+    .map((item: TreeNodeValue) => {
+      const node = treeStore.getNodes(item);
+      return showAllLevels ? getFullPathLabel(node[0]) : node[0].label;
+    })
+    .filter((item) => !!item);
 }
 
 /**
@@ -75,7 +77,7 @@ export function getPanels(treeNodes: CascaderContextType['treeNodes']) {
  */
 export function getFullPathLabel(node: TreeNode, separator = '/') {
   return node
-    .getPath()
+    ?.getPath()
     .map((node: TreeNode) => node.label)
     .join(separator);
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复 `value` 不是 options 的健值会报错 ([issue #1293](https://github.com/Tencent/tdesign-react/issues/1293))

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
