### PR TITLE
fix(tag component): 修复tag组件在selectinput中自定义选中项的筛选器输入框示例，采用valueDispla…

### DIFF
--- a/src/calendar/__tests__/__snapshots__/calendar.test.tsx.snap
+++ b/src/calendar/__tests__/__snapshots__/calendar.test.tsx.snap
@@ -7574,7 +7574,9 @@ exports[`cell-append.jsx 1`] = `
                   <span
                     class="t-tag t-tag--primary t-tag--dark t-tag--small t-tag--square t-size-s"
                   >
-                    今天
+                    <span>
+                      今天
+                    </span>
                   </span>
                 </div>
               </div>

--- a/src/card/__tests__/__snapshots__/card.test.tsx.snap
+++ b/src/card/__tests__/__snapshots__/card.test.tsx.snap
@@ -139,7 +139,9 @@ exports[`footer.jsx 1`] = `
         <span
           class="t-tag t-tag--success t-tag--dark t-tag--medium t-tag--square"
         >
-          默认标签
+          <span>
+            默认标签
+          </span>
         </span>
       </div>
     </div>

--- a/src/cascader/__tests__/__snapshots__/cascader.test.tsx.snap
+++ b/src/cascader/__tests__/__snapshots__/cascader.test.tsx.snap
@@ -118,7 +118,9 @@ exports[`check-strictly.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                1/1.1/1.1.2/1.1.2.1
+                <span>
+                  1/1.1/1.1.2/1.1.2.1
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -136,7 +138,9 @@ exports[`check-strictly.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                2
+                <span>
+                  2
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -207,7 +211,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                选项一/子选项一
+                <span>
+                  选项一/子选项一
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -225,7 +231,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                +2
+                <span>
+                  +2
+                </span>
               </span>
             </div>
             <span
@@ -273,7 +281,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                选项一/子选项一
+                <span>
+                  选项一/子选项一
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -396,7 +406,9 @@ exports[`disabled.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square t-tag--disabled"
               >
-                选项一/子选项一
+                <span>
+                  选项一/子选项一
+                </span>
               </span>
             </div>
             <span
@@ -545,7 +557,9 @@ exports[`filterable.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                当选项一数据展示文本过长时/子选项一
+                <span>
+                  当选项一数据展示文本过长时/子选项一
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -824,7 +838,9 @@ exports[`multiple.jsx 1`] = `
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              选项一/子选项一
+              <span>
+                选项一/子选项一
+              </span>
               <svg
                 class="t-icon t-icon-close t-tag__icon-close"
                 fill="none"
@@ -1635,7 +1651,9 @@ exports[`value-type.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                选项一/子选项一
+                <span>
+                  选项一/子选项一
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -1653,7 +1671,9 @@ exports[`value-type.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                选项一/子选项二
+                <span>
+                  选项一/子选项二
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"

--- a/src/collapse/__tests__/__snapshots__/collapse.test.tsx.snap
+++ b/src/collapse/__tests__/__snapshots__/collapse.test.tsx.snap
@@ -142,7 +142,9 @@ exports[`base.jsx 1`] = `
                     <span
                       class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                     >
-                      Vue
+                      <span>
+                        Vue
+                      </span>
                       <svg
                         class="t-icon t-icon-close t-tag__icon-close"
                         fill="none"
@@ -160,7 +162,9 @@ exports[`base.jsx 1`] = `
                     <span
                       class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                     >
-                      React
+                      <span>
+                        React
+                      </span>
                       <svg
                         class="t-icon t-icon-close t-tag__icon-close"
                         fill="none"
@@ -497,7 +501,9 @@ exports[`icon.jsx 1`] = `
                         <span
                           class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                         >
-                          Vue
+                          <span>
+                            Vue
+                          </span>
                           <svg
                             class="t-icon t-icon-close t-tag__icon-close"
                             fill="none"
@@ -515,7 +521,9 @@ exports[`icon.jsx 1`] = `
                         <span
                           class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                         >
-                          React
+                          <span>
+                            React
+                          </span>
                           <svg
                             class="t-icon t-icon-close t-tag__icon-close"
                             fill="none"
@@ -778,7 +786,9 @@ exports[`mutex.jsx 1`] = `
                     <span
                       class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                     >
-                      Vue
+                      <span>
+                        Vue
+                      </span>
                       <svg
                         class="t-icon t-icon-close t-tag__icon-close"
                         fill="none"
@@ -796,7 +806,9 @@ exports[`mutex.jsx 1`] = `
                     <span
                       class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                     >
-                      React
+                      <span>
+                        React
+                      </span>
                       <svg
                         class="t-icon t-icon-close t-tag__icon-close"
                         fill="none"
@@ -972,7 +984,9 @@ exports[`other.jsx 1`] = `
                         <span
                           class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                         >
-                          Vue
+                          <span>
+                            Vue
+                          </span>
                           <svg
                             class="t-icon t-icon-close t-tag__icon-close"
                             fill="none"
@@ -990,7 +1004,9 @@ exports[`other.jsx 1`] = `
                         <span
                           class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                         >
-                          React
+                          <span>
+                            React
+                          </span>
                           <svg
                             class="t-icon t-icon-close t-tag__icon-close"
                             fill="none"

--- a/src/image/__tests__/__snapshots__/image.test.tsx.snap
+++ b/src/image/__tests__/__snapshots__/image.test.tsx.snap
@@ -82,21 +82,23 @@ exports[`extra-always.jsx 1`] = `
                   class="t-tag t-tag--warning t-tag--dark t-tag--medium t-tag--mark"
                   style="border-radius: 3px; background: transparent; color: rgb(255, 255, 255);"
                 >
-                  <svg
-                    class="t-icon t-icon-print"
-                    fill="none"
-                    height="1em"
-                    style="font-size: 16px;"
-                    viewBox="0 0 16 16"
-                    width="1em"
-                  >
-                    <path
-                      d="M4 2v2H3a1 1 0 00-1 1v5a1 1 0 001 1h1v3h8v-3h1a1 1 0 001-1V5a1 1 0 00-1-1h-1V2H4zm7 2H5V3h6v1zM3 5h10v5h-1V8H4v2H3V5zm2 8V9h6v4H5z"
-                      fill="currentColor"
-                      fill-opacity="0.9"
-                    />
-                  </svg>
-                   高清
+                  <span>
+                    <svg
+                      class="t-icon t-icon-print"
+                      fill="none"
+                      height="1em"
+                      style="font-size: 16px;"
+                      viewBox="0 0 16 16"
+                      width="1em"
+                    >
+                      <path
+                        d="M4 2v2H3a1 1 0 00-1 1v5a1 1 0 001 1h1v3h8v-3h1a1 1 0 001-1V5a1 1 0 00-1-1h-1V2H4zm7 2H5V3h6v1zM3 5h10v5h-1V8H4v2H3V5zm2 8V9h6v4H5z"
+                        fill="currentColor"
+                        fill-opacity="0.9"
+                      />
+                    </svg>
+                     高清
+                  </span>
                 </span>
               </div>
             </div>
@@ -177,21 +179,23 @@ exports[`extra-always.jsx 1`] = `
                 class="t-tag t-tag--warning t-tag--dark t-tag--medium t-tag--mark"
                 style="position: absolute; right: 8px; bottom: 8px; border-radius: 3px; background: rgb(236, 242, 254); color: rgb(0, 82, 217);"
               >
-                <svg
-                  class="t-icon t-icon-print"
-                  fill="none"
-                  height="1em"
-                  style="font-size: 16px;"
-                  viewBox="0 0 16 16"
-                  width="1em"
-                >
-                  <path
-                    d="M4 2v2H3a1 1 0 00-1 1v5a1 1 0 001 1h1v3h8v-3h1a1 1 0 001-1V5a1 1 0 00-1-1h-1V2H4zm7 2H5V3h6v1zM3 5h10v5h-1V8H4v2H3V5zm2 8V9h6v4H5z"
-                    fill="currentColor"
-                    fill-opacity="0.9"
-                  />
-                </svg>
-                 高清
+                <span>
+                  <svg
+                    class="t-icon t-icon-print"
+                    fill="none"
+                    height="1em"
+                    style="font-size: 16px;"
+                    viewBox="0 0 16 16"
+                    width="1em"
+                  >
+                    <path
+                      d="M4 2v2H3a1 1 0 00-1 1v5a1 1 0 001 1h1v3h8v-3h1a1 1 0 001-1V5a1 1 0 00-1-1h-1V2H4zm7 2H5V3h6v1zM3 5h10v5h-1V8H4v2H3V5zm2 8V9h6v4H5z"
+                      fill="currentColor"
+                      fill-opacity="0.9"
+                    />
+                  </svg>
+                   高清
+                </span>
               </span>
             </div>
           </div>
@@ -1369,7 +1373,9 @@ exports[`gallery-cover.jsx 1`] = `
         class="t-tag t-tag--warning t-tag--dark t-tag--medium t-tag--mark"
         style="margin: 8px; border-radius: 3px; background: rgb(236, 242, 254); color: rgb(0, 82, 217);"
       >
-        标签一
+        <span>
+          标签一
+        </span>
       </span>
     </div>
   </div>

--- a/src/select/__tests__/__snapshots__/select.test.tsx.snap
+++ b/src/select/__tests__/__snapshots__/select.test.tsx.snap
@@ -80,7 +80,9 @@ exports[`collapsed.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  选项一
+                  <span>
+                    选项一
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -98,7 +100,9 @@ exports[`collapsed.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  +1
+                  <span>
+                    +1
+                  </span>
                 </span>
               </div>
               <span
@@ -151,7 +155,9 @@ exports[`collapsed.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  选项一
+                  <span>
+                    选项一
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -327,17 +333,23 @@ exports[`custom-selected.jsx 1`] = `
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              选项一选项
+              <span>
+                选项一选项
+              </span>
             </span>
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              选项二选项
+              <span>
+                选项二选项
+              </span>
             </span>
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              选项三选项
+              <span>
+                选项三选项
+              </span>
             </span>
           </div>
           <span
@@ -500,7 +512,9 @@ exports[`filterable.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  选项一
+                  <span>
+                    选项一
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -673,7 +687,9 @@ exports[`keys.jsx 1`] = `
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              上海
+              <span>
+                上海
+              </span>
               <svg
                 class="t-icon t-icon-close t-tag__icon-close"
                 fill="none"
@@ -846,7 +862,9 @@ exports[`label-in-value.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  Apple
+                  <span>
+                    Apple
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -915,7 +933,9 @@ exports[`max.jsx 1`] = `
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              选项一
+              <span>
+                选项一
+              </span>
               <svg
                 class="t-icon t-icon-close t-tag__icon-close"
                 fill="none"
@@ -988,7 +1008,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  区块链
+                  <span>
+                    区块链
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1006,7 +1028,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  人工智能
+                  <span>
+                    人工智能
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1082,7 +1106,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  云服务器
+                  <span>
+                    云服务器
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1100,7 +1126,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  云数据库
+                  <span>
+                    云数据库
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1118,7 +1146,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  域名注册
+                  <span>
+                    域名注册
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1136,7 +1166,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  网站备案
+                  <span>
+                    网站备案
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1154,7 +1186,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  对象存储
+                  <span>
+                    对象存储
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"
@@ -1172,7 +1206,9 @@ exports[`multiple.jsx 1`] = `
                 <span
                   class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                 >
-                  低代码平台
+                  <span>
+                    低代码平台
+                  </span>
                   <svg
                     class="t-icon t-icon-close t-tag__icon-close"
                     fill="none"

--- a/src/table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/src/table/__tests__/__snapshots__/table.test.tsx.snap
@@ -5375,7 +5375,9 @@ exports[`editable-row.jsx 1`] = `
                             <span
                               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
                             >
-                              A
+                              <span>
+                                A
+                              </span>
                               <svg
                                 class="t-icon t-icon-close t-tag__icon-close"
                                 fill="none"

--- a/src/tag/Tag.tsx
+++ b/src/tag/Tag.tsx
@@ -93,7 +93,7 @@ const Tag = forwardRefWithStatics(
         {...otherTagProps}
       >
         {icon}
-        {maxWidth ? <span className={`${tagClassPrefix}--text`}>{children || content}</span> : children || content}
+        <span className={maxWidth ? `${tagClassPrefix}--text` : undefined}>{children || content}</span>
         {closable && deleteIcon}
       </span>
     );

--- a/src/tag/__tests__/__snapshots__/tag.test.tsx.snap
+++ b/src/tag/__tests__/__snapshots__/tag.test.tsx.snap
@@ -76,13 +76,17 @@ Object {
     <div>
       <span
         class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square t-tag--disabled"
-      />
+      >
+        <span />
+      </span>
     </div>
   </body>,
   "container": <div>
     <span
       class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square t-tag--disabled"
-    />
+    >
+      <span />
+    </span>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -166,6 +170,7 @@ Object {
             fill-rule="evenodd"
           />
         </svg>
+        <span />
       </span>
     </div>
   </body>,
@@ -193,6 +198,7 @@ Object {
           fill-rule="evenodd"
         />
       </svg>
+      <span />
     </span>
   </div>,
   "debug": [Function],
@@ -268,7 +274,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -282,7 +290,9 @@ exports[`base.jsx 1`] = `
             <span
               class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             >
-              超链接
+              <span>
+                超链接
+              </span>
             </span>
           </a>
         </div>
@@ -301,7 +311,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--dark t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -310,7 +322,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--warning t-tag--dark t-tag--medium t-tag--square"
           >
-            标签二
+            <span>
+              标签二
+            </span>
           </span>
         </div>
         <div
@@ -319,7 +333,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--danger t-tag--dark t-tag--medium t-tag--square"
           >
-            标签三
+            <span>
+              标签三
+            </span>
           </span>
         </div>
         <div
@@ -328,7 +344,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--success t-tag--dark t-tag--medium t-tag--square"
           >
-            标签四
+            <span>
+              标签四
+            </span>
           </span>
         </div>
       </div>
@@ -346,7 +364,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--light t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -355,7 +375,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--warning t-tag--light t-tag--medium t-tag--square"
           >
-            标签二
+            <span>
+              标签二
+            </span>
           </span>
         </div>
         <div
@@ -364,7 +386,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--danger t-tag--light t-tag--medium t-tag--square"
           >
-            标签三
+            <span>
+              标签三
+            </span>
           </span>
         </div>
         <div
@@ -373,7 +397,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--success t-tag--light t-tag--medium t-tag--square"
           >
-            标签四
+            <span>
+              标签四
+            </span>
           </span>
         </div>
       </div>
@@ -391,7 +417,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--outline t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -400,7 +428,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--warning t-tag--outline t-tag--medium t-tag--square"
           >
-            标签二
+            <span>
+              标签二
+            </span>
           </span>
         </div>
         <div
@@ -409,7 +439,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--danger t-tag--outline t-tag--medium t-tag--square"
           >
-            标签三
+            <span>
+              标签三
+            </span>
           </span>
         </div>
         <div
@@ -418,7 +450,9 @@ exports[`base.jsx 1`] = `
           <span
             class="t-tag t-tag--success t-tag--outline t-tag--medium t-tag--square"
           >
-            标签四
+            <span>
+              标签四
+            </span>
           </span>
         </div>
       </div>
@@ -447,7 +481,9 @@ exports[`delete.jsx 1`] = `
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
             style="margin-right: 30px;"
           >
-            可删除标签0
+            <span>
+              可删除标签0
+            </span>
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -490,7 +526,9 @@ exports[`delete.jsx 1`] = `
                 fill-rule="evenodd"
               />
             </svg>
-            可删除标签1
+            <span>
+              可删除标签1
+            </span>
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -513,7 +551,9 @@ exports[`delete.jsx 1`] = `
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square t-tag--disabled"
             style="margin-right: 30px;"
           >
-            可删除标签2
+            <span>
+              可删除标签2
+            </span>
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -540,20 +580,22 @@ exports[`delete.jsx 1`] = `
         <span
           class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
         >
-          <svg
-            class="t-icon t-icon-add"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-          可添加标签
+          <span>
+            <svg
+              class="t-icon t-icon-add"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            可添加标签
+          </span>
         </span>
       </div>
     </div>
@@ -586,7 +628,9 @@ exports[`icon.jsx 1`] = `
         fill-rule="evenodd"
       />
     </svg>
-    默认标签
+    <span>
+      默认标签
+    </span>
   </span>
 </DocumentFragment>
 `;
@@ -662,7 +706,9 @@ exports[`shape.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -671,7 +717,9 @@ exports[`shape.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--dark t-tag--medium t-tag--square"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
       </div>
@@ -690,7 +738,9 @@ exports[`shape.jsx 1`] = `
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--round"
             style="margin-right: 5px;"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -699,7 +749,9 @@ exports[`shape.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--dark t-tag--medium t-tag--round"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
       </div>
@@ -717,7 +769,9 @@ exports[`shape.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--mark"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
         <div
@@ -726,7 +780,9 @@ exports[`shape.jsx 1`] = `
           <span
             class="t-tag t-tag--primary t-tag--dark t-tag--medium t-tag--mark"
           >
-            标签一
+            <span>
+              标签一
+            </span>
           </span>
         </div>
       </div>
@@ -754,7 +810,9 @@ exports[`size.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--small t-tag--square t-size-s"
           >
-            小型标签
+            <span>
+              小型标签
+            </span>
           </span>
         </div>
         <div
@@ -763,7 +821,9 @@ exports[`size.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
           >
-            默认标签
+            <span>
+              默认标签
+            </span>
           </span>
         </div>
         <div
@@ -772,7 +832,9 @@ exports[`size.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--large t-tag--square t-size-l"
           >
-            大型标签
+            <span>
+              大型标签
+            </span>
           </span>
         </div>
       </div>

--- a/src/tag/__tests__/tag.test.tsx
+++ b/src/tag/__tests__/tag.test.tsx
@@ -12,10 +12,10 @@ describe('Tag 组件测试', () => {
   test('closable and onClose', async () => {
     const tagRegExp = /可删除标签/;
 
-    const { queryAllByText, getByText } = render(<ClosableTag></ClosableTag>);
+    const { queryAllByText, container } = render(<ClosableTag></ClosableTag>);
     // 点击i标签后，关闭一个，3个变2个
     expect(queryAllByText(tagRegExp).length).toEqual(3);
-    fireEvent.click(getByText('可删除标签0').querySelector('.t-icon-close'));
+    fireEvent.click(container.querySelector('.t-tag').querySelector('.t-icon-close'));
     expect(queryAllByText(tagRegExp).length).toEqual(2);
   });
 

--- a/src/tree-select/__tests__/__snapshots__/tree-select.test.tsx.snap
+++ b/src/tree-select/__tests__/__snapshots__/tree-select.test.tsx.snap
@@ -73,7 +73,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                广州市
+                <span>
+                  广州市
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -91,7 +93,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                +1
+                <span>
+                  +1
+                </span>
               </span>
             </div>
             <input
@@ -145,7 +149,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                广州市
+                <span>
+                  广州市
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -163,7 +169,9 @@ exports[`collapsed.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                更多...
+                <span>
+                  更多...
+                </span>
               </span>
             </div>
             <input
@@ -424,7 +432,9 @@ exports[`multiple.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
           >
-            广州市
+            <span>
+              广州市
+            </span>
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -442,7 +452,9 @@ exports[`multiple.jsx 1`] = `
           <span
             class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
           >
-            深圳市
+            <span>
+              深圳市
+            </span>
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -674,7 +686,9 @@ exports[`valuedisplay.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                广州市(guangzhou)
+                <span>
+                  广州市(guangzhou)
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -692,7 +706,9 @@ exports[`valuedisplay.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                深圳市(shenzhen)
+                <span>
+                  深圳市(shenzhen)
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -815,7 +831,9 @@ exports[`valuetype.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                广州市
+                <span>
+                  广州市
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"
@@ -833,7 +851,9 @@ exports[`valuetype.jsx 1`] = `
               <span
                 class="t-tag t-tag--default t-tag--dark t-tag--medium t-tag--square"
               >
-                深圳市
+                <span>
+                  深圳市
+                </span>
                 <svg
                   class="t-icon t-icon-close t-tag__icon-close"
                   fill="none"


### PR DESCRIPTION
…y展示的居中问题

fix #1463

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#1463](https://github.com/Tencent/tdesign-react/issues/1463)

### 💡 需求背景和解决方案
tag组件的children使用了display: inline-flex属性，在selectinput中使用valueDisplay 自定义筛选项存在居中展示错误。而直接使用tag属性则正常。
排查发现由于使用tag属性时，在外层包裹了span标签，保证了display: inline-flex展示不受影响。而且tag组件的源码中也有
```
{maxWidth ? <span className={`${tagClassPrefix}--text`}>{children || content}</span> : children || content}
```
使用span包裹children的写法，因此改为
```
<span className={maxWidth ? `${tagClassPrefix}--text` : undefined}>{children || content}</span>
```
既保证了居中展示稳定，且组件结构一致。
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
