### PR TITLE
fix(select component): 修复Select组件多选情况下，禁用组件后还能点击删除选项

### DIFF
--- a/src/select/base/Select.tsx
+++ b/src/select/base/Select.tsx
@@ -333,6 +333,7 @@ const Select = forwardRefWithStatics(
                 {...tagProps}
                 onClose={({ e }) => {
                   e.stopPropagation();
+                  if (disabled) return;
                   const values = getSelectValueArr(value, value[key], true, valueType, keys);
                   onChange(values, null);
                   tagProps?.onClose?.({ e });


### PR DESCRIPTION
fix #1525

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#1525](https://github.com/Tencent/tdesign-react/issues/1525)

### 💡 需求背景和解决方案

在disable 为true的情况下不应该执行多选组件的选项的close逻辑

### 📝 更新日志

- fix(Select): 支持多选时，禁用组件，已选选项不能被点击删除

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
