### PR TITLE
fix: 修复初次点击内容区域移到 mask 区域后关闭弹窗问题

### DIFF
--- a/src/dialog/RenderDialog.tsx
+++ b/src/dialog/RenderDialog.tsx
@@ -62,6 +62,7 @@ const RenderDialog = forwardRef((props: RenderDialogProps, ref: React.Ref<HTMLDi
   const portalRef = useRef<HTMLDivElement>();
   const bodyOverflow = useRef<string>();
   const bodyCssTextRef = useRef<string>();
+  const contentClickRef = useRef(false);
   const isModal = mode === 'modal';
   const isNormal = mode === 'normal';
   const canDraggable = props.draggable && mode === 'modeless';
@@ -152,7 +153,10 @@ const RenderDialog = forwardRef((props: RenderDialogProps, ref: React.Ref<HTMLDi
 
   const onMaskClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (showOverlay && (closeOnOverlayClick ?? local.closeOnOverlayClick)) {
-      if (e.target === dialogPosition.current) {
+      // 判断点击事件初次点击是否为内容区域
+      if (contentClickRef.current) {
+        contentClickRef.current = false;
+      } else if (e.target === dialogPosition.current) {
         onOverlayClick({ e });
         onClose({ e, trigger: 'overlay' });
       }
@@ -231,6 +235,7 @@ const RenderDialog = forwardRef((props: RenderDialogProps, ref: React.Ref<HTMLDi
     };
 
     const onDialogMoveStart = (e: React.MouseEvent<HTMLDivElement>) => {
+      contentClickRef.current = true;
       // 阻止事件冒泡
       if (canDraggable && e.currentTarget === e.target) {
         const { offsetLeft, offsetTop, offsetHeight, offsetWidth } = dialog.current;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复初次点击内容区域移到 mask 区域后关闭弹窗问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
