### PR TITLE
fix(table): 当禁用resizable时，基础表格表头默认使用用户定义的列宽

### DIFF
--- a/src/table/BaseTable.tsx
+++ b/src/table/BaseTable.tsx
@@ -202,10 +202,14 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
   }
 
   const defaultColWidth = props.tableLayout === 'fixed' && isWidthOverflow ? '100px' : undefined;
-  const colgroup = (
+  const renderColGroup = (isFixedHeader = true) => (
     <colgroup>
       {finalColumns.map((col) => {
-        const style: Styles = { width: formatCSSUnit(thWidthList.current[col.colKey] || col.width) || defaultColWidth };
+        const style: Styles = {
+          width:
+            formatCSSUnit((isFixedHeader || resizable ? thWidthList.current[col.colKey] : undefined) || col.width) ||
+            defaultColWidth,
+        };
         if (col.minWidth) {
           style.minWidth = formatCSSUnit(col.minWidth);
         }
@@ -213,7 +217,6 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
       })}
     </colgroup>
   );
-
   const headProps = {
     isFixedHeader,
     rowAndColFixedPosition,
@@ -262,7 +265,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
           className={classNames(tableElmClasses)}
           style={{ ...tableElementStyles, width: `${tableElmWidth.current}px` }}
         >
-          {colgroup}
+          {renderColGroup(true)}
           {props.showHeader && <THead {...headProps} />}
         </table>
       </div>
@@ -322,7 +325,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
           ])}
         >
           <table className={tableElmClasses} style={{ ...tableElementStyles, width: `${tableElmWidth.current}px` }}>
-            {colgroup}
+            {renderColGroup(true)}
             <TFoot
               rowKey={props.rowKey}
               isFixedHeader={isFixedHeader}
@@ -384,8 +387,8 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
     >
       {isVirtual && <div className={virtualScrollClasses.cursor} style={virtualStyle} />}
       <table ref={tableElmRef} className={classNames(tableElmClasses)} style={tableElementStyles}>
-        {colgroup}
-        {props.showHeader && <THead {...headProps} />}
+        {renderColGroup(false)}
+        {props.showHeader && <THead {...{ ...headProps, thWidthList: resizable ? thWidthList.current : {} }} />}
         <TBody {...tableBodyProps} />
         <TFoot
           rowKey={props.rowKey}


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/1934

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 表格在resizable=false是，基础表格的表头读取用户设置进来的默认宽度

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 当禁用resizable时，基础表格表头默认使用用户定义的列宽

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
