### PR TITLE
fix(input): autowidth

### DIFF
--- a/src/pagination/Pagination.tsx
+++ b/src/pagination/Pagination.tsx
@@ -46,6 +46,7 @@ const Pagination = forwardRef((props: PaginationProps, ref: React.Ref<HTMLDivEle
     onPageSizeChange,
     style,
     className,
+    selectProps,
     ...otherProps
   } = props;
   // 原生 html 属性透传
@@ -151,7 +152,7 @@ const Pagination = forwardRef((props: PaginationProps, ref: React.Ref<HTMLDivEle
           value={pageSize}
           disabled={disabled}
           onChange={changePageSize}
-          {...props.selectProps}
+          {...selectProps}
         >
           {pageSizeOptions.map((item) =>
             typeof item === 'number' ? (

--- a/src/table/TR.tsx
+++ b/src/table/TR.tsx
@@ -10,6 +10,7 @@ import TEllipsis from './Ellipsis';
 import { BaseTableCellParams, TableRowData, RowspanColspan, TdBaseTableProps, TableScroll } from './type';
 import useLazyLoad from './hooks/useLazyLoad';
 import { getCellKey, SkipSpansValue } from './hooks/useRowspanAndColspan';
+import { TooltipProps } from '../tooltip';
 
 export interface RenderTdExtra {
   rowAndColFixedPosition: RowAndColFixedPosition;
@@ -143,7 +144,7 @@ export default function TR(props: TrProps) {
 
   function renderEllipsisCell(cellParams: BaseTableCellParams<TableRowData>, params: RenderEllipsisCellParams) {
     const { cellNode } = params;
-    const { col } = cellParams;
+    const { col, colIndex } = cellParams;
     let content = isFunction(col.ellipsis) ? col.ellipsis(cellParams) : undefined;
     if (typeof col.ellipsis === 'object' && isFunction(col.ellipsis.content)) {
       content = col.ellipsis.content(cellParams);
@@ -153,9 +154,11 @@ export default function TR(props: TrProps) {
       tooltipProps = 'props' in col.ellipsis ? col.ellipsis.props : col.ellipsis || undefined;
     }
     const tableElement = props.tableElm;
+    let placement: TooltipProps['placement'] = colIndex === 0 ? 'top-left' : 'top';
+    placement = colIndex === props.columns.length - 1 ? 'top-right' : placement;
     return (
       <TEllipsis
-        placement={'top'}
+        placement={placement}
         attach={tableElement ? () => tableElement : undefined}
         popupContent={content}
         tooltipProps={tooltipProps}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复在输入框进行预渲染处于 `display: none` 状态时，宽度计算不正确问题，[tdesign-vue#1678](https://github.com/Tencent/tdesign-vue/issues/1678)
- fix(Pagination): 修复 `selectProps` warn

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
