### PR TITLE
fix(tree-select): 修复 valueDisplay 和 filterable 同时设置时的显示问题

### DIFF
--- a/src/tree-select/TreeSelect.tsx
+++ b/src/tree-select/TreeSelect.tsx
@@ -92,13 +92,36 @@ const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivEle
     return filterable && popupVisible ? filterInput : normalizedValue[0] || '';
   }, [multiple, normalizedValue, filterable, popupVisible, filterInput]);
 
+  const normalizedValueDisplay = useMemo(() => {
+    if (!valueDisplay) {
+      return;
+    }
+    if (typeof valueDisplay === 'string') return valueDisplay;
+    if (multiple) return ({ onClose }) => valueDisplay({ value: normalizedValue, onClose });
+    return normalizedValue.length ? (valueDisplay({ value: normalizedValue[0], onClose: noop }) as string) : '';
+  }, [valueDisplay, multiple, normalizedValue]);
+
+  const internalInputValueDisplay = useMemo(() => {
+    // 只有单选且下拉展开时需要隐藏 valueDisplay
+    if (filterable && !multiple && popupVisible) {
+      return undefined;
+    }
+    return normalizedValueDisplay;
+  }, [filterable, popupVisible, multiple, normalizedValueDisplay]);
+
   const inputPlaceholder = useMemo(() => {
     // 可筛选、单选、弹框且有值时提示当前值
     if (filterable && !multiple && popupVisible && normalizedValue.length) {
+      // 设置了 valueDisplay 时，优先展示 valueDisplay
+      const valueDisplayPlaceholder = normalizedValueDisplay;
+      if (typeof valueDisplayPlaceholder === 'string') {
+        return valueDisplayPlaceholder;
+      }
+
       return typeof normalizedValue[0].label === 'string' ? normalizedValue[0].label : String(normalizedValue[0].value);
     }
     return placeholder;
-  }, [filterable, multiple, popupVisible, normalizedValue, placeholder]);
+  }, [filterable, multiple, popupVisible, normalizedValue, placeholder, normalizedValueDisplay]);
 
   const showLoading = !disabled && loading;
 
@@ -244,12 +267,6 @@ const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivEle
       prefixIcon
     );
 
-  const normalizedValueDisplay = () => {
-    if (typeof valueDisplay === 'string') return valueDisplay;
-    if (multiple) return ({ onClose }) => valueDisplay({ value: normalizedValue, onClose });
-    return normalizedValue.length ? (valueDisplay({ value: normalizedValue[0], onClose: noop }) as string) : '';
-  };
-
   return (
     <SelectInput
       status={props.status}
@@ -288,7 +305,7 @@ const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivEle
       }
       collapsedItems={renderCollapsedItems}
       label={renderLabel()}
-      valueDisplay={valueDisplay && normalizedValueDisplay()}
+      valueDisplay={internalInputValueDisplay}
     />
   );
 });


### PR DESCRIPTION
fix #1668

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-react/issues/1668

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
#### 背景
当 `valueDisplay` 和 `filterable` 同时开启时（单选模式下），输入框的值没有清空，且输入的值无法感知。

#### 解决方案
开启 `filterable` 和 `valueDisplay` 时，如果处于选择（输入状态）则不传 `valueDisplay`。
```
  const internalInputValueDisplay = useMemo(() => {
    // 只有单选且下拉展开时需要隐藏 valueDisplay
    if (filterable && popupVisible) {
      return undefined;
    }
    return normalizedValueDisplay;
  }, [filterable, popupVisible, normalizedValueDisplay]);
```
且 `placeholder` 优先展示 `valueDisplay` 内容。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select): 修复 valueDisplay 和 filterable 同时设置时的显示问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
