### PR TITLE
feat(tree-select): 暴露 treeRef 的方法

### DIFF
--- a/src/tree-select/TreeSelect.tsx
+++ b/src/tree-select/TreeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, forwardRef, ElementRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, forwardRef, ElementRef, useEffect, useImperativeHandle } from 'react';
 
 import classNames from 'classnames';
 import type { TdTreeSelectProps, TreeSelectValue } from './type';
@@ -28,7 +28,7 @@ export interface NodeOptions {
 const useMergeFn = <T extends any[]>(...fns: Array<(...args: T) => void>) =>
   usePersistFn((...args: T) => fns.forEach((fn) => fn?.(...args)));
 
-const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivElement>) => {
+const TreeSelect = forwardRef((props: TreeSelectProps, ref) => {
   /* ---------------------------------config---------------------------------------- */
 
   // 国际化文本初始化
@@ -68,8 +68,14 @@ const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivEle
   const [filterInput, setFilterInput] = useControlled(props, 'inputValue', onInputChange);
 
   const treeRef = useRef<ElementRef<typeof Tree>>();
+  const selectInputRef = useRef();
 
   const { normalizeValue, formatValue, getNodeItem } = useTreeSelectUtils(props, treeRef);
+
+  useImperativeHandle(ref, () => ({
+    ...(selectInputRef.current || {}),
+    ...(treeRef.current || {}),
+  }));
 
   /* ---------------------------------computed value---------------------------------------- */
 
@@ -273,7 +279,7 @@ const TreeSelect = forwardRef((props: TreeSelectProps, ref: React.Ref<HTMLDivEle
       tips={props.tips}
       {...props.selectInputProps}
       {...selectInputProps}
-      ref={ref}
+      ref={selectInputRef}
       className={classNames(
         `${classPrefix}-tree-select`,
         {


### PR DESCRIPTION
fix #1695

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-react/issues/1695

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
支持配合自定义字段和 `TreeInstanceFunctions.getItem` 方法，解决重复节点问题。
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(tree-select): 暴露 treeRef 的方法

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
