### PR TITLE
fix: popconfirm describe text color

### DIFF
--- a/src/popconfirm/_example/describe.jsx
+++ b/src/popconfirm/_example/describe.jsx
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button, Popconfirm, Space } from 'tdesign-react';
 
+const classStyles = `
+<style>
+.title {
+  font-weight: 500;
+  font-size: 14px;
+}
+.describe {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--td-text-color-secondary);
+}
+</style>
+`;
 export default function ContentExample() {
+  useEffect(() => {
+    // 添加示例代码所需样式
+    document.head.insertAdjacentHTML('beforeend', classStyles);
+  }, []);
   const content = (
     <>
-      <p style={{ fontWeight: 500, fontSize: 14 }}>带描述的气泡确认框文字按钮</p>
-      <p style={{ marginTop: 8, fontSize: 12 }}>带描述的气泡确认框在主要说明之外增加了操作相关的详细描述</p>
+      <p className="title">带描述的气泡确认框文字按钮</p>
+      <p className="describe">带描述的气泡确认框在主要说明之外增加了操作相关的详细描述</p>
     </>
   );
   return (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[#251](https://github.com/Tencent/tdesign/issues/251)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
问题：官网上，带有描述文案的demo气泡框里描述字体的颜色不对
<img width="484" alt="image" src="https://user-images.githubusercontent.com/49859520/201527465-a99da5cd-174d-4152-b6af-39efd55975e6.png">

解决方案和效果：
<img width="415" alt="image" src="https://user-images.githubusercontent.com/49859520/201527551-736ca7f5-c66c-4c90-9ac7-1d4632716437.png">
<img width="310" alt="image" src="https://user-images.githubusercontent.com/49859520/201527558-c59423db-5a8a-4318-8bf4-41a604464c89.png">



<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popconfirm): 修复官网demo气泡框描述文案字体颜色

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
