### PR TITLE
[Table] Some features and bugs

### DIFF
--- a/src/table/Cell.tsx
+++ b/src/table/Cell.tsx
@@ -9,6 +9,7 @@ import { getColumnFixedStyles } from './hooks/useFixed';
 import { TableClassName } from './hooks/useClassName';
 import { formatClassNames } from './utils';
 import { TooltipProps } from '../tooltip';
+import { PaginationProps } from '../pagination';
 
 export interface RenderEllipsisCellParams {
   cellNode: any;
@@ -29,6 +30,7 @@ export interface CellProps {
   tableElm?: HTMLDivElement;
   classPrefix?: string;
   overlayClassName?: string;
+  pagination?: PaginationProps;
   rowspanAndColspan: TdBaseTableProps['rowspanAndColspan'];
   onClick?: (e: MouseEvent<HTMLTableCellElement>) => void;
 }
@@ -37,11 +39,18 @@ export function renderCell(
   params: BaseTableCellParams<TableRowData>,
   extra?: {
     cellEmptyContent?: TdBaseTableProps['cellEmptyContent'];
+    pagination?: PaginationProps;
   },
 ) {
   const { col, row, rowIndex } = params;
   // support serial number column
   if (col.colKey === 'serial-number') {
+    const { current, pageSize, defaultCurrent, defaultPageSize } = extra?.pagination || {};
+    const tCurrent = current || defaultCurrent;
+    const tPageSize = pageSize || defaultPageSize;
+    if (tPageSize && tCurrent) {
+      return tPageSize * (tCurrent - 1) + rowIndex + 1;
+    }
     return rowIndex + 1;
   }
   if (isFunction(col.cell)) {
@@ -86,13 +95,13 @@ function renderEllipsisCell(cellParams: BaseTableCellParams<TableRowData>, param
 }
 
 const Cell = (props: CellProps) => {
-  const { cellParams, tableClassNames, tableElm, columnLength, classPrefix, overlayClassName } = props;
+  const { cellParams, tableClassNames, tableElm, columnLength, classPrefix, overlayClassName, pagination } = props;
   const { col, colIndex, rowIndex } = cellParams;
   const { cellSpans, dataLength, rowAndColFixedPosition, cellEmptyContent, rowspanAndColspan, onClick } = props;
   const { tableColFixedClasses, tdEllipsisClass, tableBaseClass, tdAlignClasses, tableDraggableClasses } =
     tableClassNames;
 
-  const cellNode = renderCell(cellParams, { cellEmptyContent });
+  const cellNode = renderCell(cellParams, { cellEmptyContent, pagination });
   const tdStyles = getColumnFixedStyles(col, colIndex, rowAndColFixedPosition, tableColFixedClasses);
   const customClasses = formatClassNames(col.className, { ...cellParams, type: 'td' });
   const classes = [

--- a/src/table/PrimaryTable.tsx
+++ b/src/table/PrimaryTable.tsx
@@ -37,7 +37,10 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((props, ref
   // 排序功能
   const { renderSortIcon } = useSorter(props);
   // 行选中功能
-  const { formatToRowSelectColumn, selectedRowClassNames } = useRowSelect(props, tableSelectedClasses);
+  const { selectedRowClassNames, setCurrentPaginateData, formatToRowSelectColumn, setTSelectedRowKeys } = useRowSelect(
+    props,
+    tableSelectedClasses,
+  );
   // 过滤功能
   const { hasEmptyCondition, isTableOverflowHidden, renderFilterIcon, renderFirstFilterRow } = useFilter(
     props,
@@ -166,12 +169,21 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((props, ref
   })();
 
   const onInnerPageChange = (pageInfo: PageInfo, newData: Array<TableRowData>) => {
+    setCurrentPaginateData(newData);
     props.onPageChange?.(pageInfo, newData);
     const changeParams: Parameters<TdPrimaryTableProps['onChange']> = [
       { pagination: pageInfo },
       { trigger: 'pagination', currentData: newData },
     ];
     props.onChange?.(...changeParams);
+    // 是否在分页时保留选中结果，如果不保留则需清空
+    if (!props.reserveSelectedRowOnPaginate) {
+      setTSelectedRowKeys([], {
+        selectedRowData: [],
+        type: 'uncheck',
+        currentRowKey: 'CLEAR_ON_PAGINATE',
+      });
+    }
   };
 
   function formatNode(api: string, renderInnerNode: Function, condition: boolean, extra?: { reverse?: boolean }) {

--- a/src/table/TBody.tsx
+++ b/src/table/TBody.tsx
@@ -9,6 +9,7 @@ import useClassName from './hooks/useClassName';
 import useRowspanAndColspan from './hooks/useRowspanAndColspan';
 import { BaseTableProps, RowAndColFixedPosition } from './interface';
 import { TdBaseTableProps } from './type';
+import { PaginationProps } from '../pagination';
 
 export const ROW_AND_TD_LISTENERS = ROW_LISTENERS.concat('cell-click');
 export interface TableBodyProps extends BaseTableProps {
@@ -22,6 +23,7 @@ export interface TableBodyProps extends BaseTableProps {
   cellEmptyContent: TdBaseTableProps['cellEmptyContent'];
   tableWidth?: number;
   isWidthOverflow?: boolean;
+  pagination?: PaginationProps;
 
   // 以下内容为虚拟滚动所需参数
   translateY?: number;
@@ -137,6 +139,7 @@ export default function TBody(props: TableBodyProps) {
       classPrefix: props.classPrefix,
       ellipsisOverlayClassName: props.ellipsisOverlayClassName,
       ...pick(props, properties),
+      pagination: props.pagination,
     };
     if (props.onCellClick) {
       trProps.onCellClick = props.onCellClick;

--- a/src/table/TR.tsx
+++ b/src/table/TR.tsx
@@ -9,6 +9,7 @@ import { TableRowData, RowspanColspan, TdBaseTableProps, TableScroll } from './t
 import useLazyLoad from './hooks/useLazyLoad';
 import { getCellKey, SkipSpansValue } from './hooks/useRowspanAndColspan';
 import Cell from './Cell';
+import { PaginationProps } from '../pagination';
 
 export type TrCommonProps = Pick<TdBaseTableProps, TrPropsKeys>;
 
@@ -51,6 +52,7 @@ export interface TrProps extends TrCommonProps {
   scroll?: TableScroll;
   tableElm?: HTMLDivElement;
   tableContentElm?: HTMLDivElement;
+  pagination?: PaginationProps;
   onRowMounted?: () => void;
 }
 
@@ -135,6 +137,7 @@ export default function TR(props: TrProps) {
         tableElm={props.tableElm}
         classPrefix={props.classPrefix}
         overlayClassName={props.ellipsisOverlayClassName}
+        pagination={props.pagination}
       />
     );
   });

--- a/src/table/_example/pagination-ajax.jsx
+++ b/src/table/_example/pagination-ajax.jsx
@@ -8,6 +8,11 @@ const columns = [
     width: 64,
   },
   {
+    colKey: 'serial-number',
+    title: '序号',
+    width: 60,
+  },
+  {
     width: 200,
     colKey: 'name',
     title: '姓名',
@@ -105,6 +110,7 @@ export default function TableBasic() {
       }}
       selectedRowKeys={selectedRowKeys}
       onSelectChange={onSelectChange}
+      // reserveSelectedRowOnPaginate={false}
     />
   );
 }

--- a/src/table/_example/pagination.jsx
+++ b/src/table/_example/pagination.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Table } from 'tdesign-react';
+import React, { useState } from 'react';
+import { Table, Space, Radio } from 'tdesign-react';
 
 const data = [];
 const total = 60;
@@ -48,57 +48,79 @@ const columns = [
     width: 200,
     ellipsis: true,
   },
+  {
+    colKey: 'row-select',
+    type: 'multiple',
+    width: 46,
+  },
 ];
 
 export default function TableBasic() {
-  // const [current, setCurrent] = useState(1);
-  // const [pageSize, setPageSize] = useState(10);
+  const [reserveSelectedRowOnPaginate, setReserveSelectedRowOnPaginate] = useState(true);
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
 
   return (
-    <Table
-      id='pagination-table'
-      data={data}
-      columns={columns}
-      rowKey="index"
-      // 非受控写法
-      pagination={{
-        defaultCurrent: 2,
-        defaultPageSize: 5,
-        total,
-        showJumper: true,
-        onChange(pageInfo) {
-          console.log(pageInfo, 'onChange pageInfo');
-        },
-        onCurrentChange(current, pageInfo) {
-          console.log(current, 'onCurrentChange current');
-          console.log(pageInfo, 'onCurrentChange pageInfo');
-        },
-        onPageSizeChange(size, pageInfo) {
-          console.log(size, 'onPageSizeChange size');
-          console.log(pageInfo, 'onPageSizeChange pageInfo');
-        },
-        selectProps: {
-          popupProps: {
-            attach: () => document.getElementById('pagination-table'),
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Radio.Group
+        variant="default-filled"
+        value={reserveSelectedRowOnPaginate}
+        onChange={setReserveSelectedRowOnPaginate}
+      >
+        <Radio.Button value={true}>跨分页选中</Radio.Button>
+        <Radio.Button value={false}>当前页选中</Radio.Button>
+      </Radio.Group>
+
+      <Table
+        id='pagination-table'
+        data={data}
+        columns={columns}
+        rowKey="index"
+        // 非受控写法
+        pagination={{
+          defaultCurrent: 2,
+          defaultPageSize: 5,
+          total,
+          showJumper: true,
+          onChange(pageInfo) {
+            console.log(pageInfo, 'onChange pageInfo');
           },
-        },
-      }}
-      // 受控用法：与分页组件对齐
-      // pagination={{
-      //   current,
-      //   pageSize,
-      //   showJumper: true,
-      //   total,
-      //   onChange(pageInfo) {
-      //     console.log(pageInfo, 'onChange pageInfo');
-      //     setCurrent(pageInfo.current);
-      //     setPageSize(pageInfo.pageSize);
-      //   },
-      // }}
-      onPageChange={(pageInfo, newDataSource) => {
-        console.log(pageInfo, 'onPageChange pageInfo');
-        console.log(newDataSource, 'onPageChange newDataSource');
-      }}
-    />
+          onCurrentChange(current, pageInfo) {
+            console.log(current, 'onCurrentChange current');
+            console.log(pageInfo, 'onCurrentChange pageInfo');
+          },
+          onPageSizeChange(size, pageInfo) {
+            console.log(size, 'onPageSizeChange size');
+            console.log(pageInfo, 'onPageSizeChange pageInfo');
+          },
+          selectProps: {
+            popupProps: {
+              attach: () => document.getElementById('pagination-table'),
+            },
+          },
+        }}
+        // 受控用法：与分页组件对齐
+        // pagination={{
+        //   current,
+        //   pageSize,
+        //   showJumper: true,
+        //   total,
+        //   onChange(pageInfo) {
+        //     console.log(pageInfo, 'onChange pageInfo');
+        //     setCurrent(pageInfo.current);
+        //     setPageSize(pageInfo.pageSize);
+        //   },
+        // }}
+        onPageChange={(pageInfo, newDataSource) => {
+          console.log(pageInfo, 'onPageChange pageInfo');
+          console.log(newDataSource, 'onPageChange newDataSource');
+        }}
+        selectedRowKeys={selectedRowKeys}
+        onSelectChange={(val, context) => {
+          setSelectedRowKeys(val);
+          console.log(val, context);
+        }}
+        reserveSelectedRowOnPaginate={reserveSelectedRowOnPaginate}
+      />
+    </Space>
   );
 }

--- a/src/table/_example/single-sort.jsx
+++ b/src/table/_example/single-sort.jsx
@@ -29,8 +29,7 @@ const columns = [
     sortType: 'all',
     sorter: true,
     // 自定义列，或单元格类名
-    className: (params) => {
-      console.log(params);
+    className: () => {
       return 'status-class-bg';
     },
   },

--- a/src/table/_example/style.jsx
+++ b/src/table/_example/style.jsx
@@ -86,7 +86,7 @@ export default function TableStyle() {
   ];
   
   const getRowClassName = ({ row, rowIndex }) => {
-   console.log(row, rowIndex);
+  //  console.log(row, rowIndex);
    if (rowIndex === 2) return 'custom-third-class-name';
    return '';
   };

--- a/src/table/defaultProps.ts
+++ b/src/table/defaultProps.ts
@@ -31,6 +31,7 @@ export const primaryTableDefaultProps: Pick<
   | 'expandIcon'
   | 'defaultExpandedRowKeys'
   | 'multipleSort'
+  | 'reserveSelectedRowOnPaginate'
   | 'defaultSelectedRowKeys'
   | 'showSortColumnBgColor'
   | 'sortOnRowDraggable'
@@ -40,6 +41,7 @@ export const primaryTableDefaultProps: Pick<
   expandIcon: true,
   defaultExpandedRowKeys: [],
   multipleSort: false,
+  reserveSelectedRowOnPaginate: true,
   defaultSelectedRowKeys: [],
   showSortColumnBgColor: false,
   sortOnRowDraggable: false,

--- a/src/table/hooks/usePagination.tsx
+++ b/src/table/hooks/usePagination.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import useConfig from '../../hooks/useConfig';
-import Pagination, { PageInfo } from '../../pagination';
+import Pagination, { PageInfo, PaginationProps } from '../../pagination';
 import { TdBaseTableProps, TableRowData } from '../type';
 
 // 分页功能包含：远程数据排序受控、远程数据排序非受控、本地数据排序受控、本地数据排序非受控 等 4 类功能
 export default function usePagination(props: TdBaseTableProps) {
   const { pagination, data, disableDataPage } = props;
   const { classPrefix } = useConfig();
+  const [innerPagination, setInnerPagination] = useState<PaginationProps>(props.pagination);
 
   const [dataSource, setDataSource] = useState<TableRowData[]>([]);
   const [isPaginateData, setIsPaginateData] = useState(false);
@@ -16,13 +17,16 @@ export default function usePagination(props: TdBaseTableProps) {
       // data 数据数量超出分页大小时，则自动启动本地数据分页
       const isPaginateData = Boolean(!disableDataPage && data.length > pageSize);
       setIsPaginateData(isPaginateData);
+      let newData: TableRowData[] = [];
       if (isPaginateData) {
         const start = (current - 1) * pageSize;
         const end = current * pageSize;
-        setDataSource([...data.slice(start, end)]);
+        newData = [...data.slice(start, end)];
       } else {
-        setDataSource(data);
+        newData = data;
       }
+      setDataSource(newData);
+      return newData;
     },
     [data, disableDataPage],
   );
@@ -48,11 +52,14 @@ export default function usePagination(props: TdBaseTableProps) {
           {...pagination}
           onChange={(pageInfo: PageInfo) => {
             props.pagination?.onChange?.(pageInfo);
-            props.onPageChange?.(pageInfo, dataSource);
+            setInnerPagination(pageInfo);
+            let newData = dataSource;
             // 如果是非受控情况的分页变化，还需更新分页数据（data）
             if (pagination && !pagination.current && pagination.defaultCurrent) {
-              updateDataSourceAndPaginate(pageInfo.current, pageInfo.pageSize);
+              newData = updateDataSourceAndPaginate(pageInfo.current, pageInfo.pageSize);
             }
+            // TODO: dataSource
+            props.onPageChange?.(pageInfo, newData);
           }}
         />
       </div>
@@ -62,6 +69,7 @@ export default function usePagination(props: TdBaseTableProps) {
   return {
     isPaginateData,
     dataSource,
+    innerPagination,
     renderPagination,
   };
 }

--- a/src/table/table.en-US.md
+++ b/src/table/table.en-US.md
@@ -27,7 +27,7 @@ horizontalScrollAffixedBottom | Boolean / Object | - | affix props。Typescript�
 hover | Boolean | false | show hover style | N
 lastFullRow | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 loading | TNode | undefined | loading state table。Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
-loadingProps | Object | - | Typescript：`LoadingProps`，[Loading API Documents](./loading?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
+loadingProps | Object | - | Typescript：`Partial<LoadingProps>`，[Loading API Documents](./loading?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
 maxHeight | String / Number | - | table max height | N
 pagination | Object | - | you can use all props of pagination component with paginationProps。Typescript：`PaginationProps`，[Pagination API Documents](./pagination?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
 paginationAffixedBottom | Boolean / Object | - | affix props。Typescript：`boolean \| Partial<AffixProps>` | N
@@ -109,6 +109,7 @@ defaultFilterValue | Object | - | filter value。uncontrolled property。Typescr
 hideSortTips | Boolean | - | hide sort tips | N
 indeterminateSelectedRowKeys | Array | - | indeterminate selected row keys, row key is from data[rowKey]。Typescript：`Array<string \| number>` | N
 multipleSort | Boolean | false | support multiple column fields sort | N
+reserveSelectedRowOnPaginate | Boolean | true | \- | N
 selectedRowKeys | Array | [] | selected row keys, row key is from data[rowKey]。Typescript：`Array<string \| number>` | N
 defaultSelectedRowKeys | Array | [] | selected row keys, row key is from data[rowKey]。uncontrolled property。Typescript：`Array<string \| number>` | N
 showSortColumnBgColor | Boolean | false | column shows sort bg color | N

--- a/src/table/table.md
+++ b/src/table/table.md
@@ -27,7 +27,7 @@ horizontalScrollAffixedBottom | Boolean / Object | - | 滚动条吸底。基于 
 hover | Boolean | false | 是否显示鼠标悬浮状态 | N
 lastFullRow | TNode | - | 尾行内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 loading | TNode | undefined | 加载中状态。值为 `true` 会显示默认加载中样式，可以通过 Function 和 插槽 自定义加载状态呈现内容和样式。值为 `false` 则会取消加载状态。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
-loadingProps | Object | - | 透传加载组件全部属性。TS 类型：`LoadingProps`，[Loading API Documents](./loading?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
+loadingProps | Object | - | 透传加载组件全部属性。TS 类型：`Partial<LoadingProps>`，[Loading API Documents](./loading?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
 maxHeight | String / Number | - | 表格最大高度，超出后会出现滚动条。示例：100, '30%', '300'。值为数字类型，会自动加上单位 px | N
 pagination | Object | - | 分页配置，值为空则不显示。具体 API 参考分页组件。当 `data` 数据长度超过分页大小时，会自动对本地数据 `data` 进行排序，如果不希望对于 `data` 进行排序，可以设置 `disableDataPage = true`。TS 类型：`PaginationProps`，[Pagination API Documents](./pagination?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/table/type.ts) | N
 paginationAffixedBottom | Boolean / Object | - | 分页吸底。基于 Affix 组件开发，透传全部 Affix 组件属性。TS 类型：`boolean \| Partial<AffixProps>` | N
@@ -109,6 +109,7 @@ defaultFilterValue | Object | - | 过滤数据的值。非受控属性。TS 类�
 hideSortTips | Boolean | - | 隐藏排序文本提示，支持全局配置 `GlobalConfigProvider`，默认全局配置值为 `false` | N
 indeterminateSelectedRowKeys | Array | - | 半选状态行。选中行请更为使用 `selectedRowKeys` 控制。TS 类型：`Array<string \| number>` | N
 multipleSort | Boolean | false | 是否支持多列排序 | N
+reserveSelectedRowOnPaginate | Boolean | true | 行选中功能，是否在分页时保留上一页选中结果不清空，本地数据分页场景下，会全选所有页数据。值为 `false` 则表示全部选中操作停留在当前页，不跨分页；本地数据分页场景下，全选仅选中当前页 | N
 selectedRowKeys | Array | [] | 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制。TS 类型：`Array<string \| number>` | N
 defaultSelectedRowKeys | Array | [] | 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制。非受控属性。TS 类型：`Array<string \| number>` | N
 showSortColumnBgColor | Boolean | false | 当前排序列是否显示背景色 | N

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -115,7 +115,7 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
   /**
    * 透传加载组件全部属性
    */
-  loadingProps?: LoadingProps;
+  loadingProps?: Partial<LoadingProps>;
   /**
    * 表格最大高度，超出后会出现滚动条。示例：100, '30%', '300'。值为数字类型，会自动加上单位 px
    */
@@ -427,6 +427,11 @@ export interface TdPrimaryTableProps<T extends TableRowData = TableRowData>
    * @default false
    */
   multipleSort?: boolean;
+  /**
+   * 行选中功能，是否在分页时保留上一页选中结果不清空，本地数据分页场景下，会全选所有页数据。值为 `false` 则表示全部选中操作停留在当前页，不跨分页；本地数据分页场景下，全选仅选中当前页
+   * @default true
+   */
+  reserveSelectedRowOnPaginate?: boolean;
   /**
    * 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制
    * @default []


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 选中行功能，新增 `reserveSelectedRowOnPaginate`，用于支持在分页场景中，仅选中当前页数据，切换分页时清空选中结果，全选仅选中当前页数据
- fix(Table): 修复本地数据分页场景中，切换分页大小，`onPageChange` 事件参数返回的数据不正确问题
- fix(Table): 序号列支持跨分页显示，[issue#1726](https://github.com/Tencent/tdesign-react/issues/1726)，[tdesign-vue-next#2072](https://github.com/Tencent/tdesign-vue-next/issues/2072)
- fix(Table): 修复分页场景下，设置 max-height 和 bordered 之后，边框线位置不正确 [tdesign-vue-next#2062](https://github.com/Tencent/tdesign-vue-next/issues/2062)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
