### PR TITLE
feat(ColorPicker): add showPrimaryColorPreview API

### DIFF
--- a/src/color-picker/_example/trigger.jsx
+++ b/src/color-picker/_example/trigger.jsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { ColorPicker } from 'tdesign-react';
 
 export default function PanelExample() {
-  return <ColorPicker defaultValue={'#0052d9'} />;
+  return <ColorPicker defaultValue={'#0052d9'} showPrimaryColorPreview={false} />;
 }

--- a/src/color-picker/color-picker.en-US.md
+++ b/src/color-picker/color-picker.en-US.md
@@ -18,6 +18,7 @@ popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./po
 recentColors | Array | [] | used color recently。Typescript：`boolean \| Array<string>` | N
 defaultRecentColors | Array | [] | used color recently。uncontrolled property。Typescript：`boolean \| Array<string>` | N
 selectInputProps | Object | - | Typescript：`SelectInputProps`，[SelectInput API Documents](./select-input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/color-picker/type.ts) | N
+showPrimaryColorPreview | Boolean | true | \- | N
 swatchColors | Array | - | swatch colors。Typescript：`Array<string>` | N
 value | String | - | color value | N
 defaultValue | String | - | color value。uncontrolled property | N

--- a/src/color-picker/color-picker.md
+++ b/src/color-picker/color-picker.md
@@ -18,6 +18,7 @@ popupProps | Object | - | 透传 Popup 组件全部属性，如 `placement` `ove
 recentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。TS 类型：`boolean \| Array<string>` | N
 defaultRecentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。非受控属性。TS 类型：`boolean \| Array<string>` | N
 selectInputProps | Object | - | 透传 SelectInputProps 筛选器输入框组件全部属性。TS 类型：`SelectInputProps`，[SelectInput API Documents](./select-input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/color-picker/type.ts) | N
+showPrimaryColorPreview | Boolean | true | 是否展示颜色选择条右侧的颜色预览区域 | N
 swatchColors | Array | - | 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色。TS 类型：`Array<string>` | N
 value | String | - | 色值 | N
 defaultValue | String | - | 色值。非受控属性 | N

--- a/src/color-picker/components/panel/index.tsx
+++ b/src/color-picker/components/panel/index.tsx
@@ -44,6 +44,7 @@ const Panel = forwardRef((props: ColorPickerProps, ref: MutableRefObject<HTMLDiv
     togglePopup,
     closeBtn,
     colorModes = ['linear-gradient', 'monochrome'],
+    showPrimaryColorPreview = true,
   } = props;
   const [innerValue, setInnerValue] = useControlled(props, 'value', onChange);
   const colorInstanceRef = useRef<Color>(new Color(innerValue || DEFAULT_COLOR));
@@ -319,14 +320,16 @@ const Panel = forwardRef((props: ColorPickerProps, ref: MutableRefObject<HTMLDiv
             <HUESlider {...baseProps} onChange={handleHUEChange} />
             {enableAlpha && <AlphaSlider {...baseProps} onChange={handleAlphaChange} />}
           </div>
-          <div className={classNames([`${baseClassName}__sliders-preview`, `${baseClassName}--bg-alpha`])}>
-            <span
-              className={`${baseClassName}__sliders-preview-inner`}
-              style={{
-                background: isGradient ? colorInstanceRef.current.linearGradient : colorInstanceRef.current.rgba,
-              }}
-            />
-          </div>
+          {showPrimaryColorPreview ? (
+            <div className={classNames([`${baseClassName}__sliders-preview`, `${baseClassName}--bg-alpha`])}>
+              <span
+                className={`${baseClassName}__sliders-preview-inner`}
+                style={{
+                  background: isGradient ? colorInstanceRef.current.linearGradient : colorInstanceRef.current.rgba,
+                }}
+              />
+            </div>
+          ) : null}
         </div>
 
         <FormatPanel

--- a/src/color-picker/defaultProps.ts
+++ b/src/color-picker/defaultProps.ts
@@ -11,4 +11,5 @@ export const colorPickerDefaultProps: TdColorPickerProps = {
   format: 'RGB',
   multiple: false,
   defaultRecentColors: [],
+  showPrimaryColorPreview: true,
 };

--- a/src/color-picker/type.ts
+++ b/src/color-picker/type.ts
@@ -62,6 +62,11 @@ export interface TdColorPickerProps {
    */
   selectInputProps?: SelectInputProps;
   /**
+   * 是否展示颜色选择条右侧的颜色预览区域
+   * @default true
+   */
+  showPrimaryColorPreview?: boolean;
+  /**
    * 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色
    */
   swatchColors?: Array<string>;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ColorPicker): 新增`showPrimaryColorPreview` API 控制色彩选择条右侧主色区块的展示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
