### PR TITLE
feat(table): some features

### DIFF
--- a/src/table/FilterController.tsx
+++ b/src/table/FilterController.tsx
@@ -1,10 +1,8 @@
 import React, { useState, useRef, ReactNode } from 'react';
 import { FilterIcon as TdFilterIcon } from 'tdesign-icons-react';
-
 import isEmpty from 'lodash/isEmpty';
 import classNames from 'classnames';
-
-import Popup from '../popup';
+import Popup, { PopupProps } from '../popup';
 import Checkbox from '../checkbox';
 import Radio from '../radio';
 import Input from '../input';
@@ -34,6 +32,7 @@ export interface TableFilterControllerProps {
   isFocusClass: string;
   column: PrimaryTableCol;
   primaryTableElement: HTMLElement;
+  popupProps: PopupProps;
   onVisibleChange: (val: boolean) => void;
   onReset: (column: PrimaryTableCol<TableRowData>) => void;
   onConfirm: (column: PrimaryTableCol<TableRowData>) => void;
@@ -142,6 +141,7 @@ export default function TableFilterController(props: TableFilterControllerProps)
             {getBottomButtons(column)}
           </div>
         }
+        {...props.popupProps}
       >
         <div ref={triggerElementRef}>{props.filterIcon || defaultFilterIcon}</div>
       </Popup>

--- a/src/table/PrimaryTable.tsx
+++ b/src/table/PrimaryTable.tsx
@@ -37,10 +37,13 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((props, ref
   // 排序功能
   const { renderSortIcon } = useSorter(props);
   // 行选中功能
-  const { selectedRowClassNames, setCurrentPaginateData, formatToRowSelectColumn, setTSelectedRowKeys } = useRowSelect(
-    props,
-    tableSelectedClasses,
-  );
+  const {
+    selectedRowClassNames,
+    setCurrentPaginateData,
+    formatToRowSelectColumn,
+    setTSelectedRowKeys,
+    onInnerSelectRowClick,
+  } = useRowSelect(props, tableSelectedClasses);
   // 过滤功能
   const { hasEmptyCondition, isTableOverflowHidden, renderFilterIcon, renderFirstFilterRow } = useFilter(
     props,
@@ -186,6 +189,11 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((props, ref
     }
   };
 
+  const onInnerRowClick: TdPrimaryTableProps['onRowClick'] = (context) => {
+    onInnerExpandRowClick(context);
+    onInnerSelectRowClick(context);
+  };
+
   function formatNode(api: string, renderInnerNode: Function, condition: boolean, extra?: { reverse?: boolean }) {
     if (!condition) return props[api];
     const innerNode = renderInnerNode();
@@ -232,8 +240,8 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((props, ref
     renderExpandedRow: showExpandedRow ? renderExpandedRow : undefined,
   } as BaseTableProps;
 
-  if (props.expandOnRowClick) {
-    baseTableProps.onRowClick = onInnerExpandRowClick;
+  if (props.expandOnRowClick || props.selectOnRowClick) {
+    baseTableProps.onRowClick = onInnerRowClick;
   }
 
   return (

--- a/src/table/_example/data-sort.jsx
+++ b/src/table/_example/data-sort.jsx
@@ -58,13 +58,19 @@ for (let i = 0; i < 5; i++) {
 
 export default function TableSingleSort() {
   const [data, setData] = useState(initialData);
-  const [sortInfo, setSortInfo] = useState({ sortBy: 'survivalTime', descending: true });
+  const [sortInfo, setSortInfo] = useState({ sortBy: 'status', descending: true });
   const [multipleSort, setMultipleSort] = useState(false);
 
   function onSortChange(sort, options) {
     console.log(sort, options);
     setSortInfo(sort);
-    setData(options.currentDataSource);
+    // 默认不存在排序时，也可以在这里设置 data 的值
+    // setData(options.currentDataSource);
+  }
+
+  // 默认存在排序时，必须在这里给 data 赋值
+  function onDataChange(newData) {
+    setData(newData);
   }
 
   return (
@@ -79,6 +85,7 @@ export default function TableSingleSort() {
         sort={sortInfo}
         multipleSort={multipleSort}
         onSortChange={onSortChange}
+        onDataChange={onDataChange}
       />
     </Space>
   );

--- a/src/table/_example/filter-controlled.jsx
+++ b/src/table/_example/filter-controlled.jsx
@@ -22,6 +22,11 @@ const columns = [
         { label: '已过期', value: 1 },
         { label: '审批失败', value: 2 },
       ],
+      // 透传浮层全部属性，示例代码
+      // popupProps: {
+      //   placement: 'right',
+      //   attach: () => document.body
+      // },
     },
     cell: ({ row }) => (
       <Tag shape="round" theme={statusNameListMap[row.status].theme} variant="light-outline">

--- a/src/table/_example/select-multiple.jsx
+++ b/src/table/_example/select-multiple.jsx
@@ -55,10 +55,9 @@ for (let i = 0; i < 5; i++) {
   });
 }
 
-
 export default function TableSingleSort() {
   const [data] = useState([...initData]);
-  const [selectedRowKeys, setSelectedRowKeys] = useState([1]);
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
 
   function onSelectChange(value, { selectedRowData }) {
     console.log(value, selectedRowData);
@@ -70,6 +69,7 @@ export default function TableSingleSort() {
       rowKey="index"
       data={data}
       columns={columns}
+      selectOnRowClick={true}
       selectedRowKeys={selectedRowKeys}
       onSelectChange={onSelectChange}
     />

--- a/src/table/_example/select-single.jsx
+++ b/src/table/_example/select-single.jsx
@@ -75,6 +75,7 @@ export default function TableSingleSort() {
       rowKey="index"
       data={data}
       columns={columns}
+      selectOnRowClick={true}
       selectedRowKeys={selectedRowKeys}
       onSelectChange={onSelectChange}
     />

--- a/src/table/hooks/useFilter.tsx
+++ b/src/table/hooks/useFilter.tsx
@@ -144,6 +144,7 @@ export default function useFilter(props: TdPrimaryTableProps, primaryTableRef: M
         innerFilterValue={innerFilterValue}
         tableFilterClasses={tableFilterClasses}
         isFocusClass={isFocusClass}
+        popupProps={col.filter.popupProps}
         onReset={onReset}
         onConfirm={onConfirm}
         onInnerFilterChange={onInnerFilterChange}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

同步 Vue2/Vue3 已实现 Feature，https://github.com/Tencent/tdesign-vue/pull/1891

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 可筛选表格，新增 `filter.popupProps` ，支持透传 Popup 组件全部属性，[tdesign-vue-next#2088](https://github.com/Tencent/tdesign-vue-next/issues/2088)
- feat(Table): 选中行表格，新增 `selectOnRowClick`，支持点击行选中，[tdesign-vue-next#1954](https://github.com/Tencent/tdesign-vue-next/issues/1954)
- feat(Table): 本地排序功能，支持对默认数据进行排序


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
