### PR TITLE
fix(color-picker): 选择色值mode的popup隐藏问题

### DIFF
--- a/src/color-picker/ColorPicker.tsx
+++ b/src/color-picker/ColorPicker.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Popup, PopupProps } from '../popup';
 import { ColorPickerProps, TdColorContext } from './interface';
 import useClassName from './hooks/useClassNames';
 import useControlled from '../hooks/useControlled';
 import ColorTrigger from './components/trigger';
 import ColorPanel from './components/panel/index';
-import useClickOutside from '../_util/useClickOutside';
 import { colorPickerDefaultProps } from './defaultProps';
 
 const ColorPicker: React.FC<ColorPickerProps> = (props) => {
@@ -13,7 +12,6 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
   const { popupProps, disabled, inputProps, onChange, colorModes, ...rest } = props;
   const { overlayClassName, overlayInnerStyle = {}, ...restPopupProps } = popupProps || {};
 
-  const [visible, setVisible] = useState(false);
   const [innerValue, setInnerValue] = useControlled(props, 'value', onChange);
   const triggerRef = useRef<HTMLDivElement>();
   const colorPanelRef = useRef();
@@ -22,7 +20,6 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
     placement: 'bottom-left',
     expandAnimation: true,
     trigger: 'click',
-    visible,
     ...restPopupProps,
     overlayClassName: [baseClassName, overlayClassName],
     overlayInnerStyle: {
@@ -31,18 +28,9 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
     },
   };
 
-  useClickOutside(
-    [triggerRef, colorPanelRef],
-    () => {
-      setVisible(false);
-    },
-    true,
-  );
-
   return (
     <Popup
       {...popProps}
-      onVisibleChange={(v) => setVisible(v)}
       content={
         !disabled && (
           <ColorPanel
@@ -50,7 +38,6 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
             disabled={disabled}
             value={innerValue}
             colorModes={colorModes}
-            togglePopup={setVisible}
             onChange={(value: string, context: TdColorContext) => setInnerValue(value, context)}
             ref={colorPanelRef}
           />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复

### 🔗 相关 Issue
哈喽，大佬们好。最近给 `color-picker` 加测试用例时发现个小问题如下：
![color-picker](https://user-images.githubusercontent.com/30046649/213616021-ca2b60e7-4616-406b-a44e-c9b47e77abb5.gif)
在点开 `color-picker` 的 `popup` 后，再点开选择色值 `mode` 下拉框，然后将鼠标移出整个 `color-picker-popup`，点击一下后色值下拉框没有隐藏。可以在 [官方文档中复现](https://tdesign.tencent.com/react/components/color-picker#%E5%B8%A6%E8%A7%A6%E5%8F%91%E5%85%83%E7%B4%A0%E7%9A%84%E9%A2%9C%E8%89%B2%E9%80%89%E6%8B%A9%E5%99%A8)。

看了下源码，`color-picker` 组件中对 `popup` 进行 **显隐控制**，其中的 `useClickOutside` 的处理逻辑跟 `popup` 组件中 `useTrigger` 的处理类似。并且 `picker` 组件中传递给 `ColorPanel` 组件的 `togglePopup={setVisible}` 也没有用上，所以大佬们看看是不是可以**不用在 `picker` 组件中对 `popup` 进行显隐控制**，将控制交还给 `popup` 自己。如果可以的话，那上面的问题就能解决了。但是一定要在 `picker` 中控制 `popup` 显隐逻辑的话，可能需要将 `visible` 带进去色值选择的下拉中来正确处理隐藏逻辑了。
