### PR TITLE
fix(table): 拖拽滚动条回到顶部白屏问题

### DIFF
--- a/src/table/BaseTable.tsx
+++ b/src/table/BaseTable.tsx
@@ -156,7 +156,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
 
   const virtualConfig = useVirtualScroll(tableContentRef, { data, scroll: props.scroll });
 
-  let lastScrollY = 0;
+  let lastScrollY = -1;
   const onInnerVirtualScroll = (e: WheelEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
     const top = target.scrollTop;
@@ -164,7 +164,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
     if (lastScrollY !== top) {
       virtualConfig.isVirtualScroll && virtualConfig.handleScroll();
     } else {
-      lastScrollY = 0;
+      lastScrollY = -1;
       updateColumnFixedShadow(target);
     }
     lastScrollY = top;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
大佬们好，在虚拟列表的使用中发现点问题如 `gif` ：
![virtual-table](https://user-images.githubusercontent.com/30046649/215304519-55555188-a32b-40e2-91b0-196d9d3aa894.gif)

操作路径描述（可在官网文档复现）：
1. 将虚拟表格滚动到一定高度
2. 稍微快速的用鼠标拖拽滚动条置顶再松开，表格内容白屏
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
调试代码时发现这个判断条件会导致上述问题，也就是 `top` 为 `0` 且又等于 `lastScrollY` 时就没有执行表格展示的逻辑函数 `handleScroll`。
![image](https://user-images.githubusercontent.com/30046649/215304549-a7ccd809-f963-472e-9fb3-88fe64babe1b.png)

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
