### PR TITLE
[Table] remove editable-cell useless code; useResizeObserver support container change

### DIFF
--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from 'react';
+import isFunction from 'lodash/isFunction';
 
 export default function useResizeObserver(container: HTMLElement, callback: (data: [ResizeObserverEntry]) => void) {
   let containerObserver: ResizeObserver = null;
@@ -6,7 +7,7 @@ export default function useResizeObserver(container: HTMLElement, callback: (dat
   const cleanupObserver = () => {
     if (!containerObserver) return;
     containerObserver.unobserve(container);
-    containerObserver.disconnect();
+    isFunction(containerObserver.disconnect) && containerObserver.disconnect();
     containerObserver = null;
   };
 

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,24 +1,29 @@
 import { useLayoutEffect } from 'react';
-import isFunction from 'lodash/isFunction';
 
 export default function useResizeObserver(container: HTMLElement, callback: (data: [ResizeObserverEntry]) => void) {
   let containerObserver: ResizeObserver = null;
 
-  const observeContainer = () => {
-    if (!container || !container || !window || !window.ResizeObserver) {
-      containerObserver?.unobserve(container);
-      containerObserver?.disconnect();
-    } else {
-      containerObserver = new window.ResizeObserver(callback);
-      containerObserver.observe(container);
-    }
+  const cleanupObserver = () => {
+    if (!containerObserver) return;
+    containerObserver.unobserve(container);
+    containerObserver.disconnect();
+    containerObserver = null;
+  };
+
+  const addObserver = (el: HTMLElement) => {
+    containerObserver = new ResizeObserver(callback);
+    containerObserver.observe(el);
   };
 
   useLayoutEffect(() => {
-    observeContainer();
+    const isSupport = window && window.ResizeObserver;
+    if (!isSupport) return;
+
+    cleanupObserver();
+    container && addObserver(container);
+
     return () => {
-      containerObserver?.unobserve(container);
-      isFunction(containerObserver?.disconnect) && containerObserver.disconnect();
+      cleanupObserver();
     };
     // eslint-disable-next-line
   }, [container, containerObserver]);

--- a/src/table/EditableCell.tsx
+++ b/src/table/EditableCell.tsx
@@ -205,11 +205,9 @@ const EditableCell = (props: EditableCellProps) => {
     }
   };
 
-  const documentClickHandler = (e: PointerEvent) => {
+  const documentClickHandler = () => {
     if (!col.edit || !col.edit.component) return;
     if (!isEdit) return;
-    // @ts-ignore
-    if (e.path?.includes(tableEditableCellRef?.current?.currentElement)) return;
     const outsideAbortEvent = col.edit.onEdited;
     updateAndSaveAbort(outsideAbortEvent, {
       value: editValue,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fefactor(Table): 可编辑单元格，去除非必要路径比较代码
- feat: useResizeObserver 支持元素变化

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
