### PR TITLE
fix(table): 解决lazy-table重置、切换数据白屏问题

### DIFF
--- a/src/table/TR.tsx
+++ b/src/table/TR.tsx
@@ -35,7 +35,7 @@ export const TABLE_PROPS = [
   'onRowMouseup',
 ] as const;
 
-export type TrPropsKeys = typeof TABLE_PROPS[number];
+export type TrPropsKeys = (typeof TABLE_PROPS)[number];
 
 export interface TrProps extends TrCommonProps {
   rowKey: string;
@@ -102,7 +102,7 @@ export default function TR(props: TrProps) {
   }, [row, rowClassName, rowIndex, rowKey, trStyles?.classes]);
 
   const useLazyLoadParams = useMemo(() => ({ ...scroll, rowIndex }), [scroll, rowIndex]);
-  const { hasLazyLoadHolder, tRowHeight } = useLazyLoad(tableContentElm, trRef.current, useLazyLoadParams);
+  const { hasLazyLoadHolder, tRowHeight } = useLazyLoad(tableContentElm, trRef, useLazyLoadParams);
 
   useEffect(() => {
     if (virtualConfig.isVirtualScroll && trRef.current) {

--- a/src/table/hooks/useLazyLoad.ts
+++ b/src/table/hooks/useLazyLoad.ts
@@ -1,7 +1,7 @@
 /**
  * 原作者 @louiszhai 思路
  */
-import { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import observe from '../../_common/js/utils/observe';
 
 export type UseLazyLoadParams = {
@@ -13,12 +13,12 @@ export type UseLazyLoadParams = {
 
 export default function useLazyLoad(
   containerRef: HTMLElement,
-  childRef: HTMLTableRowElement,
+  childRef: React.MutableRefObject<HTMLTableRowElement>,
   params: UseLazyLoadParams,
 ) {
   // useMemo 用意：1. 为了实时响应数据；2. 表格的计算量容易过大，提前存储
   const tRowHeight = useMemo(() => Math.max(params.rowHeight || 48, 48), [params.rowHeight]);
-  const [isInit, setIsInit] = useState(params.rowIndex === 0);
+  const [isInit, setIsInit] = useState(params.rowIndex === -1);
   const hasLazyLoadHolder = useMemo(() => params?.type === 'lazy' && !isInit, [isInit, params?.type]);
 
   const requestAnimationFrame =
@@ -37,7 +37,7 @@ export default function useLazyLoad(
     const timer = setTimeout(() => {
       const bufferSize = Math.max(10, params.bufferSize || 10);
       const height = tRowHeight * bufferSize;
-      childRef && observe(childRef, containerRef, init, height);
+      childRef && observe(childRef.current, containerRef, init, height);
       clearTimeout(timer);
     });
     return () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
懒加载 `table`，更新、重置数据后出现白屏。如图所示：
![image](https://user-images.githubusercontent.com/30046649/216402102-9db85537-e604-4999-a015-2301b543d2fc.png)

复现操作路径：
1. 官网文档 -> table -> 懒加载 -> 点击“列表恢复初始状态”按钮

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
