### PR TITLE
fix(popup): fix popup position when edge case occurs

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -66,6 +66,7 @@ const Popup = forwardRef((props: PopupProps, ref: React.RefObject<PopupRef>) => 
   const prevVisible = usePrevious(visible);
 
   const [popupElement, setPopupElement] = useState(null);
+  const [styleState, setStyleState] = useState<boolean>(false);
   const triggerRef = useRef(null); // 记录 trigger 元素
   const popupRef = useRef(null); // popup dom 元素，css transition 需要用
   const portalRef = useRef(null); // portal dom 元素
@@ -140,6 +141,11 @@ const Popup = forwardRef((props: PopupProps, ref: React.RefObject<PopupRef>) => 
     ...popperOptions,
   });
   const { styles, attributes } = popperRef.current;
+
+  // Popper样式变化时强刷组件
+  useEffect(() => {
+    setStyleState(!styleState);
+  }, [styleState, styles]);
 
   // 整理浮层样式
   function getOverlayStyle(overlayStyle: TdPopupProps['overlayStyle']) {


### PR DESCRIPTION
fix first occurrence position of popup when edge case occurs

fix #2064

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当 Popup 出现边缘情况时（如默认弹出位置受到视图窗口遮挡），`react-popper` 会即时调整位置，但 `Portal` 组件无法感知子组件样式发生调整，所以会出现首次定位不准确的问题，具体反馈 issue 如下：

[Issue #2064](https://github.com/Tencent/tdesign-react/issues/2064)

修复方法为监听到 popper 样式发生调整时更新组件的状态

**背景**

**解决方案**

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): 修复边界情况下Popup组件首次弹出位置不准确问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
  
