### PR TITLE
fix(Notification): 初始化notification容器时，可能拿不到实例的bug

### DIFF
--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -142,12 +142,10 @@ export const fetchListInstance = (
           zIndex={Number(zIndex)}
           renderCallback={(instance) => {
             listMap.set(placement, instance);
+            resolve(instance);
           }}
         />,
         attach,
       );
-      requestAnimationFrame(() => {
-        resolve(listMap.get(placement));
-      });
     }
   });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- 日常 bug 修复

### 💡 需求背景和解决方案

初始化notification容器时，可能拿不到容器实例，在我是在qiankun套react 17.x的项目下遇到的。

- fix(Notification): 初始化notification容器时，可能拿不到实例的bug
