### PR TITLE
fix(Select): 修复label为白屏的情况下,搜索就会白屏的bug

### DIFF
--- a/src/select/base/Select.tsx
+++ b/src/select/base/Select.tsx
@@ -213,7 +213,9 @@ const Select = forwardRefWithStatics(
         }
       } else if (Array.isArray(tmpPropOptions)) {
         const upperValue = value.toUpperCase();
-        filteredOptions = tmpPropOptions.filter((option) => (option?.label || '').toUpperCase().includes(upperValue)); // 不区分大小写
+        filteredOptions = tmpPropOptions.filter(
+          (option) => typeof option?.label === 'string' && (option?.label || '').toUpperCase().includes(upperValue),
+        ); // 不区分大小写
       }
 
       if (creatable) {


### PR DESCRIPTION
Tencent/tdesign-react#2123

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [✅] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
 https://github.com/Tencent/tdesign-react/issues/2123

### 💡 需求背景和解决方案
[Select] label为节点不是string会有报错导致白屏
### 📝 更新日志
[Select] 修复abel为节点不是string会有报错导致白屏

- fix(Select): 修复abel为节点不是string会有报错导致白屏

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅ ] 文档已补充或无须补充
- [ ✅] 代码演示已提供或无须提供
- [✅ ] TypeScript 定义已补充或无须补充
- [ ✅] Changelog 已提供或无须提供
