### PR TITLE
fix(Select): 修复输入字符按退格键删除tag的bug

### DIFF
--- a/src/tag-input/TagInput.tsx
+++ b/src/tag-input/TagInput.tsx
@@ -156,8 +156,8 @@ const TagInput = forwardRef((props: TagInputProps, ref: React.RefObject<InputRef
       onPaste={onPaste}
       onClick={onInnerClick}
       onEnter={onInputEnter}
-      onKeydown={onInputBackspaceKeyUp}
-      onKeyup={onInputBackspaceKeyDown}
+      onKeydown={onInputBackspaceKeyDown}
+      onKeyup={onInputBackspaceKeyUp}
       onMouseenter={(context) => {
         addHover(context);
         scrollToRightOnEnter();

--- a/src/tag-input/TagInput.tsx
+++ b/src/tag-input/TagInput.tsx
@@ -59,10 +59,11 @@ const TagInput = forwardRef((props: TagInputProps, ref: React.RefObject<InputRef
   const { scrollToRight, onWheel, scrollToRightOnEnter, scrollToLeftOnLeave, tagInputRef } = useTagScroll(props);
 
   // handle tag add and remove
-  const { tagValue, onClose, onInnerEnter, onInputBackspaceKeyUp, clearAll, renderLabel } = useTagList({
-    ...props,
-    getDragProps,
-  });
+  const { tagValue, onClose, onInnerEnter, onInputBackspaceKeyUp, clearAll, renderLabel, onInputBackspaceKeyDown } =
+    useTagList({
+      ...props,
+      getDragProps,
+    });
 
   const NAME_CLASS = `${prefix}-tag-input`;
   const WITH_SUFFIX_ICON_CLASS = `${prefix}-tag-input__with-suffix-icon`;
@@ -156,6 +157,7 @@ const TagInput = forwardRef((props: TagInputProps, ref: React.RefObject<InputRef
       onClick={onInnerClick}
       onEnter={onInputEnter}
       onKeydown={onInputBackspaceKeyUp}
+      onKeyup={onInputBackspaceKeyDown}
       onMouseenter={(context) => {
         addHover(context);
         scrollToRightOnEnter();

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, KeyboardEvent, ReactNode, Fragment } from 'react';
+import React, { useState, MouseEvent, KeyboardEvent, ReactNode, Fragment } from 'react';
 import isFunction from 'lodash/isFunction';
 import { TagInputChangeContext, TagInputValue, TdTagInputProps } from './type';
 import { InputValue } from '../input';
@@ -18,6 +18,7 @@ export default function useTagList(props: TagInputProps) {
     props;
   // handle controlled property and uncontrolled property
   const [tagValue, setTagValue] = useControlled(props, 'value', props.onChange);
+  const [oldInputValue, setOldInputValue] = useState<InputValue>();
 
   // 点击标签关闭按钮，删除标签
   const onClose = (p: { e?: MouseEvent<SVGSVGElement>; index: number; item: string | number }) => {
@@ -48,12 +49,16 @@ export default function useTagList(props: TagInputProps) {
     props?.onEnter?.(newValue, { ...context, inputValue: value });
   };
 
+  const onInputBackspaceKeyUp = (value: InputValue) => {
+    if (!tagValue || !tagValue.length) return;
+    setOldInputValue(value);
+  };
   // 按下回退键，删除标签
-  const onInputBackspaceKeyUp = (value: InputValue, context: { e: KeyboardEvent<HTMLInputElement> }) => {
+  const onInputBackspaceKeyDown = (value: InputValue, context: { e: KeyboardEvent<HTMLInputElement> }) => {
     const { e } = context;
     if (!tagValue || !tagValue.length) return;
     // 回车键删除，输入框值为空时，才允许 Backspace 删除标签
-    if (!value && ['Backspace', 'NumpadDelete'].includes(e.key)) {
+    if (!oldInputValue && ['Backspace', 'NumpadDelete'].includes(e.key)) {
       const index = tagValue.length - 1;
       const item = tagValue[index];
       const trigger = 'backspace';
@@ -109,6 +114,7 @@ export default function useTagList(props: TagInputProps) {
     clearAll,
     onClose,
     onInnerEnter,
+    onInputBackspaceKeyDown,
     onInputBackspaceKeyUp,
     renderLabel,
   };

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MouseEvent, KeyboardEvent, ReactNode, Fragment } from 'react';
+import React, { MouseEvent, KeyboardEvent, ReactNode, Fragment } from 'react';
 import isFunction from 'lodash/isFunction';
 import { TagInputChangeContext, TagInputValue, TdTagInputProps } from './type';
 import { InputValue } from '../input';
@@ -18,7 +18,6 @@ export default function useTagList(props: TagInputProps) {
     props;
   // handle controlled property and uncontrolled property
   const [tagValue, setTagValue] = useControlled(props, 'value', props.onChange);
-  const [oldInputValue, setOldInputValue] = useState<InputValue>();
 
   // 点击标签关闭按钮，删除标签
   const onClose = (p: { e?: MouseEvent<SVGSVGElement>; index: number; item: string | number }) => {
@@ -54,7 +53,7 @@ export default function useTagList(props: TagInputProps) {
     const { e } = context;
     if (!tagValue || !tagValue.length) return;
     // 回车键删除，输入框值为空时，才允许 Backspace 删除标签
-    if (!oldInputValue && ['Backspace', 'NumpadDelete'].includes(e.key)) {
+    if (!value && ['Backspace', 'NumpadDelete'].includes(e.key)) {
       const index = tagValue.length - 1;
       const item = tagValue[index];
       const trigger = 'backspace';
@@ -62,7 +61,6 @@ export default function useTagList(props: TagInputProps) {
       setTagValue(newValue, { e, index, item, trigger });
       onRemove?.({ e, index, item, trigger, value: newValue });
     }
-    setOldInputValue(value);
   };
 
   const renderLabel = ({ displayNode, label }: { displayNode: ReactNode; label: ReactNode }) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- #2112
### 💡 需求背景和解决方案

输入一个字符，按退格会删除最后一个tag
输入多个字符，字符全部删除后按两次退格才会删除tag
判断删除tag的逻辑有问题

### 📝 更新日志

- fix(TagInput): 修复基于`TagInput`的组件使用筛选时删除关键词时会删除已选值的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
