### PR TITLE
fix($table): synchronize the colspan state of the table component

### DIFF
--- a/src/table/hooks/useRowspanAndColspan.ts
+++ b/src/table/hooks/useRowspanAndColspan.ts
@@ -23,7 +23,7 @@ export default function useRowspanAndColspan(
   rowKey: string,
   rowspanAndColspan: TableRowspanAndColspanFunc<TableRowData>,
 ) {
-  const [skipSpansMap] = useState(new Map<string, SkipSpansValue>());
+  const [skipSpansMap, setSpansMap] = useState(new Map<string, SkipSpansValue>());
 
   // 计算单元格是否跳过渲染
   const onTrRowspanOrColspan = (params: BaseTableCellParams<TableRowData>, skipSpansValue: SkipSpansValue) => {
@@ -78,7 +78,8 @@ export default function useRowspanAndColspan(
   useEffect(() => {
     updateSkipSpansMap(data, columns, rowspanAndColspan);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, columns, rowspanAndColspan]);
+    setSpansMap(pre => new Map<string, SkipSpansValue>([...pre.entries()]))
+  }, [data, columns, rowspanAndColspan, setSpansMap]);
 
-  return { skipSpansMap, updateSkipSpansMap };
+  return { skipSpansMap };
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 📝 更新日志

- fix(Table): 
在使用Table组件的合并单元格功能时，发现在填充数据后的第一次update中没有合并单元格，需要强制再update一次才能正常合并。查看Table源码发现：控制单元格合并的状态skipSpansMap在表格数据发生变化时，仅对skipSpansMap进行了异步的原地修改，因此不能及时更新视图。
解决方案：在状态需要改变时，构建新的不可变数据，并使用useState返回的state setter来及时更新。

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
