### PR TITLE
fix(tree-select): fix the bug in rendering when the label is Reactnode

### DIFF
--- a/src/tree/TreeItem.tsx
+++ b/src/tree/TreeItem.tsx
@@ -1,4 +1,13 @@
-import React, { CSSProperties, DragEventHandler, forwardRef, MouseEvent, ReactNode, useRef, DragEvent } from 'react';
+import React, {
+  CSSProperties,
+  DragEventHandler,
+  forwardRef,
+  MouseEvent,
+  ReactNode,
+  useRef,
+  DragEvent,
+  isValidElement,
+} from 'react';
 import classNames from 'classnames';
 import isFunction from 'lodash/isFunction';
 import { CaretRightSmallIcon as TdCaretRightSmallIcon } from 'tdesign-icons-react';
@@ -229,7 +238,9 @@ const TreeItem = forwardRef((props: TreeItemProps, ref: React.Ref<HTMLDivElement
         ref={setRefCurrent}
         date-target="label"
         className={labelClasses}
-        title={String(node.data?.text || node.label)}
+        // label 可以传入 ReactNode， 如果直接取里面的 children 值，当多层级的时候会有问题
+        // 所以这里判断如果 label是 ReactNode， 并且 text没有值 就不展示 title
+        title={isValidElement(node.label) && !node.data?.text ? '' : String(node.data?.text || node.label)}
       >
         <span style={{ position: 'relative' }}>{labelText}</span>
       </span>


### PR DESCRIPTION
fix #2181

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...
  修复当label传入为 ReactNode时， 页面item hover 会渲染出 [object Object]的bug

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
