### PR TITLE
feat: support show tooltip when side menu collapsed

### DIFF
--- a/src/menu/MenuContext.ts
+++ b/src/menu/MenuContext.ts
@@ -13,7 +13,7 @@ export type SetMenuState = React.Dispatch<React.SetStateAction<MenuState>>;
 export type MenuMode = 'title' | 'accordion' | 'popup';
 
 interface MenuContextType
-  extends Pick<TdMenuProps, 'onChange' | 'value' | 'expanded' | 'expandMutex' | 'expandType' | 'theme'> {
+  extends Pick<TdMenuProps, 'onChange' | 'value' | 'expanded' | 'expandMutex' | 'expandType' | 'theme' | 'collapsed'> {
   /**
    * 修改非受控组件状态
    */

--- a/src/menu/MenuItem.tsx
+++ b/src/menu/MenuItem.tsx
@@ -6,6 +6,7 @@ import useRipple from '../_util/useRipple';
 import { TdMenuItemProps } from './type';
 import { StyledProps } from '../common';
 import { MenuContext } from './MenuContext';
+import TooltipLite from '../tooltip';
 
 export interface MenuItemProps extends TdMenuItemProps, StyledProps {}
 
@@ -28,7 +29,7 @@ const MenuItem: FC<MenuItemProps> = (props) => {
   const [menuItemDom, setRefCurrent] = useDomRefCallback();
   useRipple(menuItemDom);
 
-  const { onChange, setState, active } = useContext(MenuContext);
+  const { onChange, setState, active, collapsed } = useContext(MenuContext);
 
   const handleClick = (e: React.MouseEvent<HTMLLIElement>) => {
     e.stopPropagation();
@@ -39,7 +40,7 @@ const MenuItem: FC<MenuItemProps> = (props) => {
     setState({ active: value });
   };
 
-  return (
+  const liContent = (
     <li
       ref={setRefCurrent}
       className={classNames(`${classPrefix}-menu__item`, className, {
@@ -62,6 +63,17 @@ const MenuItem: FC<MenuItemProps> = (props) => {
       </>
     </li>
   );
+
+  // 菜单收起，且只有本身为一级菜单才需要显示 tooltip
+  if (collapsed && !disabled && !/submenu/i.test(className)) {
+    return (
+      <TooltipLite content={children} placement="right">
+        {liContent}
+      </TooltipLite>
+    );
+  }
+
+  return liContent;
 };
 
 MenuItem.displayName = 'MenuItem';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/2318

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<img width="194" alt="image" src="https://github.com/Tencent/tdesign-react/assets/7600149/447d7bd3-10dc-467a-b199-6a6c5e4d067f">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Menu): 侧边导航菜单收起时，Tooltip 展示菜单内容

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
