### PR TITLE
fix: useLockStyle 在 SSR 环境下报错

### DIFF
--- a/src/dialog/hooks/useLockStyle.ts
+++ b/src/dialog/hooks/useLockStyle.ts
@@ -5,7 +5,7 @@ import { getScrollbarWidth } from '../../_common/js/utils/getScrollbarWidth';
 let key = 1;
 
 export default function useDialogLockStyle({ preventScrollThrough, visible, mode, showInAttachedElement }) {
-  const lockStyleRef = useRef(document.createElement('style'));
+  const lockStyleRef = useRef<HTMLStyleElement>(null!);
   const timerRef = useRef(null);
 
   const clearStyleFunc = useCallback(() => {
@@ -17,6 +17,9 @@ export default function useDialogLockStyle({ preventScrollThrough, visible, mode
 
   useLayoutEffect(() => {
     if (typeof document === 'undefined') return;
+    if (!lockStyleRef.current) {
+      lockStyleRef.current = document.createElement('style');
+    }
     const hasScrollBar = document.documentElement.scrollHeight > document.documentElement.clientHeight;
     const scrollbarWidth = hasScrollBar ? getScrollbarWidth() : 0;
 

--- a/src/dialog/hooks/useLockStyle.ts
+++ b/src/dialog/hooks/useLockStyle.ts
@@ -5,7 +5,7 @@ import { getScrollbarWidth } from '../../_common/js/utils/getScrollbarWidth';
 let key = 1;
 
 export default function useDialogLockStyle({ preventScrollThrough, visible, mode, showInAttachedElement }) {
-  const lockStyleRef = useRef<HTMLStyleElement>(null!);
+  const lockStyleRef = useRef<HTMLStyleElement>(null);
   const timerRef = useRef(null);
 
   const clearStyleFunc = useCallback(() => {

--- a/src/drawer/hooks/useLockStyle.ts
+++ b/src/drawer/hooks/useLockStyle.ts
@@ -6,7 +6,7 @@ let key = 1;
 
 export default function useLockStyle(props) {
   const { preventScrollThrough, mode, visible, showInAttachedElement, placement, sizeValue } = props;
-  const lockStyleRef = useRef<HTMLStyleElement>(null!);
+  const lockStyleRef = useRef<HTMLStyleElement>(null);
   const timerRef = useRef(null);
 
   const clearStyleFunc = useCallback(() => {

--- a/src/drawer/hooks/useLockStyle.ts
+++ b/src/drawer/hooks/useLockStyle.ts
@@ -6,7 +6,7 @@ let key = 1;
 
 export default function useLockStyle(props) {
   const { preventScrollThrough, mode, visible, showInAttachedElement, placement, sizeValue } = props;
-  const lockStyleRef = useRef(document.createElement('style'));
+  const lockStyleRef = useRef<HTMLStyleElement>(null!);
   const timerRef = useRef(null);
 
   const clearStyleFunc = useCallback(() => {
@@ -29,6 +29,9 @@ export default function useLockStyle(props) {
 
   useLayoutEffect(() => {
     if (typeof document === 'undefined') return;
+    if (!lockStyleRef.current) {
+      lockStyleRef.current = document.createElement('style');
+    }
     const hasScrollBar = document.documentElement.scrollHeight > document.documentElement.clientHeight;
     const scrollbarWidth = hasScrollBar ? getScrollbarWidth() : 0;
     lockStyleRef.current.dataset.id = `td_drawer_${+new Date()}_${(key += 1)}`;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue 
- https://github.com/Tencent/tdesign-react/issues/2279

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Dialog 组件和 Drawer 组件在 SSR 环境下报错

解决方案：在 useLayoutEffect 里进行 dom 创建

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复 Dialog 在 SSR 环境下报错
- fix(Drawer): 修复 Drawer 在 SSR 环境下报错

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
