### PR TITLE
fix(ColorPicker): 初始化为渐变模式时 支持空字符串作为初始值

### DIFF
--- a/src/color-picker/components/panel/format/index.tsx
+++ b/src/color-picker/components/panel/format/index.tsx
@@ -14,7 +14,7 @@ export interface TdColorFormatProps extends TdColorPickerProps {
 }
 
 const FormatPanel = (props: TdColorFormatProps) => {
-  const { baseClassName, format, onModeChange } = props;
+  const { baseClassName, format, onModeChange, selectInputProps } = props;
   const [formatMode, setFormatMode] = useState(format);
 
   const handleModeChange = (v: TdColorPickerProps['format']) => {
@@ -32,6 +32,7 @@ const FormatPanel = (props: TdColorFormatProps) => {
           className={`${baseClassName}__format-mode-select`}
           popupProps={{
             overlayClassName: `${baseClassName}__select-options`,
+            ...selectInputProps?.popupProps,
           }}
           autoWidth
           value={formatMode}

--- a/src/color-picker/components/panel/index.tsx
+++ b/src/color-picker/components/panel/index.tsx
@@ -46,9 +46,12 @@ const Panel = forwardRef<HTMLDivElement, ColorPickerProps>((props, ref) => {
     showPrimaryColorPreview = true,
   } = props;
   const [innerValue, setInnerValue] = useControlled(props, 'value', onChange);
-  const colorInstanceRef = useRef<Color>(new Color(innerValue || DEFAULT_COLOR));
+  const [mode, setMode] = useState<TdColorModes>(colorModes?.length === 1 ? colorModes[0] : 'monochrome');
+  const isGradient = mode === 'linear-gradient'; // 判断是否为gradient模式
+
+  const defaultEmptyColor = isGradient ? DEFAULT_LINEAR_GRADIENT : DEFAULT_COLOR;
+  const colorInstanceRef = useRef<Color>(new Color(innerValue || defaultEmptyColor));
   const getmodeByColor = colorInstanceRef.current.isGradient ? 'linear-gradient' : 'monochrome';
-  const [mode, setMode] = useState<TdColorModes>(colorModes?.length === 1 ? colorModes[0] : getmodeByColor);
   const [updateId, setUpdateId] = useState(0);
   const update = useCallback(
     (value) => {
@@ -293,8 +296,6 @@ const Panel = forwardRef<HTMLDivElement, ColorPickerProps>((props, ref) => {
       </>
     );
   });
-
-  const isGradient = mode === 'linear-gradient';
 
   return (
     <div

--- a/src/color-picker/type.ts
+++ b/src/color-picker/type.ts
@@ -51,12 +51,12 @@ export interface TdColorPickerProps {
    * 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”
    * @default []
    */
-  recentColors?: boolean | Array<string>;
+  recentColors?: boolean | Array<string> | null;
   /**
    * 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”，非受控属性
    * @default []
    */
-  defaultRecentColors?: boolean | Array<string>;
+  defaultRecentColors?: boolean | Array<string> | null;
   /**
    * 透传 SelectInputProps 筛选器输入框组件全部属性
    */
@@ -69,7 +69,7 @@ export interface TdColorPickerProps {
   /**
    * 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色
    */
-  swatchColors?: Array<string>;
+  swatchColors?: Array<string> | null;
   /**
    * 色值
    * @default ''


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/2904
- https://github.com/Tencent/tdesign-vue-next/issues/2903
- https://github.com/Tencent/tdesign-vue/issues/2498
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ColorPicker): 初始化为渐变模式时 支持空字符串作为初始值
- fix(ColorPicker): 修复 `recentColors` 等字段的类型问题
- fix(ColorPicker): 修复内部下拉选项未透传 `popupProps` 的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
