### PR TITLE
fix(Popconfirm): button props propagation

### DIFF
--- a/src/popconfirm/Popcontent.tsx
+++ b/src/popconfirm/Popcontent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import isString from 'lodash/isString';
 import classNames from 'classnames';
 import { InfoCircleFilledIcon as TdInfoCircleFilledIcon } from 'tdesign-icons-react';
-import Button from '../button';
+import Button, { ButtonProps } from '../button';
 import noop from '../_util/noop';
 import useConfig from '../hooks/useConfig';
 import useGlobalIcon from '../hooks/useGlobalIcon';
@@ -71,6 +71,7 @@ const Popcontent = (props: PopconfirmProps & { onClose?: (context: PopconfirmVis
           onClose({ e, trigger: 'cancel' });
           onCancel({ e });
         }}
+        {...(typeof cancelBtn === 'object' ? { ...(cancelBtn as ButtonProps) } : {})}
       >
         {isString(cancelBtn) && cancelBtn}
       </Button>
@@ -99,6 +100,7 @@ const Popcontent = (props: PopconfirmProps & { onClose?: (context: PopconfirmVis
           onClose({ e, trigger: 'confirm' });
           onConfirm({ e });
         }}
+        {...(typeof confirmBtn === 'object' ? { ...(confirmBtn as ButtonProps) } : {})}
       >
         {isString(confirmBtn) && confirmBtn}
       </Button>

--- a/src/popconfirm/__tests__/popconfirm.test.tsx
+++ b/src/popconfirm/__tests__/popconfirm.test.tsx
@@ -84,6 +84,53 @@ describe('Popconfirm 组件测试', () => {
     expect(onConfirmMock).toHaveBeenCalledTimes(1);
   });
 
+  test('确认/取消按钮透传 null/object 测试', async () => {
+    const onCancelMock = vi.fn();
+    const onConfirmMock = vi.fn();
+    const { getByText, queryByTestId, queryByText, queryAllByRole } = render(
+      <Popconfirm
+        placement="top"
+        content={<div data-testid={testId}>{text}</div>}
+        onCancel={onCancelMock}
+        onConfirm={onConfirmMock}
+        destroyOnClose={false}
+        // 传入 null
+        confirmBtn={null}
+        // 传入 object
+        cancelBtn={{ onClick: onCancelMock, content: '取消操作', theme: 'danger' }}
+      >
+        {triggerElement}
+      </Popconfirm>,
+    );
+
+    // 鼠标点击前，没有元素存在
+    const element1 = await waitFor(() => queryByTestId(testId));
+    expect(element1).toBeNull();
+
+    // 模拟鼠标点击
+    act(() => {
+      fireEvent.click(getByText(triggerElement));
+    });
+
+    // 鼠标进入后，有元素，而且内容为 popupText， 且 confirmBtn={null} 只有一个按钮
+    const element2 = await waitFor(() => queryByTestId(testId));
+    expect(element2).not.toBeNull();
+
+    // 测试只有一个按钮
+    const buttons = await waitFor(() => queryAllByRole('button'));
+    expect(buttons).toHaveLength(1);
+
+    const cancelBtn = await waitFor(() => queryByText('取消操作'));
+    // 查询 content 验证透传成功
+    expect(cancelBtn).not.toBeNull();
+
+    // 测试点击事件透传成功
+    act(() => {
+      fireEvent.click(cancelBtn);
+    });
+    expect(onCancelMock).toHaveBeenCalledTimes(1);
+  });
+
   test('ref test', () => {
     render(
       <Popconfirm placement="top" content={<div data-testid={testId}>{text}</div>} theme="warning">


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-react/issues/2360

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当 `confirmBtn/cancelBtn` 值类型为 `Object` 时未透传。

<img width="918" alt="image" src="https://github.com/Tencent/tdesign-react/assets/41513919/13c4e88b-1e52-4322-81df-d9973d997cd1">


修改后测试结果：

<img width="1140" alt="image" src="https://github.com/Tencent/tdesign-react/assets/41513919/383dc68b-8bf5-4f63-81c9-bd271a02e26a">

```js
<Popconfirm theme={'default'} 
  content={'您确定要提交吗'} 
  confirmBtn={'确认提交'} 

  // object 透传
  cancelBtn={{onClick: ()=>{console.log("test")}, content: "test", theme: "danger"}}
>
  <Button theme="default" variant="outline">
    按钮样式（属性-字符串）
  </Button>
</Popconfirm>
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popconfirm): 当 `confirmBtn/cancelBtn` 值类型为 `Object` 时未透传

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
