### PR TITLE
feat: popupconfirm components add trigger API

### DIFF
--- a/src/popconfirm/Popconfirm.tsx
+++ b/src/popconfirm/Popconfirm.tsx
@@ -22,9 +22,9 @@ const Popconfirm = forwardRef((props: PopconfirmProps, ref: React.RefObject<Popu
   return (
     <Popup
       ref={ref}
+      trigger={props.trigger || 'click'}
       {...props}
       visible={visible}
-      trigger="click"
       onVisibleChange={(visible) => setVisible(visible)}
       overlayClassName={classNames(`${classPrefix}-popconfirm`)}
       content={

--- a/src/popconfirm/_usage/props.json
+++ b/src/popconfirm/_usage/props.json
@@ -61,6 +61,29 @@
     ]
   },
   {
+    "name": "trigger",
+    "type": "enum",
+    "defaultValue": "click",
+    "options": [
+      {
+        "label": "hover",
+        "value": "hover"
+      },
+      {
+        "label": "click",
+        "value": "click"
+      },
+      {
+        "label": "focus",
+        "value": "focus"
+      },
+      {
+        "label": "context-menu",
+        "value": "context-menu"
+      }
+    ]
+  },
+  {
     "name": "showArrow",
     "type": "Boolean",
     "defaultValue": true,

--- a/src/popconfirm/popconfirm.en-US.md
+++ b/src/popconfirm/popconfirm.en-US.md
@@ -18,6 +18,7 @@ placement | String | top | options：top/left/right/bottom/top-left/top-right/bo
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/popconfirm/type.ts) | N
 showArrow | Boolean | true | \- | N
 theme | String | default | options：default/warning/danger | N
+trigger | String | click | options：hover/click/focus/mousedown/context-menu | N
 triggerElement | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 visible | Boolean | - | \- | N
 defaultVisible | Boolean | - | uncontrolled property | N

--- a/src/popconfirm/popconfirm.md
+++ b/src/popconfirm/popconfirm.md
@@ -17,6 +17,7 @@ placement | String | top | 浮层出现位置。可选项：top/left/right/botto
 popupProps | Object | - | 透传 Popup 组件属性。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/popconfirm/type.ts) | N
 showArrow | Boolean | true | 是否显示浮层箭头 | N
 theme | String | default | 文字提示风格。可选项：default/warning/danger | N
+trigger | String | click | 触发浮层出现的方式。可选项：hover/click/focus/mousedown/context-menu | N
 triggerElement | TNode | - | 触发元素。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 visible | Boolean | - | 是否显示气泡确认框 | N
 defaultVisible | Boolean | - | 是否显示气泡确认框。非受控属性 | N

--- a/src/popconfirm/type.ts
+++ b/src/popconfirm/type.ts
@@ -69,6 +69,11 @@ export interface TdPopconfirmProps {
    */
   theme?: 'default' | 'warning' | 'danger';
   /**
+   * 触发浮层出现的方式
+   * @default hover
+   */
+  trigger?: 'hover' | 'click' | 'focus' | 'mousedown' | 'context-menu';
+  /**
    * 触发元素
    */
   triggerElement?: TNode;


### PR DESCRIPTION
fix #2351

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
close #2351
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
popupconfirm components add trigger API 

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
popupconfirm 组件添加trigger来进行多类型触发样式组件
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
