### PR TITLE
fix(Tree): virtual nodes  rescroll again when wrapped in css transition

### DIFF
--- a/src/tree/Tree.tsx
+++ b/src/tree/Tree.tsx
@@ -262,11 +262,7 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
       );
 
     return (
-      <TransitionGroup
-        name={transitionNames.treeNode}
-        className={treeClassNames.treeList}
-        style={isVirtual ? virtualTreeNodeStyle : null}
-      >
+      <TransitionGroup name={transitionNames.treeNode} className={treeClassNames.treeList}>
         {renderNode.map((node, index) => (
           // https://github.com/reactjs/react-transition-group/issues/668
           <CSSTransition
@@ -290,8 +286,6 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
               disableCheck={disableCheck}
               onClick={handleItemClick}
               onChange={handleChange}
-              onTreeItemMounted={handleRowMounted}
-              isVirtual={isVirtual}
             />
           </CSSTransition>
         ))}

--- a/src/tree/Tree.tsx
+++ b/src/tree/Tree.tsx
@@ -87,7 +87,13 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
   );
   const treeRef = useRef(null);
 
-  const { visibleData, isVirtual, treeNodeStyle, cursorStyle, handleRowMounted } = useTreeVirtualScroll({
+  const {
+    visibleData,
+    isVirtual,
+    treeNodeStyle: virtualTreeNodeStyle,
+    cursorStyle,
+    handleRowMounted,
+  } = useTreeVirtualScroll({
     treeRef,
     scroll,
     data: visibleNodes,
@@ -228,24 +234,14 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
     if (renderNode.length <= 0) {
       return renderEmpty();
     }
-
-    return (
-      <TransitionGroup
-        name={transitionNames.treeNode}
-        className={treeClassNames.treeList}
-        style={isVirtual ? { ...treeNodeStyle } : null}
-      >
-        {renderNode.map((node, index) => (
-          // https://github.com/reactjs/react-transition-group/issues/668
-          <CSSTransition
-            nodeRef={nodeList[index]}
-            key={node.value}
-            timeout={transitionDuration}
-            classNames={transitionClassNames}
-          >
+    if (isVirtual)
+      return (
+        <div className={treeClassNames.treeList} style={virtualTreeNodeStyle}>
+          {renderNode.map((node, index) => (
             <TreeItem
               ref={nodeList[index]}
-              node={store.getNode(node.value)}
+              key={node.value}
+              node={node}
               empty={empty}
               icon={icon}
               label={label}
@@ -259,7 +255,43 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
               onClick={handleItemClick}
               onChange={handleChange}
               onTreeItemMounted={handleRowMounted}
-              isVirtual={true}
+              isVirtual={isVirtual}
+            />
+          ))}
+        </div>
+      );
+
+    return (
+      <TransitionGroup
+        name={transitionNames.treeNode}
+        className={treeClassNames.treeList}
+        style={isVirtual ? virtualTreeNodeStyle : null}
+      >
+        {renderNode.map((node, index) => (
+          // https://github.com/reactjs/react-transition-group/issues/668
+          <CSSTransition
+            nodeRef={nodeList[index]}
+            key={node.value}
+            timeout={transitionDuration}
+            classNames={transitionClassNames}
+          >
+            <TreeItem
+              ref={nodeList[index]}
+              node={node}
+              empty={empty}
+              icon={icon}
+              label={label}
+              line={line}
+              transition={transition}
+              expandOnClickNode={expandOnClickNode}
+              activable={activable}
+              operations={operations}
+              checkProps={checkProps}
+              disableCheck={disableCheck}
+              onClick={handleItemClick}
+              onChange={handleChange}
+              onTreeItemMounted={handleRowMounted}
+              isVirtual={isVirtual}
             />
           </CSSTransition>
         ))}
@@ -284,14 +316,14 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
           [treeClassNames.treeCheckable]: checkable,
           [treeClassNames.treeFx]: transition,
           [treeClassNames.treeBlockNode]: expandOnClickNode,
-          [`${treeClassNames.tree}__vscroll`]: isVirtual,
+          [treeClassNames.treeVscroll]: isVirtual,
         })}
         style={style}
         ref={treeRef}
       >
         {isVirtual ? (
           <>
-            <div className={`${treeClassNames.tree}__vscroll-cursor`} style={cursorStyle} />
+            <div className={treeClassNames.treeVscrollCursor} style={cursorStyle} />
             {renderItems(visibleData)}
           </>
         ) : (

--- a/src/tree/hooks/useTreeConfig.ts
+++ b/src/tree/hooks/useTreeConfig.ts
@@ -45,6 +45,9 @@ export function useTreeConfig() {
       loading: `${prefix}-icon-loading ${prefix}-icon-loading-blue`,
       toggleEnter: `${tree}__item--enter-active`, // 节点展开动画
       toggleLeave: `${tree}__item--leave-active`, // 节点关闭动画
+      // 虚拟滚动相关
+      treeVscroll: `${tree}__vscroll`,
+      treeVscrollCursor: `${tree}__vscroll-cursor`,
     };
 
     const transitionNames = {

--- a/src/tree/hooks/useTreeVirtualScroll.ts
+++ b/src/tree/hooks/useTreeVirtualScroll.ts
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect, CSSProperties } from 'react';
+import { useMemo, useEffect, CSSProperties } from 'react';
 import useVirtualScroll from '../../hooks/useVirtualScroll';
 import TreeNode from '../../_common/js/tree/tree-node';
 
@@ -43,25 +43,22 @@ export default function useTreeVirtualScroll({
     data: data || [],
     scroll: scrollParams,
   });
+
   let lastScrollY = -1;
-  const onInnerVirtualScroll = useCallback(
-    (e: WheelEvent) => {
-      if (!isVirtual) {
-        return;
-      }
-      const target = e.target as HTMLElement;
-      const top = target.scrollTop;
-      // 排除横向滚动出发的纵向虚拟滚动计算
-      if (Math.abs(lastScrollY - top) > 5) {
-        handleVirtualScroll();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        lastScrollY = top;
-      } else {
-        lastScrollY = -1;
-      }
-    },
-    [isVirtual, data],
-  );
+  const onInnerVirtualScroll = (e: WheelEvent) => {
+    if (!isVirtual) {
+      return;
+    }
+    const target = e.target as HTMLElement;
+    const top = target.scrollTop;
+    if (lastScrollY !== top) {
+      handleVirtualScroll();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    } else {
+      lastScrollY = -1;
+    }
+    lastScrollY = top;
+  };
 
   useEffect(() => {
     const treeList = treeRef?.current;
@@ -75,7 +72,7 @@ export default function useTreeVirtualScroll({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVirtual, onInnerVirtualScroll, treeRef.current]);
+  }, [isVirtual, onInnerVirtualScroll]);
 
   const cursorStyle = {
     position: 'absolute',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 修复开启虚拟滚动时部分场景下节点回滚的交互异常问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
