### PR TITLE
fix(Table): resizable属性开启后，翻页之后各列宽度未能保存(#2386)

### DIFF
--- a/src/table/BaseTable.tsx
+++ b/src/table/BaseTable.tsx
@@ -44,6 +44,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
     resizable,
     lazyLoad,
     pagination,
+    isStatic = false,
   } = props;
   const tableRef = useRef<HTMLDivElement>();
   const tableElmRef = useRef<HTMLTableElement>();
@@ -56,7 +57,7 @@ const BaseTable = forwardRef<BaseTableRef, BaseTableProps>((props, ref) => {
   const { isMultipleHeader, spansAndLeafNodes, thList } = useTableHeader({ columns: props.columns });
   const finalColumns = useMemo(
     () => spansAndLeafNodes?.leafColumns || columns,
-    [spansAndLeafNodes?.leafColumns, columns],
+    isStatic ? [] : [spansAndLeafNodes?.leafColumns, columns],
   );
 
   // 固定表头和固定列逻辑

--- a/src/table/table.en-US.md
+++ b/src/table/table.en-US.md
@@ -1,6 +1,7 @@
 :: BASE_DOC ::
 
 ## API
+
 ### BaseTable Props
 
 name | type | default | description | required
@@ -11,6 +12,7 @@ attach | String / Function | - | elements with popup would be attached to `attac
 bordered | Boolean | false | show table bordered | N
 bottomContent | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 cellEmptyContent | TNode | - | Typescript：`string \| TNode<BaseTableCellParams<T>>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
+isStatic | Boolean | false | Static table,used in scenarios where the columns attribute of the table does not change dynamically。Typescript：`boolean`。| N
 columns | Array | [] | table column configs。Typescript：`Array<BaseTableCol<T>>` | N
 data | Array | [] | table data。Typescript：`Array<T>` | N
 disableDataPage | Boolean | false | \- | N

--- a/src/table/table.md
+++ b/src/table/table.md
@@ -1,6 +1,7 @@
 :: BASE_DOC ::
 
 ## API
+
 ### BaseTable Props
 
 名称 | 类型 | 默认值 | 说明 | 必传
@@ -11,6 +12,7 @@ attach | String / Function | - | 超出省略等所有浮层元素统一绑定�
 bordered | Boolean | false | 是否显示表格边框 | N
 bottomContent | TNode | - | 表格底部内容，可以用于自定义列设置等。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 cellEmptyContent | TNode | - | 单元格数据为空时呈现的内容。TS 类型：`string \| TNode<BaseTableCellParams<T>>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
+isStatic | Boolean | false | 静态的表格，用于表格的columns属性不会动态变化的场景。TS 类型：`boolean`。| N
 columns | Array | [] | 列配置，泛型 T 指表格数据类型。TS 类型：`Array<BaseTableCol<T>>` | N
 data | Array | [] | 数据源，泛型 T 指表格数据类型。TS 类型：`Array<T>` | N
 disableDataPage | Boolean | false | 是否禁用本地数据分页。当 `data` 数据长度超过分页大小时，会自动进行本地数据分页。如果 `disableDataPage` 设置为 true，则无论何时，都不会进行本地数据分页 | N

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -52,6 +52,10 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
    */
   cellEmptyContent?: string | TNode<BaseTableCellParams<T>>;
   /**
+   * 静态的表格，用于表格的columns属性不会动态变化的场景 @link https://github.com/Tencent/tdesign-react/issues/2386
+   */
+  isStatic?: Boolean;
+  /**
    * 列配置，泛型 T 指表格数据类型
    * @default []
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2386 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1、问题

只要一翻页，宽度就变成默认的了
预期翻页后各列宽度为调整后的宽度

2、实现方案

为`Table`组件新增`isStatic`属性，用于在生成`finalColumns`是指定对应的`dependence`
```typescript
const finalColumns = useMemo(
    () => spansAndLeafNodes?.leafColumns || columns,
    isStatic ? [] : [spansAndLeafNodes?.leafColumns, columns],
  );
```
3、变化

![bandicam_2023-08-10_16-39-48-603_AdobeExpress](https://github.com/Tencent/tdesign-react/assets/89344405/9724c4f1-62ca-41c0-a0fa-d33dcd4f49c4)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 增加`isStatic`属性，用于表格的columns属性不会动态变化的场景

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
