### PR TITLE
fix(dialog): 修复 tdesign react dialog 闪烁的问题

### DIFF
--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -29,7 +29,7 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
   const wrapRef = useRef<HTMLDivElement>();
   const maskRef = useRef<HTMLDivElement>();
   const contentClickRef = useRef(false);
-  const dialogCardRef = useRef();
+  const dialogCardRef = useRef<HTMLDivElement>();
   const dialogPosition = useRef();
   const portalRef = useRef();
   const [state, setState] = useSetState<DialogProps>({ isPlugin: false, ...props });
@@ -149,6 +149,16 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
     wrapRef.current.style.display = 'block';
   };
 
+  const onInnerAnimateStart = () => {
+    if (!dialogCardRef.current) return;
+    dialogCardRef.current.style.display = 'block';
+  };
+
+  const onInnerAnimateLeave = () => {
+    if (!dialogCardRef.current) return;
+    dialogCardRef.current.style.display = 'none';
+  };
+
   const renderMask = () => {
     if (mode !== 'modal') return null;
 
@@ -207,6 +217,8 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
                 timeout={300}
                 classNames={`${componentCls}-zoom`}
                 nodeRef={dialogCardRef}
+                onEnter={onInnerAnimateStart}
+                onExited={onInnerAnimateLeave}
               >
                 <DialogCard
                   ref={dialogCardRef}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

css 的样式是加在最内层的 dom 上的，也就是 DialogCard 这个 Component 上，但是由于 内层的 CSSTransition 没有绑定 onExited 事件，因此在 transition 内部的 removeClass 中就会删掉 class，但是组件还没有被 display 为 false，要等到外层的这个 setState 触发完成后才会触发 onExited 设置 display。导致组件闪烁


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复 dialog 闪烁的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
