### PR TITLE
fix(date-picker): hover cell 造成不必要的渲染

### DIFF
--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import useConfig from '../hooks/useConfig';
@@ -108,9 +108,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
       setPopupVisible(false);
     }
   }
-
   // 头部快速切换
-  function onJumperClick({ trigger }) {
+  const onJumperClick = React.useCallback(({ trigger }) => {
     const monthCountMap = { date: 1, week: 1, month: 12, quarter: 12, year: 120 };
     const monthCount = monthCountMap[mode] || 0;
 
@@ -130,7 +129,8 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
 
     setYear(nextYear);
     setMonth(nextMonth);
-  }
+    // eslint-disable-next-line
+  }, []);
 
   // timePicker 点击
   function onTimePickerChange(val: string) {
@@ -180,13 +180,15 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     setPopupVisible(false);
   }
 
-  function onYearChange(year: number) {
+  const onYearChange = useCallback((year: number) => {
     setYear(year);
-  }
+    // eslint-disable-next-line
+  }, []);
 
-  function onMonthChange(month: number) {
+  const onMonthChange = useCallback((month: number) => {
     setMonth(month);
-  }
+    // eslint-disable-next-line
+  }, []);
 
   const panelProps = {
     value: cacheValue,

--- a/src/date-picker/base/Header.tsx
+++ b/src/date-picker/base/Header.tsx
@@ -228,4 +228,4 @@ const DatePickerHeader = (props: DatePickerHeaderProps) => {
 
 DatePickerHeader.displayName = 'DatePickerHeader';
 
-export default DatePickerHeader;
+export default React.memo(DatePickerHeader);

--- a/src/date-picker/panel/PanelContent.tsx
+++ b/src/date-picker/panel/PanelContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import DateHeader from '../base/Header';
 import DateTable from '../base/Table';
 import { TimePickerPanel } from '../../time-picker';
@@ -62,6 +62,21 @@ export default function PanelContent(props: PanelContentProps) {
 
   const defaultTime = '00:00:00';
 
+  const onMonthChangeInner = useCallback((val: number) => {
+    onMonthChange?.(val, { partial });
+    // eslint-disable-next-line
+  }, []);
+
+  const onYearChangeInner = useCallback((val: number) => {
+    onYearChange?.(val, { partial });
+    // eslint-disable-next-line
+  }, []);
+
+  const onJumperClickInner = useCallback(({ trigger }) => {
+    onJumperClick?.({ trigger, partial });
+    // eslint-disable-next-line
+  }, []);
+
   return (
     <div className={`${panelName}-content`}>
       <div className={`${panelName}-${mode}`}>
@@ -69,9 +84,9 @@ export default function PanelContent(props: PanelContentProps) {
           mode={mode}
           year={year}
           month={month}
-          onMonthChange={(val: number) => onMonthChange?.(val, { partial })}
-          onYearChange={(val: number) => onYearChange?.(val, { partial })}
-          onJumperClick={({ trigger }) => onJumperClick?.({ trigger, partial })}
+          onMonthChange={onMonthChangeInner}
+          onYearChange={onYearChangeInner}
+          onJumperClick={onJumperClickInner}
         />
 
         <DateTable


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2439

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

由于 DateTable 接受的 onMouseEnter 事件（在顶部 DatePicker 中声明）会触发 set inputValue，从而导致hover 日期 Cell 后，所有子组件重新渲染。

使用 `memo` 缓存 `DatePickerHeader`，使用 `useCallback` 缓存传入 `DatePickerHeader` 的三个函数

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(date-picker): hover cell 造成不必要的渲染

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
