### PR TITLE
fix(tabs): fix Tabs use list,lose panel content

### DIFF
--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -93,7 +93,7 @@ const Tabs = forwardRefWithStatics(
                 return child;
               }
               if (child.props.destroyOnHide === false) {
-                return <TabPanel style={{ display: 'none' }}>{child.props.children}</TabPanel>;
+                return <TabPanel style={{ display: 'none' }}>{child.props.children || child.props.panel}</TabPanel>;
               }
             }
             return null;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2497 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

选项卡使用list渲染标签面板，里面传递的是panel，不是children，导致丢失内容

解决方案：
<img width="778" alt="截屏2023-09-06 20 24 35" src="https://github.com/Tencent/tdesign-react/assets/65376724/fba827a5-79bf-4c7f-bda8-1ab7d8f45744">

判断children为空添加panel

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复使用选项卡的list，丢失标签面板的内容

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
