### PR TITLE
fix(Menu): fix menu expandType default mode the menuitem to pass onClick not trigger

### DIFF
--- a/src/menu/HeadMenu.tsx
+++ b/src/menu/HeadMenu.tsx
@@ -49,8 +49,8 @@ const HeadMenu: FC<HeadMenuProps> = (props) => {
               value={currentChildListValues.includes(value.active) ? value.active : currentChildListValues[0]}
               onChange={value.onChange}
             >
-              {childList.map(({ props }) => (
-                <TabPanel value={props.value} key={props.value} label={props.children}></TabPanel>
+              {childList.map(({ props: { children, ...restProps } }) => (
+                <TabPanel key={props.value} {...restProps} label={children}></TabPanel>
               ))}
             </Tabs>
           </ul>

--- a/src/menu/__tests__/menu.test.tsx
+++ b/src/menu/__tests__/menu.test.tsx
@@ -170,4 +170,22 @@ describe('Menu 组件测试', () => {
     fireEvent.click(getByText('列表项'));
     expect(ulNode.style.maxHeight).not.toBe('0');
   });
+
+  test('menu 測試 menuItem onClick事件', () => {
+    const clickFn = vi.fn();
+    const { getByText } = render(
+      <Menu>
+        <SubMenu title="列表项" value="1-1">
+          <MenuItem value="item1" onClick={clickFn}>
+            仪表盘
+          </MenuItem>
+        </SubMenu>
+        <SubMenu title="列表项" value="2-1">
+          <MenuItem value="2-1-1">基础列表项</MenuItem>
+        </SubMenu>
+      </Menu>,
+    );
+    fireEvent.click(getByText('仪表盘'));
+    expect(clickFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tabs/TabNav.tsx
+++ b/src/tabs/TabNav.tsx
@@ -210,6 +210,7 @@ const TabNav: React.FC<TabNavProps> = (props) => {
   const handleTabItemClick = (clickItem) => {
     tabClick(clickItem.value);
     onChange(clickItem.value);
+    clickItem?.onClick?.(clickItem.value);
   };
 
   const handleTabAdd = (e) => {


### PR DESCRIPTION


<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2349 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复菜单expandType默认模式下menuitem传递onClick不触发的问题

![image](https://github.com/Tencent/tdesign-react/assets/65376724/bcc76f32-7f91-4e02-b859-a60ca09e671f)

![image](https://github.com/Tencent/tdesign-react/assets/65376724/fa8d6ecf-05ad-485c-b4d5-d01c26fc3b99)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): 修复菜单expandType默认模式下menuitem传递onClick不触发的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
