### PR TITLE
feat(select-input): clear input value on blur

### DIFF
--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -70,6 +70,9 @@ export default function useMultiple(props: TdSelectInputProps) {
       onFocus={(val, context) => {
         props.onFocus?.(props.value, { ...context, tagInputValue: val });
       }}
+      onBlur={() => {
+        setTInputValue('');
+      }}
       {...props.tagInputProps}
       inputProps={{
         readonly: !props.allowInput || props.readonly,

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -88,6 +88,9 @@ export default function useSingle(props: TdSelectInputProps) {
           // focus might not need to change input value. it will caught some curious errors in tree-select
           // !popupVisible && setInputValue(getInputValue(value, keys), { ...context, trigger: 'input' });
         }}
+        onBlur={() => {
+          setInputValue('');
+        }}
         onEnter={(val, context) => {
           props.onEnter?.(value, { ...context, inputValue: val });
         }}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #2527

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(SelectInput): input 失去焦点时清空值

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
