### PR TITLE
fix(rate): 修复Rate组件鼠标移走，未恢复到之前的状态的bug

### DIFF
--- a/src/rate/Rate.tsx
+++ b/src/rate/Rate.tsx
@@ -21,6 +21,8 @@ const Rate = forwardRef((props: RateProps, ref: React.Ref<HTMLDivElement>) => {
   const [hoverValue = undefined, setHoverValue] = useState<number | undefined>(undefined);
   const displayValue = hoverValue || starValue;
   const rootRef = React.useRef(null);
+  const hoverCheckRef = React.useRef(null);
+  const checkTimeHandler = React.useRef(null);
 
   const activeColor = Array.isArray(color) ? color[0] : color;
   const defaultColor = Array.isArray(color) ? color[1] : 'var(--td-bg-color-component)';
@@ -58,6 +60,19 @@ const Rate = forwardRef((props: RateProps, ref: React.Ref<HTMLDivElement>) => {
     setHoverValue(undefined);
   };
 
+  const mouseOutHandler = () => {
+    if (disabled) return;
+    // fix: 2250 鼠标移走，未恢复到之前的状态
+    clearTimeout(checkTimeHandler.current);
+    checkTimeHandler.current = setTimeout(() => {
+      const computedStyle = getComputedStyle(hoverCheckRef.current);
+      const fontSize = computedStyle.getPropertyValue('font-size');
+      if (fontSize === '0px') {
+        setHoverValue(undefined);
+      }
+    }, 100);
+  };
+
   const clickHandler = (event: MouseEvent<HTMLElement>, index: number) => {
     if (disabled) return;
     setStarValue(getStarValue(event, index));
@@ -75,6 +90,7 @@ const Rate = forwardRef((props: RateProps, ref: React.Ref<HTMLDivElement>) => {
       style={style}
       className={classNames(`${classPrefix}-rate`, className)}
       onMouseLeave={mouseLeaveHandler}
+      onMouseOut={mouseOutHandler}
     >
       <ul className={`${classPrefix}-rate__list`} style={{ gap }} ref={rootRef}>
         {[...Array(count)].map((_, index) => (
@@ -106,6 +122,7 @@ const Rate = forwardRef((props: RateProps, ref: React.Ref<HTMLDivElement>) => {
           </li>
         ))}
       </ul>
+      <span ref={hoverCheckRef} className={`${classPrefix}-rate__hover__check`}></span>
       {showText && <div className={`${classPrefix}-rate__text`}>{texts[displayValue - 1]}</div>}
     </div>
   );


### PR DESCRIPTION
fix #2250

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix: #2250
[Rate] hover时，鼠标移走，未恢复到之前的状态 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、解决了Rate组件，鼠标快速移走，未恢复到之前的状态的bug
解决办法：使用css的hover特性，在rate组件中新增了一个隐藏的元素，元素默认字体大小为0，当hover的时候，改变字体大小，然后让mouseout的时候去延时判断当前的隐藏元素的字体大小，如果为0的时候，说明鼠标移动走了，即需要恢复组件状态。
```html
<span ref={hoverCheckRef} className={`${classPrefix}-rate__hover__check`}></span>
```

```ts
  const mouseOutHandler = () => {
    if (disabled) return;
    // fix: 2250 鼠标移走，未恢复到之前的状态
    clearTimeout(checkTimeHandler.current);
    checkTimeHandler.current = setTimeout(() => {
      const computedStyle = getComputedStyle(hoverCheckRef.current);
      const fontSize = computedStyle.getPropertyValue('font-size');
      if (fontSize === '0px') {
        setHoverValue(undefined);
      }
    }, 100);
  };
```


注意⚠️：本次改动需要同时在_common项目的rate的样式里面新增以下样式

```scss
  .@{rate-cls}__hover__check {
    display: none;
    width: 0;
    height: 0;
    font-size: 0;
  }

  &__list:hover + .@{rate-cls}__hover__check {
    font-size: 1px;
  }
```
这个还没有提交pr，如果大家认同这个修改方案，我在为_common项目提交样式修改的pr

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(rate): 修复Rate组件鼠标移走，未恢复到之前的状态的bug

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 无须补充
- [x] Changelog 已提供
