### PR TITLE
fix(date-picker): 🐛 date picker PaginationMini select

### DIFF
--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -109,28 +109,30 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     }
   }
   // 头部快速切换
-  const onJumperClick = React.useCallback(({ trigger }) => {
-    const monthCountMap = { date: 1, week: 1, month: 12, quarter: 12, year: 120 };
-    const monthCount = monthCountMap[mode] || 0;
+  const onJumperClick = React.useCallback(
+    ({ trigger }) => {
+      const monthCountMap = { date: 1, week: 1, month: 12, quarter: 12, year: 120 };
+      const monthCount = monthCountMap[mode] || 0;
 
-    const current = new Date(year, month);
+      const current = new Date(year, month);
 
-    let next = null;
-    if (trigger === 'prev') {
-      next = subtractMonth(current, monthCount);
-    } else if (trigger === 'current') {
-      next = new Date();
-    } else if (trigger === 'next') {
-      next = addMonth(current, monthCount);
-    }
+      let next = null;
+      if (trigger === 'prev') {
+        next = subtractMonth(current, monthCount);
+      } else if (trigger === 'current') {
+        next = new Date();
+      } else if (trigger === 'next') {
+        next = addMonth(current, monthCount);
+      }
 
-    const nextYear = next.getFullYear();
-    const nextMonth = next.getMonth();
+      const nextYear = next.getFullYear();
+      const nextMonth = next.getMonth();
 
-    setYear(nextYear);
-    setMonth(nextMonth);
-    // eslint-disable-next-line
-  }, []);
+      setYear(nextYear);
+      setMonth(nextMonth);
+    },
+    [year, month, mode, setYear, setMonth],
+  );
 
   // timePicker 点击
   function onTimePickerChange(val: string) {

--- a/src/date-picker/panel/PanelContent.tsx
+++ b/src/date-picker/panel/PanelContent.tsx
@@ -82,8 +82,7 @@ export default function PanelContent(props: PanelContentProps) {
     ({ trigger }) => {
       onJumperClick?.({ trigger, partial });
     },
-    // eslint-disable-next-line
-    [partial],
+    [partial, onJumperClick],
   );
 
   return (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<img width="284" alt="image" src="https://github.com/Tencent/tdesign-react/assets/46063163/bb987821-32a6-4603-91fd-983838826a0f">

日期选择器面板，右上角的这三个快速切换的按钮。只能切到当前月份/上一月/下一月，无法继续往前或往后切换。

原因在于 onJumperClick 没有及时更新，PaginationMini 持有的 onChange 还是老的 onJumperClick（持有的老的 year 和 month），所以每次点击都在以当前 year 和 month 做加减。这里的 useCallback 需要根据 year 和 month 来更新

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
