### PR TITLE
fix(Tree): node open state class condition error

### DIFF
--- a/src/tree/TreeItem.tsx
+++ b/src/tree/TreeItem.tsx
@@ -340,7 +340,9 @@ const TreeItem = forwardRef(
         data-value={node.value}
         data-level={level}
         className={classNames(treeClassNames.treeNode, {
-          [treeClassNames.treeNodeOpen]: node.expanded,
+          [treeClassNames.treeNodeOpen]:
+            node.expanded &&
+            (typeof node.data.children === 'boolean' ? node.data.children : node.data.children !== undefined),
           [treeClassNames.actived]: node.isActivable() ? node.actived : false,
           [treeClassNames.disabled]: node.isDisabled(),
           [treeClassNames.treeNodeDraggable]: node.isDraggable(),

--- a/src/tree/__tests__/tree.test.tsx
+++ b/src/tree/__tests__/tree.test.tsx
@@ -197,6 +197,20 @@ describe('Tree test', () => {
     expect(onChangeFn1).not.toHaveBeenCalled();
   });
 
+  it('should calculate right class of tree item.', async () => {
+    const { container } = await renderTreeWithProps({
+      expanded: [1, '1-2', '1-2', 2],
+    });
+
+    await mockDelay(300);
+    const allItems = container.querySelectorAll('.t-tree__item');
+    expect(allItems.length).toBe(4);
+    const nodeOpenItems = container.querySelectorAll('.t-tree__item--open');
+    // only set expanded when node has children
+    // or children is `true` when the tree is lazy
+    expect(nodeOpenItems.length).toBe(1);
+  });
+
   test('props.line', async () => {
     const data = [
       {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

树结点自定义 icon 的时候，如果不控制 expand state 的状态由子节点来得到的话，则会导致所有的图标颜色全部切换为 primary 的蓝色。

### 📝 更新日志

- fix(tree): 树组件结点的 open class 状态控制逻辑错误导致的样式异常

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
