### PR TITLE
fix: index and key of ScrollToElementParams should be optional

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -115,7 +115,7 @@ export type InfinityScroll = TScroll;
 
 export interface ScrollToElementParams {
   /** 跳转元素下标 */
-  index: number;
+  index?: number;
   /** 跳转元素距离顶部的距离 */
   top?: number;
   /** 单个元素高度非固定场景下，即 isFixedRowHeight = false。延迟设置元素位置，一般用于依赖不同高度异步渲染等场景，单位：毫秒 */
@@ -124,5 +124,5 @@ export interface ScrollToElementParams {
 }
 
 export interface ComponentScrollToElementParams extends ScrollToElementParams {
-  key: string | number;
+  key?: string | number;
 }

--- a/src/tree/_example/vscroll.jsx
+++ b/src/tree/_example/vscroll.jsx
@@ -13,7 +13,6 @@ export default () => {
       newOptions.push({
         label: `第${i}段`,
         value: i,
-        key: i,
         children: [
           {
             label: `第${i}段第1个子节点`,
@@ -30,7 +29,7 @@ export default () => {
   }, []);
 
   const handleScroll = () => {
-    treeRef.current.scrollTo({ index: '10', behavior: 'smooth' });
+    treeRef.current.scrollTo({ key: '10.1', behavior: 'smooth' });
   };
 
   const defaultChecked = ['1.2', '2.2'];


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 指定滚动到特定节点API中的`key`和`index`应为可选

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
