### PR TITLE
fix(dialog): resolve `styledProps` pass frame wrong

### DIFF
--- a/src/dialog/Dialog.tsx
+++ b/src/dialog/Dialog.tsx
@@ -37,6 +37,8 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
   const [local] = useLocaleReceiver('dialog');
 
   const {
+    className,
+    dialogClassName,
     style,
     width,
     mode,
@@ -192,7 +194,7 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
       <Portal attach={attach} ref={portalRef}>
         <div
           ref={wrapRef}
-          className={classNames(props.className, `${componentCls}__ctx`, `${componentCls}__${mode}`, {
+          className={classNames(className, `${componentCls}__ctx`, `${componentCls}__${mode}`, {
             [`${componentCls}__ctx--fixed`]: !showInAttachedElement,
             [`${componentCls}__ctx--absolute`]: showInAttachedElement,
           })}
@@ -224,6 +226,7 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
                 <DialogCard
                   ref={dialogCardRef}
                   {...restState}
+                  className={dialogClassName}
                   style={{ ...style, width: parseValueToPx(width || style?.width) }}
                   onConfirm={onConfirm}
                   onCancel={handleCancel}

--- a/src/dialog/type.ts
+++ b/src/dialog/type.ts
@@ -10,6 +10,11 @@ import { MouseEvent, KeyboardEvent } from 'react';
 
 export interface TdDialogProps extends TdDialogCardProps {
   /**
+   * 弹框元素类名，示例：'t-class-dialog-first t-class-dialog-second'
+   * @default ''
+   */
+  dialogClassName?: string;
+  /**
    * 对话框挂载的节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body
    */
   attach?: AttachNode;
@@ -156,12 +161,12 @@ export interface DialogOptions extends Omit<TdDialogProps, 'attach'> {
    */
   attach?: AttachNode;
   /**
-   * 弹框类名，示例：'t-class-dialog-first t-class-dialog-second'
+   * ctx 弹框顶层元素类名，示例：'t-class-dialog-ctx-first t-class-dialog-ctx-second'
    * @default ''
    */
   className?: string;
   /**
-   * 弹框 style 属性，输入 [CSSStyleDeclaration.cssText](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/cssText)
+   * 弹框顶层元素 style 属性，输入 [CSSStyleDeclaration.cssText](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/cssText)
    */
   style?: Styles;
 }


### PR DESCRIPTION
- Tencent/tdesign-react#2619

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Tencent/tdesign-react#2619

### 💡 需求背景和解决方案

`Dialog` 组件的 className 存在实现问题，导致其会被挂在到多个节点。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复了 Dialog 的 `className` 引入时的多次节点挂载实现错误

添加了 `dialogClassName` 用于处理内部 dialog 样式，`className` 将仅被挂载至 ctx 元素上。建议之前通过 `className` 直接修改弹窗本体样式的用户切换使用为 `dialogClassName`。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
