### PR TITLE
fix(DatePicker): fix Clear the content and the pop-up window will flash

### DIFF
--- a/src/input/Input.tsx
+++ b/src/input/Input.tsx
@@ -128,7 +128,13 @@ const Input = forwardRefWithStatics(
     let suffixIconNew = suffixIcon;
 
     if (isShowClearIcon)
-      suffixIconNew = <CloseCircleFilledIcon className={`${classPrefix}-input__suffix-clear`} onClick={handleClear} />;
+      suffixIconNew = (
+        <CloseCircleFilledIcon
+          className={`${classPrefix}-input__suffix-clear`}
+          onMouseDown={handleMouseDown}
+          onClick={handleClear}
+        />
+      );
     if (type === 'password' && typeof suffixIcon === 'undefined') {
       if (renderType === 'password') {
         suffixIconNew = (
@@ -290,6 +296,11 @@ const Input = forwardRefWithStatics(
         setComposingValue(newStr);
         onChange(newStr, { e, trigger });
       }
+    }
+    // 添加MouseDown阻止冒泡，防止點擊Clear value會導致彈窗閃爍一下
+    // https://github.com/Tencent/tdesign-react/issues/2320
+    function handleMouseDown(e: React.MouseEvent<SVGSVGElement, globalThis.MouseEvent>) {
+      e.stopPropagation();
     }
     function handleClear(e: React.MouseEvent<SVGSVGElement>) {
       onChange?.('', { e, trigger: 'clear' });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #2320
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
![image](https://github.com/Tencent/tdesign-react/assets/65376724/befe26f6-204a-4679-be53-e98646daa015)

- Popup的`trigger`是`mousedown`，导致会执行`setPopupVisible(true)`，
所以在Input组件的清除图标上添加mousedown阻止冒泡。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 修复日期点击清空内容，弹窗会闪烁一下

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
