### PR TITLE
fix(select-input): fix select-input popup content width calculation problem

### DIFF
--- a/src/select-input/useOverlayInnerStyle.ts
+++ b/src/select-input/useOverlayInnerStyle.ts
@@ -23,12 +23,24 @@ export default function useOverlayInnerStyle(
 
   const matchWidthFunc = (triggerElement: HTMLElement, popupElement: HTMLElement) => {
     if (!triggerElement || !popupElement) return;
-    // 避免因滚动条出现文本省略，预留宽度 8
-    const SCROLLBAR_WIDTH = popupElement.scrollHeight > popupElement.offsetHeight ? 8 : 0;
+
+    // popupElement的scrollBar宽度
+    const overlayScrollWidth = popupElement.offsetWidth - popupElement.scrollWidth;
+
+    /**
+     * issue：https://github.com/Tencent/tdesign-react/issues/2642
+     *
+     * popupElement的内容宽度不超过triggerElement的宽度，就使用triggerElement的宽度减去popup的滚动条宽度，
+     * 让popupElement的宽度加上scrollBar的宽度等于triggerElement的宽度；
+     *
+     * popupElement的内容宽度超过triggerElement的宽度，就使用popupElement的scrollWidth，
+     * 不用offsetWidth是会包含scrollBar的宽度
+     */
     const width =
-      popupElement.offsetWidth + SCROLLBAR_WIDTH >= triggerElement.offsetWidth
-        ? popupElement.offsetWidth
-        : triggerElement.offsetWidth;
+      popupElement.offsetWidth - overlayScrollWidth > triggerElement.offsetWidth
+        ? popupElement.scrollWidth
+        : triggerElement.offsetWidth - overlayScrollWidth;
+
     let otherOverlayInnerStyle: React.CSSProperties = {};
     if (popupProps && typeof popupProps.overlayInnerStyle === 'object' && !popupProps.overlayInnerStyle.width) {
       otherOverlayInnerStyle = popupProps.overlayInnerStyle;

--- a/src/select-input/useOverlayInnerStyle.ts
+++ b/src/select-input/useOverlayInnerStyle.ts
@@ -24,6 +24,9 @@ export default function useOverlayInnerStyle(
   const matchWidthFunc = (triggerElement: HTMLElement, popupElement: HTMLElement) => {
     if (!triggerElement || !popupElement) return;
 
+    // 设置display来可以获取popupElement的宽度
+    // eslint-disable-next-line no-param-reassign
+    popupElement.style.display = '';
     // popupElement的scrollBar宽度
     const overlayScrollWidth = popupElement.offsetWidth - popupElement.scrollWidth;
 


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #2642 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复popup内容宽度计算问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(SelectInput): 修复SelectInput的popup内容宽度计算问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
