### PR TITLE
fix(slider): slider will rerender when every `mouseEvent` emitted

### DIFF
--- a/src/slider/Slider.tsx
+++ b/src/slider/Slider.tsx
@@ -93,6 +93,8 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>((originalProps, ref
   const sizeKey = isVertical ? 'height' : 'width';
   const renderDots = isVertical ? dots.map((item) => ({ ...item, position: 1 - item.position })) : dots;
 
+  const positionsRef = useRef([0]);
+
   const handleInputChange = (newValue: number, nodeIndex: SliderHandleNode) => {
     const safeValue = Number(newValue.toFixed(32));
     let resultValue = Math.max(Math.min(max, safeValue), min);
@@ -160,8 +162,13 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>((originalProps, ref
     const clientKey = isVertical ? 'clientY' : 'clientX';
     const sliderPositionInfo = sliderRef.current.getBoundingClientRect();
     const sliderOffset = sliderPositionInfo[startDirection];
+    const oldPosition = positionsRef.current[nodeIndex || 0];
     const position = ((event[clientKey] - sliderOffset) / sliderPositionInfo[sizeKey]) * (isVertical ? -1 : 1);
+    if (oldPosition === position) {
+      return;
+    }
     setPosition(position, nodeIndex);
+    positionsRef.current[nodeIndex || 0] = position;
   };
 
   const handleClickMarks = (event: React.MouseEvent, value: number) => {


### PR DESCRIPTION
We only should setState when the position changes

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

开发环境时如果稍微快速拖动 Slider 调整数据，就很容易导致组件的 rerender，因为组件将每一个鼠标移动事件，都进行了状态的更新。

在这里我们使用一个 Ref 的 number[] 数组对已有的数据进行缓存，只有和上一步的值出现了变动的时候，才需要去更新我们的状态，从而防止触发 React 的短时间内过多的更新导致的白屏现象。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(slider): 更好的拖拽性能

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
