### PR TITLE
fix(Tree): fix tree expand icon status when keys.children is set

### DIFF
--- a/src/tree/Tree.tsx
+++ b/src/tree/Tree.tsx
@@ -275,6 +275,7 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
               ref={nodeList[index]}
               key={node.value}
               node={node}
+              keys={props.keys}
               empty={empty}
               icon={icon}
               label={label}
@@ -307,6 +308,7 @@ const Tree = forwardRef((props: TreeProps, ref: React.Ref<TreeInstanceFunctions>
             <TreeItem
               ref={nodeList[index]}
               node={node}
+              keys={props.keys}
               empty={empty}
               icon={icon}
               label={label}

--- a/src/tree/TreeItem.tsx
+++ b/src/tree/TreeItem.tsx
@@ -336,7 +336,7 @@ const TreeItem = forwardRef(
       setDragStatus('drop', evt);
     };
     const childrenKey = props.keys?.children || 'children';
-    console.log(childrenKey, 'childrenKey');
+
     return (
       <div
         ref={composeRefs(ref, nodeRef)}

--- a/src/tree/TreeItem.tsx
+++ b/src/tree/TreeItem.tsx
@@ -23,6 +23,7 @@ import useDraggable from './hooks/useDraggable';
 import composeRefs from '../_util/composeRefs';
 import useConfig from '../hooks/useConfig';
 
+import type { TdTreeProps } from './type';
 import type { TreeItemProps } from './interface';
 
 /**
@@ -33,6 +34,7 @@ const TreeItem = forwardRef(
     props: TreeItemProps & {
       onTreeItemMounted?: (rowData: { ref: HTMLElement; data: TreeNode }) => void;
       isVirtual?: boolean;
+      keys: TdTreeProps['keys'];
     },
     ref: React.Ref<HTMLDivElement>,
   ) => {
@@ -333,7 +335,8 @@ const TreeItem = forwardRef(
       evt.preventDefault();
       setDragStatus('drop', evt);
     };
-
+    const childrenKey = props.keys?.children || 'children';
+    console.log(childrenKey, 'childrenKey');
     return (
       <div
         ref={composeRefs(ref, nodeRef)}
@@ -342,7 +345,9 @@ const TreeItem = forwardRef(
         className={classNames(treeClassNames.treeNode, {
           [treeClassNames.treeNodeOpen]:
             node.expanded &&
-            (typeof node.data.children === 'boolean' ? node.data.children : node.data.children !== undefined),
+            (typeof node.data[childrenKey] === 'boolean'
+              ? node.data[childrenKey]
+              : node.data[childrenKey] !== undefined),
           [treeClassNames.actived]: node.isActivable() ? node.actived : false,
           [treeClassNames.disabled]: node.isDisabled(),
           [treeClassNames.treeNodeDraggable]: node.isDraggable(),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://codesandbox.io/p/sandbox/tdesign-react-demo-forked-jvj76h?file=%2Fsrc%2Fdemo.jsx%3A49%2C3
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 修复设置 `keys.children` 后展开图标没有正常变化的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
