### PR TITLE
fix: 🐛 replace defaultProps with useDefaultProp

### DIFF
--- a/src/sticky-tool/StickyItem.tsx
+++ b/src/sticky-tool/StickyItem.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef, useCallback, useMemo, MouseEvent } from 'react';
+import React, { useCallback, useMemo, MouseEvent } from 'react';
 import classNames from 'classnames';
 import useConfig from '../hooks/useConfig';
 import type { TdStickyItemProps, TdStickyToolProps } from './type';
-import Popup, { PopupProps } from '../popup';
+import Popup, { PopupPlacement, PopupProps } from '../popup';
 import type { StyledProps, Styles } from '../common';
 
 export interface StickyItemProps extends TdStickyItemProps, StyledProps {
@@ -16,7 +16,7 @@ export interface StickyItemProps extends TdStickyItemProps, StyledProps {
   children?: React.ReactNode;
 }
 
-const StickyItem = forwardRef((props: StickyItemProps, ref: React.Ref<HTMLDivElement>) => {
+const StickyItem = React.forwardRef<HTMLDivElement, StickyItemProps>((props, ref) => {
   const {
     icon,
     label,
@@ -34,8 +34,8 @@ const StickyItem = forwardRef((props: StickyItemProps, ref: React.Ref<HTMLDivEle
     className,
   } = props;
   const { classPrefix } = useConfig();
-  const popupPlacement = useMemo(() => (placement.indexOf('right') !== -1 ? 'left' : 'right'), [placement]);
-  const styles = useMemo(() => {
+  const popupPlacement = useMemo<PopupPlacement>(() => (placement.includes('right') ? 'left' : 'right'), [placement]);
+  const styles = useMemo<React.CSSProperties>(() => {
     const styles: Styles = { ...style };
     if (baseWidth) {
       const selfWidth = type === 'normal' ? '56px' : '40px';

--- a/src/sticky-tool/StickyTool.tsx
+++ b/src/sticky-tool/StickyTool.tsx
@@ -6,6 +6,7 @@ import type { TdStickyToolProps, TdStickyItemProps } from './type';
 import type { StyledProps, Styles } from '../common';
 import StickyItem from './StickyItem';
 import { stickyToolDefaultProps } from './defaultProps';
+import useDefaultProps from '../hooks/useDefaultProps';
 
 export interface StickyToolProps extends TdStickyToolProps, StyledProps {
   children?: React.ReactNode;
@@ -14,10 +15,10 @@ export interface StickyToolProps extends TdStickyToolProps, StyledProps {
 const StickyTool = forwardRefWithStatics(
   (props: StickyToolProps, ref: React.Ref<HTMLDivElement>) => {
     const { style, className, children, width, type, shape, placement, offset, popupProps, list, onClick, onHover } =
-      props;
+      useDefaultProps<StickyToolProps>(props, stickyToolDefaultProps);
     const { classPrefix } = useConfig();
 
-    const styles = useMemo(() => {
+    const styles = useMemo<React.CSSProperties>(() => {
       const position: Array<string | number> = offset ? [80, 24] : ['80px', '24px'];
       offset?.forEach((item, index) => {
         position[index] = isNaN(Number(item))
@@ -33,7 +34,9 @@ const StickyTool = forwardRefWithStatics(
           styles.transform = 'translate(0, -50%)';
         }
       });
-      if (width) styles.width = typeof width === 'number' ? `${width}px` : width;
+      if (width) {
+        styles.width = typeof width === 'number' ? `${width}px` : width;
+      }
       return styles;
     }, [offset, placement, width, style]);
 
@@ -50,9 +53,9 @@ const StickyTool = forwardRefWithStatics(
       [onHover],
     );
 
-    const stickyItemList = useMemo(() => {
+    const stickyItemList = useMemo<React.ReactNode[]>(() => {
       if (list?.length) {
-        return list.map((item, index: number) => {
+        return list.map<React.ReactNode>((item, index: number) => {
           const itemProps = {
             ...item,
             type,
@@ -98,6 +101,5 @@ const StickyTool = forwardRefWithStatics(
 );
 
 StickyTool.displayName = 'StickyTool';
-StickyTool.defaultProps = stickyToolDefaultProps;
 
 export default StickyTool;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(StickyTool): `StickyTool` replace `defaultProps` with `useDefaultProp`

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供