### PR TITLE
fix: 🐛 replace defaultProps with useDefaultProp

### DIFF
--- a/src/time-picker/TimePicker.tsx
+++ b/src/time-picker/TimePicker.tsx
@@ -21,6 +21,7 @@ import { timePickerDefaultProps } from './defaultProps';
 
 import type { StyledProps } from '../common';
 import type { TdTimePickerProps } from './type';
+import useDefaultProps from '../hooks/useDefaultProps';
 
 // https://github.com/iamkun/dayjs/issues/1552
 dayjs.extend(customParseFormat);
@@ -28,7 +29,8 @@ dayjs.extend(customParseFormat);
 export interface TimePickerProps extends TdTimePickerProps, StyledProps {}
 
 const TimePicker = forwardRefWithStatics(
-  (props: TimePickerProps, ref: Ref<HTMLDivElement>) => {
+  (originalProps: TimePickerProps, ref: Ref<HTMLDivElement>) => {
+    const props = useDefaultProps<TimePickerProps>(originalProps, timePickerDefaultProps);
     const TEXT_CONFIG = useTimePickerTextConfig();
     const {
       allowInput,
@@ -147,6 +149,5 @@ const TimePicker = forwardRefWithStatics(
 );
 
 TimePicker.displayName = 'TimePicker';
-TimePicker.defaultProps = timePickerDefaultProps;
 
 export default TimePicker;

--- a/src/time-picker/TimeRangePicker.tsx
+++ b/src/time-picker/TimeRangePicker.tsx
@@ -16,12 +16,14 @@ import { TIME_PICKER_EMPTY } from '../_common/js/time-picker/const';
 import { TdTimeRangePickerProps, TimeRangeValue, TimeRangePickerPartial } from './type';
 import { StyledProps } from '../common';
 import { timeRangePickerDefaultProps } from './defaultProps';
+import useDefaultProps from '../hooks/useDefaultProps';
 
 export interface TimeRangePickerProps extends TdTimeRangePickerProps, StyledProps {}
 
 const defaultArrVal = [undefined, undefined];
 
-const TimeRangePicker: FC<TimeRangePickerProps> = (props) => {
+const TimeRangePicker: FC<TimeRangePickerProps> = (originalProps) => {
+  const props = useDefaultProps<TimeRangePickerProps>(originalProps, timeRangePickerDefaultProps);
   const TEXT_CONFIG = useTimePickerTextConfig();
 
   const {
@@ -172,6 +174,5 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (props) => {
 };
 
 TimeRangePicker.displayName = 'TimeRangePicker';
-TimeRangePicker.defaultProps = timeRangePickerDefaultProps;
 
 export default TimeRangePicker;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TimePicker): `TimePicker` replace `defaultProps` with `useDefaultProp`

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供