### PR TITLE
fix(Tree): fix setData not render tree-item

### DIFF
--- a/src/tree/TreeItem.tsx
+++ b/src/tree/TreeItem.tsx
@@ -8,6 +8,7 @@ import React, {
   DragEvent,
   isValidElement,
   useEffect,
+  useState,
 } from 'react';
 import classNames from 'classnames';
 import isFunction from 'lodash/isFunction';
@@ -25,6 +26,7 @@ import useConfig from '../hooks/useConfig';
 
 import type { TdTreeProps } from './type';
 import type { TreeItemProps } from './interface';
+import type { TypeTreeNodeData } from '../_common/js/tree-v1/types';
 
 /**
  * 树节点组件
@@ -210,11 +212,23 @@ const TreeItem = forwardRef(
     const [labelDom, setRefCurrent] = useDomRefCallback();
     useRipple(labelDom);
 
+    // setData需要强制刷新组件来更新数据
+    const [, updateRender] = useState({});
+
     const renderLabel = () => {
       const emptyView = locale('empty');
       let labelText: string | ReactNode = '';
       if (label instanceof Function) {
-        labelText = label(node.getModel()) || emptyView;
+        const { setData: nodeSetData, ...rest } = node.getModel();
+        labelText =
+          label({
+            ...rest,
+            // 拦截setData render tree-item
+            setData: (value: TypeTreeNodeData) => {
+              nodeSetData(value);
+              updateRender({});
+            },
+          }) || emptyView;
       } else {
         labelText = node.label || emptyView;
       }

--- a/src/tree/__tests__/tree.test.tsx
+++ b/src/tree/__tests__/tree.test.tsx
@@ -320,4 +320,71 @@ describe('Tree test', () => {
     await mockDelay(300);
     expect(container.querySelectorAll('.t-loading').length).toBe(1);
   });
+
+  test('custom label', async () => {
+    const data = [
+      {
+        label: '第1一段',
+        value: 1,
+        children: [
+          {
+            label: '第二段',
+            value: '1-1',
+          },
+        ],
+      },
+      {
+        label: '第二段',
+        value: 2,
+      },
+    ];
+    const { container } = await renderTreeWithProps({
+      data,
+      label: ({ data, setData }) =>
+        data.isEditing ? (
+          <input
+            className="tree-item-input"
+            defaultValue={data.label as string}
+            onBlur={(e) => {
+              console.log('blur', { ...data, isEditing: false });
+              setData({ ...data, label: e.target.value, isEditing: false });
+            }}
+            onKeyDown={(e) => {
+              console.log('keydown', e.key);
+              if (e.key === 'Enter') {
+                setData({ ...data, label: e.currentTarget.value, isEditing: false });
+                console.log('Enter setData({ ...data, name: e.target.value, isEditing: false })');
+              }
+              if (e.key === 'Escape') {
+                setData({ ...data, isEditing: false });
+                console.log('ESC setData({ ...data, isEditing: false })');
+              }
+            }}
+          />
+        ) : (
+          <span
+            className="tree-item-span"
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              setData({ ...data, isEditing: true });
+            }}
+          >
+            {data.label}
+          </span>
+        ),
+    });
+    await mockDelay(300);
+    expect(container.querySelector('.tree-item-span')).not.toBeNull();
+    fireEvent.dblClick(container.querySelector('.tree-item-span'));
+    await mockDelay(300);
+    expect(container.querySelector('.tree-item-input')).not.toBeNull();
+    fireEvent.change(container.querySelector('.tree-item-input'), { target: { value: '123' } });
+    expect(container.querySelector('.tree-item-input').value).toBe('123');
+    container.querySelector('.tree-item-input').focus();
+    container.querySelector('.tree-item-input').blur();
+    await mockDelay(300);
+    expect(container.querySelector('.tree-item-input')).toBeNull();
+    expect(container.querySelector('.tree-item-span')).not.toBeNull();
+    expect(container.querySelector('.tree-item-span').textContent).toBe('123');
+  });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #2609 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复`Tree` 自定义label `setData` 没有渲染的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 修复`Tree` 自定义label `setData` 没有渲染的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
