### PR TITLE
fix(image): forget pass referrerpolicy to real image tag props #2810

### DIFF
--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -132,7 +132,7 @@ const InternalImage: React.ForwardRefRenderFunction<HTMLDivElement, ImageProps> 
         //  这里添加setTimeout是因为CSR image渲染时，onError有时快有时慢，会导致执行顺序不同导致的bug
         setTimeout(() => {
           if (!isValid && !isFirstError.current) {
-            //  SSR模式下获取不到imaage的合成事件，暂时传递image实例
+            //  SSR模式下获取不到 image 的合成事件，暂时传递 image 实例
             handleError(imgRef.current);
           }
         }, 0);
@@ -146,7 +146,7 @@ const InternalImage: React.ForwardRefRenderFunction<HTMLDivElement, ImageProps> 
     if (imgRef.current) {
       const { complete, naturalWidth, naturalHeight } = imgRef.current;
       if (complete && naturalWidth !== 0 && naturalHeight !== 0) {
-        //  SSR模式下获取不到imaage的合成事件，暂时传递image实例
+        //  SSR模式下获取不到 image 的合成事件，暂时传递 image 实例
         handleLoad(imgRef.current);
       }
     }

--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -35,7 +35,6 @@ const InternalImage: React.ForwardRefRenderFunction<HTMLDivElement, ImageProps> 
     className,
     src,
     style,
-    alt,
     fit,
     position,
     shape,
@@ -50,8 +49,14 @@ const InternalImage: React.ForwardRefRenderFunction<HTMLDivElement, ImageProps> 
     fallback,
     onLoad,
     onError,
-    ...rest
+    ...waitPassRest
   } = props;
+  const {
+    // penetrate pass to image tag element props
+    alt,
+    referrerpolicy,
+    ...rest
+  } = waitPassRest;
 
   const { classPrefix } = useConfig();
   const imageRef = useRef<HTMLDivElement>(null);
@@ -197,6 +202,7 @@ const InternalImage: React.ForwardRefRenderFunction<HTMLDivElement, ImageProps> 
           `${classPrefix}-image--position-${position}`,
         )}
         alt={alt}
+        referrerPolicy={referrerpolicy}
       />
     );
   };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2810

### 💡 需求背景和解决方案

参数未传递到正确的节点上

### 📝 更新日志

- fix(image): referrerpolicy 参数被错误传递到外层 div 上，实际传递目标为原生 image 标签

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
