### PR TITLE
fix(Guide): fix guide initial position in ssr

### DIFF
--- a/src/guide/Guide.tsx
+++ b/src/guide/Guide.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import isFunction from 'lodash/isFunction';
 import cx from 'classnames';
 import { createPortal } from 'react-dom';
@@ -12,6 +12,7 @@ import setStyle from '../_common/js/utils/set-style';
 import useControlled from '../hooks/useControlled';
 import { guideDefaultProps } from './defaultProps';
 import useDefaultProps from '../hooks/useDefaultProps';
+import useIsomorphicLayoutEffect from '../_util/useLayoutEffect';
 
 export type GuideProps = TdGuideProps;
 
@@ -88,7 +89,6 @@ const Guide: React.FC<GuideProps> = (originalProps) => {
 
   const showPopupGuide = () => {
     currentHighlightLayerElm.current = getTargetElm(currentStepInfo.element);
-
     setTimeout(() => {
       scrollToParentVisibleArea(currentHighlightLayerElm.current);
       setHighlightLayerPosition(highlightLayerRef.current);
@@ -104,6 +104,7 @@ const Guide: React.FC<GuideProps> = (originalProps) => {
   const showDialogGuide = () => {
     setTimeout(() => {
       currentHighlightLayerElm.current = dialogTooltipRef.current;
+
       scrollToParentVisibleArea(currentHighlightLayerElm.current);
       setHighlightLayerPosition(highlightLayerRef.current);
       scrollToElm(currentHighlightLayerElm.current);
@@ -179,7 +180,7 @@ const Guide: React.FC<GuideProps> = (originalProps) => {
     }
   };
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (innerCurrent >= 0 && innerCurrent < steps.length) {
       initGuide();
     } else {
@@ -189,7 +190,7 @@ const Guide: React.FC<GuideProps> = (originalProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [innerCurrent]);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     initGuide();
 
     return destroyGuide;

--- a/src/guide/Guide.tsx
+++ b/src/guide/Guide.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import isFunction from 'lodash/isFunction';
 import cx from 'classnames';
 import { createPortal } from 'react-dom';
@@ -193,9 +193,14 @@ const Guide: React.FC<GuideProps> = (originalProps) => {
   useIsomorphicLayoutEffect(() => {
     initGuide();
 
-    return destroyGuide;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(
+    () => destroyGuide,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   const renderOverlayLayer = () =>
     createPortal(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- createPortal 在 SSR 场景不会执行，在 SSR 中使用 Guide 初始化时会找不到节点，导致高亮渲染位置错位，调整为useLayoutEffect 保证在 Client 运行
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Guide): 修复`Guide`组件在`SSR`场景初始化渲染位置异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
