### PR TITLE
fix(color-picker): 修复切换预览颜色时，通道按钮位置不变的问题

### DIFF
--- a/src/color-picker/hooks/useStyles.ts
+++ b/src/color-picker/hooks/useStyles.ts
@@ -16,9 +16,9 @@ const useStyles = (params: TdColorSliderStyleParams, panelRectRef) => {
     if (!width) {
       return;
     }
-    const left = Math.round((Number(value) / Number(maxValue)) * width);
+    const left = Math.round((Number(value) / Number(maxValue)) * 100);
     setStyles({
-      left: `${left}px`,
+      left: `${left}%`,
       color: color.rgb,
     });
     // eslint-disable-next-line


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

![image](https://github.com/Tencent/tdesign-vue-next/assets/89014758/bb09889c-597a-427a-99b6-0c7acedd1328)

修复方案：将原来 left 的 px 调整为百分比

### 📝 更新日志

- fix(color-picker): 修复切换预览颜色时，通道按钮位置不变的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
