### PR TITLE
fix(Upload): fix manual uploadFilePercent not update display

### DIFF
--- a/src/upload/hooks/useUpload.ts
+++ b/src/upload/hooks/useUpload.ts
@@ -28,6 +28,7 @@ export default function useUpload(props: TdUploadProps) {
   const xhrReq = useRef<{ files: UploadFile[]; xhrReq: XMLHttpRequest }[]>([]);
   const [toUploadFiles, setToUploadFiles] = useState<UploadFile[]>([]);
   const [sizeOverLimitMessage, setSizeOverLimitMessage] = useState('');
+  const [update, forceUpdate] = useState({});
 
   const locale = useMemo(() => merge({}, globalLocale, props.locale), [globalLocale, props.locale]);
 
@@ -59,7 +60,7 @@ export default function useUpload(props: TdUploadProps) {
       isBatchUpload,
     });
     setDisplayFiles(files);
-  }, [props.multiple, toUploadFiles, uploadValue, autoUpload, isBatchUpload]);
+  }, [props.multiple, toUploadFiles, uploadValue, autoUpload, isBatchUpload, update]);
 
   const uploadFilePercent = (params: { file: UploadFile; percent: number }) => {
     const { file, percent } = params;
@@ -71,6 +72,11 @@ export default function useUpload(props: TdUploadProps) {
     } else {
       const index = uploadValue.findIndex((item) => file.raw === item.raw);
       uploadValue[index] = { ...uploadValue[index], percent };
+      /**
+       * 使用强制更新，修复手动自定义上传的percent无效
+       * https://github.com/Tencent/tdesign-react/issues/2893
+       */
+      forceUpdate({});
     }
   };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #2893
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
- `before`:
之前手动自定义上传百分比进度只是修改`uploadValue`里面的值，没触发更新`displayFiles`

- `after`:
后面添加个一个`forceUpdate`来手动更新时，强制触发更新`displayFiles`

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Upload): 修复手动修改上传进度的bug

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
