### PR TITLE
fix(Form): formitem change not trigger useWatch of formlist

### DIFF
--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -456,7 +456,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
 
     filterRules.length && validate('change');
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formValue]);
+  }, [formValue, name]);
 
   // 暴露 ref 实例方法
   const instance: FormItemInstance = {

--- a/src/form/hooks/useWatch.ts
+++ b/src/form/hooks/useWatch.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import get from 'lodash/get';
+import isUndefined from 'lodash/isUndefined';
 import type { NamePath } from '../type';
 import type { InternalFormInstance } from './interface';
 import { HOOK_MARK } from './useForm';
@@ -18,26 +19,25 @@ export default function useWatch(name: NamePath, form: InternalFormInstance) {
 
     const { registerWatch = noop } = form.getInternalHooks?.(HOOK_MARK);
 
-    const cancelRegister = registerWatch((_values, paths) => {
-      if (String(name) !== String(paths)) return;
+    const cancelRegister = registerWatch(() => {
       const allFieldsValue = form.getFieldsValue?.(true);
       const newValue = get(allFieldsValue, name);
       const nextValueStr = JSON.stringify(newValue);
-
+      console.log('first', valueStrRef.current !== nextValueStr);
       // Compare stringify in case it's nest object
       if (valueStrRef.current !== nextValueStr) {
         valueStrRef.current = nextValueStr;
-        setValue(newValue);
+        setValue(nextValueStr);
       }
     });
 
     const allFieldsValue = form.getFieldsValue?.(true);
     const initialValue = get(allFieldsValue, name);
-    setValue(initialValue);
+    setValue(JSON.stringify(initialValue));
 
     return cancelRegister;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return value;
+  return isUndefined(value) ? value : JSON.parse(value);
 }

--- a/src/form/hooks/useWatch.ts
+++ b/src/form/hooks/useWatch.ts
@@ -23,7 +23,7 @@ export default function useWatch(name: NamePath, form: InternalFormInstance) {
       const allFieldsValue = form.getFieldsValue?.(true);
       const newValue = get(allFieldsValue, name);
       const nextValueStr = JSON.stringify(newValue);
-      console.log('first', valueStrRef.current !== nextValueStr);
+
       // Compare stringify in case it's nest object
       if (valueStrRef.current !== nextValueStr) {
         valueStrRef.current = nextValueStr;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
上一次修复 [issue](https://github.com/Tencent/tdesign-react/issues/2809) 在`useWatch`判断name是否相等 [PR](https://github.com/Tencent/tdesign-react/pull/2853) ，导致监听`FormList`不会触发

解决方案:
`FormItem`添加`name`依赖来触发`notify`,然后在`useWatch`的存的值转换成`string`来对比可以解决`setState`在一些数组或者
对象中的导致的re-render问题

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): `FormItem`的修改，没有触发监听`FormList`的`useWatch`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
