### PR TITLE
fix(cascader): fix Cascader filterable checkStrictly parent node not display

### DIFF
--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -138,7 +138,8 @@ const Item = forwardRef(
         }}
       >
         {multiple ? RenderCheckBox(node, cascaderContext) : RenderLabelContent(node, cascaderContext)}
-        {node.children &&
+        {!cascaderContext.inputVal &&
+          node.children &&
           (node.loading ? (
             <TLoading className={iconClass} loading={true} size="small" />
           ) : (

--- a/src/cascader/core/className.ts
+++ b/src/cascader/core/className.ts
@@ -33,7 +33,7 @@ export function getNodeStatusClass(
   STATUS: Record<string, string>,
   cascaderContext: CascaderContextType,
 ) {
-  const { checkStrictly, multiple, value, max } = cascaderContext;
+  const { checkStrictly, multiple, value, max, inputVal } = cascaderContext;
   const expandedActive =
     (!checkStrictly && node.expanded && (multiple ? !node.isLeaf() : true)) || (checkStrictly && node.expanded);
 
@@ -46,7 +46,7 @@ export function getNodeStatusClass(
   return [
     {
       [STATUS.selected]: !isDisabled && isSelected,
-      [STATUS.expanded]: !isDisabled && expandedActive,
+      [STATUS.expanded]: !isDisabled && !inputVal && expandedActive,
       [STATUS.disabled]: isDisabled,
     },
   ];

--- a/src/cascader/core/effect.ts
+++ b/src/cascader/core/effect.ts
@@ -175,12 +175,13 @@ export const treeNodesEffect = (
   treeStore: CascaderContextType['treeStore'],
   setTreeNodes: CascaderContextType['setTreeNodes'],
   filter: CascaderContextType['filter'],
+  checkStrictly: CascaderContextType['checkStrictly'],
 ) => {
   if (!treeStore) return;
   let nodes = [];
   if (inputVal) {
     const filterMethods = (node: TreeNode) => {
-      if (!node.isLeaf()) return;
+      if (!checkStrictly && !node.isLeaf()) return;
       if (isFunction(filter)) {
         return filter(`${inputVal}`, node as TreeNodeModel & TreeNode);
       }

--- a/src/cascader/hooks.tsx
+++ b/src/cascader/hooks.tsx
@@ -95,7 +95,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
         onLoad: () => {
           setTimeout(() => {
             store.refreshNodes();
-            treeNodesEffect(inputVal, store, setTreeNodes, props.filter);
+            treeNodesEffect(inputVal, store, setTreeNodes, props.filter, checkStrictly);
           });
         },
       });
@@ -105,7 +105,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
       treeStore.reload(options);
       treeStore.refreshNodes();
       treeStoreExpendEffect(treeStore, scopeVal, []);
-      treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter);
+      treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter, checkStrictly);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
@@ -152,8 +152,8 @@ export const useCascaderContext = (props: TdCascaderProps) => {
 
   useEffect(() => {
     if (!treeStore) return;
-    treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter);
-  }, [inputVal, treeStore, props.filter]);
+    treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter, checkStrictly);
+  }, [inputVal, treeStore, props.filter, checkStrictly]);
 
   useEffect(() => {
     if (!treeStore) return;
@@ -168,7 +168,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
 
   useEffect(() => {
     const { inputVal, treeStore, setTreeNodes } = cascaderContext;
-    treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter);
+    treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter, checkStrictly);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputVal, scopeVal]);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #2910
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#### before:
`checkStrictly`模式下，`filterable`列表的父节点不显示,是在`treeNodesEffect`的函数里判断父节点都不显示

#### after:
所以在`treeNodesEffect`的函数修复

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复 `Cascader` 搜索时 `checkStrictly` 模式父节点不显示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
