### PR TITLE
fix(checkbox): render `0` number option as string

### DIFF
--- a/src/checkbox/CheckboxGroup.tsx
+++ b/src/checkbox/CheckboxGroup.tsx
@@ -152,21 +152,17 @@ const CheckboxGroup = <T extends CheckboxGroupValue = CheckboxGroupValue>(props:
       <CheckContext.Provider value={context}>
         {useOptions
           ? options.map((v: any, index) => {
-              const type = typeof v;
-              switch (type) {
-                case 'string': {
-                  const vs = v as string;
+              switch (typeof v) {
+                case 'string':
                   return (
-                    <Checkbox key={index} label={vs} value={vs}>
+                    <Checkbox key={index} label={v} value={v}>
                       {v}
                     </Checkbox>
                   );
-                }
                 case 'number': {
-                  const vs = v as number;
                   return (
-                    <Checkbox key={index} label={vs} value={vs}>
-                      {v}
+                    <Checkbox key={index} label={v} value={v}>
+                      {String(v)}
                     </Checkbox>
                   );
                 }

--- a/src/checkbox/__tests__/checkbox.test.tsx
+++ b/src/checkbox/__tests__/checkbox.test.tsx
@@ -76,6 +76,7 @@ describe('CheckboxGroup', () => {
           { value: '广州', label: '广州', disabled: true },
           { value: '北京', label: '北京', name: '北京' },
           1,
+          0,
           '重庆',
           { label: '全选', checkAll: true },
         ]}
@@ -83,6 +84,9 @@ describe('CheckboxGroup', () => {
     );
     fireEvent.click(container.firstChild.lastChild);
     expect(container.firstChild.firstChild).toHaveClass('t-is-checked');
+    const options = container.firstChild.childNodes;
+    // 0 is rendered as string '0'
+    expect(options.item(4).textContent).toBe('0');
   });
 
   test('value is string', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(checkbox): 无法渲染为值为 0 的选项

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
