### PR TITLE
fix(Table): fix empty content center position

### DIFF
--- a/src/table/TBody.tsx
+++ b/src/table/TBody.tsx
@@ -74,7 +74,7 @@ export default function TBody(props: TableBodyProps) {
       <td colSpan={columns.length}>
         <div
           className={classNames([tableBaseClass.empty, { [tableFullRowClasses.innerFullRow]: props.isWidthOverflow }])}
-          style={props.isWidthOverflow ? { width: `${props.tableWidth}px` } : {}}
+          style={props.isWidthOverflow ? { width: `${props.tableWidth.current}px` } : {}}
         >
           {props.empty || t(global.empty)}
         </div>
@@ -98,7 +98,7 @@ export default function TBody(props: TableBodyProps) {
         <td colSpan={columnLength}>
           <div
             className={classNames({ [tableFullRowClasses.innerFullRow]: isFixedToLeft })}
-            style={isFixedToLeft ? { width: `${props.tableWidth}px` } : {}}
+            style={isFixedToLeft ? { width: `${props.tableWidth.current}px` } : {}}
           >
             <div className={tableFullRowClasses.innerFullElement}>{fullRowNode}</div>
           </div>
@@ -168,7 +168,7 @@ export default function TBody(props: TableBodyProps) {
           row,
           index: rowIndex,
           columns,
-          tableWidth: props.tableWidth,
+          tableWidth: props.tableWidth.current,
           isWidthOverflow: props.isWidthOverflow,
         };
         const expandedContent = props.renderExpandedRow(p);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- 修复前未正常居中
<img width="746" alt="image" src="https://github.com/user-attachments/assets/24e12b32-f0fb-455c-8c4a-5179bd34d708">

- 修复后正常居中
<img width="781" alt="image" src="https://github.com/user-attachments/assets/5f87830e-cb57-4d6e-9ec4-ffcfa2cd89f5">

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- props.tableWidth是 MutableRefObject，current才是具体的number，此前直接使用 tableWidth 导致部分width 设置无法正常生效
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复空数据下展示内容没有居中展示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
