### PR TITLE
fix(TagInput): onDragSort capture context error caused by useRef

### DIFF
--- a/src/hooks/useDragSorter.tsx
+++ b/src/hooks/useDragSorter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 interface DragSortProps<T> {
   sortOnDraggable: boolean;
@@ -37,7 +37,6 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
   const [isDropped, setIsDropped] = useState(null);
   const [startInfo, setStartInfo] = useState({ nodeX: 0, nodeWidth: 0, mouseX: 0 });
 
-  const onDragSortRef = useRef(onDragSort);
   const onDragOver = useCallback(
     (e, index, record: T) => {
       e.preventDefault();
@@ -64,7 +63,7 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
         if (!overlap) return;
       }
 
-      onDragSortRef.current?.({
+      onDragSort({
         currentIndex: draggingIndex,
         current: dragStartData,
         target: record,
@@ -80,6 +79,7 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
       startInfo.nodeWidth,
       startInfo.mouseX,
       startInfo.nodeX,
+      onDragSort,
     ],
   );
 

--- a/src/hooks/useDragSorter.tsx
+++ b/src/hooks/useDragSorter.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import useEventCallback from './useEventCallback';
 
 interface DragSortProps<T> {
   sortOnDraggable: boolean;
@@ -36,6 +37,7 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
   const [dragStartData, setDragStartData] = useState(null);
   const [isDropped, setIsDropped] = useState(null);
   const [startInfo, setStartInfo] = useState({ nodeX: 0, nodeWidth: 0, mouseX: 0 });
+  const onDragSortEvent = useEventCallback(onDragSort);
 
   const onDragOver = useCallback(
     (e, index, record: T) => {
@@ -63,7 +65,7 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
         if (!overlap) return;
       }
 
-      onDragSort({
+      onDragSortEvent({
         currentIndex: draggingIndex,
         current: dragStartData,
         target: record,
@@ -79,7 +81,7 @@ function useDragSorter<T>(props: DragSortProps<T>): DragSortInnerProps {
       startInfo.nodeWidth,
       startInfo.mouseX,
       startInfo.nodeX,
-      onDragSort,
+      onDragSortEvent,
     ],
   );
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix([TagInput](https://tdesign.tencent.com/react/components/tag-input)): 如文档 [demo](https://tdesign.tencent.com/react/components/tag-input) 拖拽示例，新增数据拖拽会后丢失，因为 useRef 导致无法更新 onDragSort 函数，但是函数上下文已经被改变，旧的 onDragSort 函数上下文拿旧数据 tags1 ，导致拖拽调整顺序无法拿到最新的数据 tags1 进行正确的操作，还存在有时候拖拽无法交换的小问题，但起码不会丢失用户输入的内容

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
