### PR TITLE
fix(Tree): use useUpdateLayoutEffect fix bug

### DIFF
--- a/src/hooks/useUpdateLayoutEffect.ts
+++ b/src/hooks/useUpdateLayoutEffect.ts
@@ -1,0 +1,16 @@
+import type { DependencyList, EffectCallback } from 'react';
+import useIsFirstRender from './useIsFirstRender';
+import useIsomorphicLayoutEffect from './useLayoutEffect';
+
+const useUpdateLayoutEffect = (callback: EffectCallback, dependency: DependencyList) => {
+  const isFirstRender = useIsFirstRender();
+
+  useIsomorphicLayoutEffect(() => {
+    if (isFirstRender) return;
+
+    return callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependency);
+};
+
+export default useUpdateLayoutEffect;

--- a/src/tree/hooks/useStore.ts
+++ b/src/tree/hooks/useStore.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import useUpdateEffect from '../../hooks/useUpdateEffect';
+import useUpdateLayoutEffect from '../../hooks/useUpdateLayoutEffect';
 import usePrevious from '../../hooks/usePrevious';
 import TreeStore from '../../_common/js/tree-v1/tree-store';
 import { usePersistFn } from '../../hooks/usePersistFn';
@@ -157,7 +157,7 @@ export function useStore(props: TdTreeProps, refresh: () => void): TreeStore {
   /* ======== 由 props 引发的 store 更新 ======= */
   const store = storeRef.current;
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     if (data && Array.isArray(data)) {
       const expanded = store.getExpanded();
       const checked = store.getChecked();
@@ -170,7 +170,7 @@ export function useStore(props: TdTreeProps, refresh: () => void): TreeStore {
     }
   }, [data, store]);
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     store.setConfig({
       keys,
       expandAll,
@@ -207,26 +207,26 @@ export function useStore(props: TdTreeProps, refresh: () => void): TreeStore {
     valueMode,
   ]);
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     if (Array.isArray(value)) {
       store.replaceChecked(value);
     }
   }, [store, value, data]);
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     if (Array.isArray(expanded)) {
       const expandedArr = getExpandedArr(expanded, store);
       store.replaceExpanded(expandedArr);
     }
   }, [expanded, store]);
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     if (Array.isArray(actived)) {
       store.replaceActived(actived);
     }
   }, [actived, store]);
 
-  useUpdateEffect(() => {
+  useUpdateLayoutEffect(() => {
     store.setConfig({
       filter,
     });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
最近升级的版本，tree 如果用了 icon 自定义图标，tree 的点击展开会出问题，单点图标去展开，第一次还能生效展开/收起，后面就不生效了。
https://codesandbox.io/p/sandbox/tdesign-react-demo-n6mxjv
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): `Tree` 的数据更新需要使用 `useLayoutEffect` ,现在使用 `useUpdateLayoutEffect` 来修复上次更新使用 `useUpdateEffect` 的Bug

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
