### PR TITLE
fix(Popup): fix popup invisible position bug

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -18,6 +18,7 @@ import useWindowSize from '../hooks/useWindowSize';
 import { popupDefaultProps } from './defaultProps';
 import useDefaultProps from '../hooks/useDefaultProps';
 import useAttach from '../hooks/useAttach';
+import { getCssVarsValue } from '../_util/dom';
 
 export interface PopupProps extends TdPopupProps {
   // 是否触发展开收起动画，内部下拉式组件使用
@@ -114,15 +115,20 @@ const Popup = forwardRef<PopupRef, PopupProps>((originalProps, ref) => {
 
   const updateTimeRef = useRef(null);
   // 监听 trigger 节点或内容变化动态更新 popup 定位
-  useMutationObserver(getRefDom(triggerRef), () => {
-    clearTimeout(updateTimeRef.current);
-    updateTimeRef.current = setTimeout(() => popperRef.current?.update?.(), 0);
+  useMutationObserver(getRefDom(triggerRef), ([mutation]) => {
+    const isDisplayNone = getCssVarsValue('display', mutation.target as HTMLElement) === 'none';
+    if (visible && !isDisplayNone) {
+      clearTimeout(updateTimeRef.current);
+      updateTimeRef.current = setTimeout(() => popperRef.current?.update?.(), 0);
+    }
   });
   useEffect(() => () => clearTimeout(updateTimeRef.current), []);
 
   // 窗口尺寸变化时调整位置
   useEffect(() => {
-    requestAnimationFrame(() => popperRef.current?.update?.());
+    if (visible) {
+      requestAnimationFrame(() => popperRef.current?.update?.());
+    }
   }, [visible, content, windowHeight, windowWidth]);
 
   // 下拉展开时更新内部滚动条


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
https://jsfiddle.net/c6zn73ws/16/

当trigger元素为`display:none`时，会导致hide时popup定位闪烁隐藏；

修复方法:
1.`visible=true`时才更新`popup`定位
2.判断trigger元素为`display:none`时不更新定位
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 修复`popup`某些场景下，隐藏时定位会闪烁

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
