### PR TITLE
fix(popup): function component as triggerNode, but popup wont work

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -102,7 +102,7 @@ const Popup = forwardRef<PopupRef, PopupProps>((originalProps, ref) => {
     [placement],
   );
 
-  const { getTriggerNode, getPopupProps, getTriggerDom } = useTrigger({
+  const { getTriggerNode, getPopupProps } = useTrigger({
     triggerRef,
     content,
     disabled,
@@ -140,11 +140,10 @@ const Popup = forwardRef<PopupRef, PopupProps>((originalProps, ref) => {
 
   // 下拉展开时更新内部滚动条
   useEffect(() => {
-    if (!triggerRef.current) triggerRef.current = getTriggerDom();
     if (visible) {
       updateScrollTop?.(contentRef.current);
     }
-  }, [visible, updateScrollTop, getTriggerDom]);
+  }, [visible, updateScrollTop]);
 
   function handleExited() {
     !destroyOnClose && popupElement && (popupElement.style.display = 'none');

--- a/src/popup/hooks/useTrigger.tsx
+++ b/src/popup/hooks/useTrigger.tsx
@@ -1,5 +1,4 @@
-import React, { useRef, useEffect, isValidElement, useCallback, useMemo } from 'react';
-import { isFragment } from 'react-is';
+import React, { useRef, useEffect, useMemo } from 'react';
 import classNames from 'classnames';
 import { supportRef, getRefDom } from '../utils/ref';
 import composeRefs from '../../_util/composeRefs';
@@ -11,7 +10,6 @@ export default function useTrigger({ content, disabled, trigger, visible, onVisi
   const hasPopupMouseDown = useRef(false);
   const mouseDownTimer = useRef(0);
   const visibleTimer = useRef(null);
-  const triggerDataKey = useRef(`t-popup--${Math.random().toFixed(10)}`);
   const leaveFlag = useRef(false); // 防止多次触发显隐
 
   // 禁用和无内容时不展示
@@ -183,9 +181,6 @@ export default function useTrigger({ content, disabled, trigger, visible, onVisi
 
     if (supportRef(triggerNode)) {
       triggerProps.ref = composeRefs(triggerRef, (triggerNode as any).ref);
-    } else {
-      // 标记 trigger 元素
-      triggerProps['data-popup'] = triggerDataKey.current;
     }
 
     return triggerProps;
@@ -193,21 +188,12 @@ export default function useTrigger({ content, disabled, trigger, visible, onVisi
 
   // 整理 trigger 元素
   function getTriggerNode(children: React.ReactNode) {
-    const triggerNode =
-      isValidElement(children) && !isFragment(children) ? children : <span className="t-trigger">{children}</span>;
-
+    const triggerNode = <span className="t-trigger">{children}</span>;
     return React.cloneElement(triggerNode, getTriggerProps(triggerNode));
   }
-
-  // ref 透传失败时使用 dom 查找
-  const getTriggerDom = useCallback(() => {
-    if (typeof document === 'undefined') return {};
-    return document.querySelector(`[data-popup="${triggerDataKey.current}"]`);
-  }, []);
 
   return {
     getTriggerNode,
     getPopupProps,
-    getTriggerDom,
   };
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
```js
import React from 'react';
import { Popup } from 'tdesign-react';

function Button(props) {
  return <button>点击</button>;
}

export default function Disabled() {
  return (
    <Popup trigger="hover" disabled showArrow content="这是一个弹出框">
      <Button></Button>
    </Popup>
  );
}

点击无效
```
```js


解决方法：
1.给组件加一个data-popup,之后通过这个data-pop去找这个dom节点，这种情况直接去掉
2.不管子节点是什么，都在外层加一个<span/> 标签就行了
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): 修复函数组件点击不会出现popup问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
