### PR TITLE
fix: fix the error of image rotating too many times after reseting image

### DIFF
--- a/src/image-viewer/hooks/useRotate.ts
+++ b/src/image-viewer/hooks/useRotate.ts
@@ -1,14 +1,31 @@
 // 旋转控制
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 const useRotate = () => {
+  // There is an useEffect in the line 472 of ImageViewerModal.tsx, so we need to use a ref to store the rotateZ value.
+  const rotRef = useRef(0);
   const [rotateZ, setRotateZ] = useState(0);
 
   const onRotate = useCallback((ROTATE_COUNT: number) => {
-    setRotateZ((rotateZ) => rotateZ + ROTATE_COUNT);
+    setRotateZ((rotateZ) => {
+      rotRef.current = rotateZ + ROTATE_COUNT;
+      return rotateZ + ROTATE_COUNT;
+    });
   }, []);
 
-  const onResetRotate = useCallback(() => setRotateZ(0), []);
+  const onResetRotate = useCallback(() => {
+    let degreeToRotate = rotRef.current % 360;
+    // make sure we always rotate to the shortest direction
+    if (Math.abs(degreeToRotate) > 180) {
+      degreeToRotate = (degreeToRotate + 360) % 360;
+    }
+    if (degreeToRotate !== 0) {
+      setRotateZ((rotateZ) => {
+        rotRef.current = rotateZ - degreeToRotate;
+        return rotateZ - degreeToRotate;
+      });
+    }
+  }, []);
 
   return {
     rotateZ,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 💡 需求背景和解决方案

要解决的问题：修复图片预览旋转多次之后，点击重置后，图片旋转太多次的问题

实现方案：修改 useRotate 这个 hooks， 旋转多次之后， 寻找到离整除 360° 最近的角度，进行旋转， 而不是强制的将角度设置为 0

修改前: 
[screencast-tdesign_tencent_com-2024_09_18-17_41_37.webm](https://github.com/user-attachments/assets/81f307b2-f2e5-4121-bfef-878a14668af9)

修改后：
[screencast-localhost_15000-2024_09_18-17_42_35.webm](https://github.com/user-attachments/assets/ae8ecc7f-ec28-4d32-aa24-df37e36b745e)


### 📝 更新日志

1. 修复图片预览旋转多次之后，点击重置后，图片旋转太多次的问题


- fix(组件名称): ImageViewer

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
