### PR TITLE
fix(datepicker): range picker default time bug

### DIFF
--- a/src/date-picker/panel/RangePanel.tsx
+++ b/src/date-picker/panel/RangePanel.tsx
@@ -165,7 +165,7 @@ const RangePanel = forwardRef<HTMLDivElement, RangePanelProps>((originalProps, r
               partial={'start'}
               year={startYear}
               month={startMonth}
-              time={time[0]}
+              time={time[activeIndex]}
               tableData={startTableData}
               value={value}
               {...panelContentProps}
@@ -175,7 +175,7 @@ const RangePanel = forwardRef<HTMLDivElement, RangePanelProps>((originalProps, r
               partial={'end'}
               year={endYear}
               month={endMonth}
-              time={time[1]}
+              time={time[activeIndex]}
               value={value}
               tableData={endTableData}
               {...panelContentProps}

--- a/src/time-picker/TimeRangePicker.tsx
+++ b/src/time-picker/TimeRangePicker.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState, useEffect } from 'react';
 import classNames from 'classnames';
+import dayjs from 'dayjs';
 
 import { TimeIcon as TdTimeIcon } from 'tdesign-icons-react';
 import isArray from 'lodash/isArray';
@@ -109,6 +110,16 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (originalProps) => {
     handleOnPick(nextCurrentValue, context);
   };
 
+  const autoSwapTime = (valueBeforeConfirm: Array<string>) => {
+    const [startTime, endTime] = valueBeforeConfirm;
+    const startDayjs = dayjs(startTime, props.format);
+    const endDayjs = dayjs(endTime, props.format);
+
+    if (startDayjs.isAfter(endDayjs, 'second')) return [endTime, startTime];
+
+    return [startTime, endTime];
+  };
+
   const handleInputBlur = (value: TimeRangeValue, { e }: { e: React.FocusEvent<HTMLInputElement> }) => {
     if (allowInput) {
       const isValidTime = validateInputValue(currentValue[currentPanelIdx], format);
@@ -132,7 +143,7 @@ const TimeRangePicker: FC<TimeRangePickerProps> = (originalProps) => {
 
   const handleClickConfirm = () => {
     const isValidTime = !currentValue.find((v) => !validateInputValue(v, format));
-    if (isValidTime) onChange(currentValue);
+    if (isValidTime) onChange(autoSwapTime(currentValue));
     setPanelShow(false);
   };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/4566
- https://github.com/Tencent/tdesign-vue-next/issues/4427
- https://github.com/Tencent/tdesign-vue-next/issues/4382
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DateRangePicker): 修复日期区间选择器配置时间相关格式时，没有正确处理`defaultTime`的问题
- fix(DatePicker): 修复周选择器下，年份边界日期返回格式错误的问题
- feat(TimePicker): 支持时间区间选择器自动调整左右区间

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
