### PR TITLE
fix(color-picker): 修复useRef缓存引起的color实例内部属性未更新，导致的在Form中reset引起的死循环

### DIFF
--- a/src/color-picker/ColorPicker.tsx
+++ b/src/color-picker/ColorPicker.tsx
@@ -42,6 +42,7 @@ const ColorPicker: React.FC<ColorPickerProps> = (props) => {
             colorModes={colorModes}
             onChange={(value: string, context: TdColorContext) => setInnerValue(value, context)}
             ref={colorPanelRef}
+            key={innerValue}
           />
         )
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

tdesign-react ， Form 和 ColorPicker 一起用时，重置表单会直接进入死循环渲染，下面的例子，选颜色后，点重置，死循环渲染了 。
https://stackblitz.com/edit/react-fy5y49?file=src%2Fdemo.tsx

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1、在Form中reset事件会重置ColorPicker的value属性；
2、在ColorPanel中value变化会调用update方法；
3、colorInstanceRef中的originColor由于缓存问题和实际颜色不一致：
![image](https://github.com/user-attachments/assets/46e3d314-951f-4aed-9e90-b280f878cf41)
导致color实例的update方法没有进行更新：
![image](https://github.com/user-attachments/assets/bf090868-2b5f-417d-84e8-e3a5bcda39ff)
所以ColorPanel的useEffect中颜色对比不一致，导致update方法会循环触发：
![image](https://github.com/user-attachments/assets/6c41041e-5ca3-4f63-bb81-3919d6548220)
4、原因是在ColorPicker重绘时，useRef中使用的对象有奇妙的缓存问题：
![image](https://github.com/user-attachments/assets/71b131d9-91cd-48bd-8e42-82a94fdb453c)
新的color实例在useRef的时候originColor属性被还原了...


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件color-picker): 修复useRef缓存引起的color实例内部属性未更新，导致的在Form中reset引起的死循环

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
