### PR TITLE
feat(Table):  add the expandIconIndex API to configure the display position of the expandIcon

### DIFF
--- a/src/table/PrimaryTable.tsx
+++ b/src/table/PrimaryTable.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, forwardRef, useImperativeHandle, ReactNode, RefAttributes } from 'react';
 import get from 'lodash/get';
 import classNames from 'classnames';
+import { isNumber } from 'lodash';
 import BaseTable from './BaseTable';
 import useColumnController from './hooks/useColumnController';
 import useRowExpand from './hooks/useRowExpand';
@@ -28,7 +29,8 @@ export interface TPrimaryTableProps extends PrimaryTableProps, StyledProps {}
 
 const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((originalProps, ref) => {
   const props = useDefaultProps<TPrimaryTableProps>(originalProps, primaryTableDefaultProps);
-  const { columns, columnController, editableRowKeys, style, className } = props;
+  const { columns, columnController, editableRowKeys, style, className, expandIconIndex } = props;
+  console.log('expandIconIndex', expandIconIndex);
   const primaryTableRef = useRef(null);
   const innerPagination = useRef<PaginationProps>(props.pagination);
   const { classPrefix, tableDraggableClasses, tableBaseClass, tableSelectedClasses, tableSortClasses } = useClassName();
@@ -182,7 +184,12 @@ const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((originalPr
   const tColumns = (() => {
     const cols = getColumns(columns);
     if (showExpandIconColumn) {
-      cols.unshift(getExpandColumn());
+      const iconColumns = getExpandColumn();
+      if (isNumber(expandIconIndex)) {
+        cols.splice(expandIconIndex, 0, iconColumns);
+        return cols;
+      }
+      cols.unshift(iconColumns);
     }
     return cols;
   })();

--- a/src/table/PrimaryTable.tsx
+++ b/src/table/PrimaryTable.tsx
@@ -30,7 +30,6 @@ export interface TPrimaryTableProps extends PrimaryTableProps, StyledProps {}
 const PrimaryTable = forwardRef<PrimaryTableRef, TPrimaryTableProps>((originalProps, ref) => {
   const props = useDefaultProps<TPrimaryTableProps>(originalProps, primaryTableDefaultProps);
   const { columns, columnController, editableRowKeys, style, className, expandIconIndex } = props;
-  console.log('expandIconIndex', expandIconIndex);
   const primaryTableRef = useRef(null);
   const innerPagination = useRef<PaginationProps>(props.pagination);
   const { classPrefix, tableDraggableClasses, tableBaseClass, tableSelectedClasses, tableSortClasses } = useClassName();

--- a/src/table/PrimaryTable.tsx
+++ b/src/table/PrimaryTable.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, forwardRef, useImperativeHandle, ReactNode, RefAttributes } from 'react';
 import get from 'lodash/get';
 import classNames from 'classnames';
-import { isNumber } from 'lodash';
+import isNumber from 'lodash/isNumber';
 import BaseTable from './BaseTable';
 import useColumnController from './hooks/useColumnController';
 import useRowExpand from './hooks/useRowExpand';

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -431,6 +431,10 @@ export interface TdPrimaryTableProps<T extends TableRowData = TableRowData>
    */
   expandIcon?: boolean | TNode<ExpandArrowRenderParams<T>>;
   /**
+   * 配置expandIcon的显示位置
+   */
+  expandIconIndex?: number;
+  /**
    * 是否允许点击行展开
    */
   expandOnRowClick?: boolean;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1.Table 组件支持配置expandIndex 的位置
2. 增加expandIconIndex参数。


### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
