### PR TITLE
fix(Tabs): fix tabs tabPanel label change tabbar not update

### DIFF
--- a/src/tabs/TabBar.tsx
+++ b/src/tabs/TabBar.tsx
@@ -2,15 +2,17 @@ import React, { useEffect, useState, CSSProperties, useRef } from 'react';
 import classNames from 'classnames';
 import useConfig from '../hooks/useConfig';
 import useMutationObserver from '../hooks/useMutationObserver';
+import useResizeObserver from '../hooks/useResizeObserver';
 
 interface TabBarProps {
   tabPosition: string;
   activeId: string | number;
   containerRef: React.MutableRefObject<HTMLDivElement>;
+  navsWrapRef: React.MutableRefObject<HTMLDivElement>;
 }
 
 const TabBar: React.FC<TabBarProps> = (props) => {
-  const { tabPosition, activeId, containerRef } = props;
+  const { tabPosition, activeId, containerRef, navsWrapRef } = props;
   const { classPrefix } = useConfig();
   const [barStyle, setBarStyle] = useState<CSSProperties>({});
   const tabsClassPrefix = `${classPrefix}-tabs`;
@@ -65,6 +67,8 @@ const TabBar: React.FC<TabBarProps> = (props) => {
   );
 
   useMutationObserver(containerRef.current, handleMutationObserver);
+
+  useResizeObserver(navsWrapRef.current, computeStyle);
 
   return (
     <div

--- a/src/tabs/TabNav.tsx
+++ b/src/tabs/TabNav.tsx
@@ -190,7 +190,7 @@ const TabNav: React.FC<TabNavProps> = (props) => {
 
   // TabBar 组件逻辑层抽象，卡片类型时无需展示，故将逻辑整合到此处
   const TabBarCom = isCard ? null : (
-    <TabBar tabPosition={placement} activeId={activeIndex} containerRef={navsWrapRef} />
+    <TabBar tabPosition={placement} activeId={activeIndex} containerRef={navsWrapRef} navsWrapRef={navsWrapRef} />
   );
 
   const handleTabItemRemove = (removeItem) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3132
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#### 监听`navsWrapRef`元素的宽度来更新激活的选项卡底部横线，但是这里就会有个情况，在可编辑和新增的选项卡，也会触发底部横线的事件
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复`TabPanel` 的`label`改变时，激活的选项卡底部横线没更新

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
