### PR TITLE
fix(Typography): fix Typography Ellipsis bug

### DIFF
--- a/src/typography/ellipsis/Truncate.tsx
+++ b/src/typography/ellipsis/Truncate.tsx
@@ -248,7 +248,7 @@ export default class Truncate extends React.Component<TruncateProps, TruncateSta
     const lines = [];
     const text = innerText(elements.text);
 
-    const textLines = text.split('\n').map((line) => line.split(' '));
+    const textLines = text.split('\n').map((line) => line.split(''));
     let didTruncate = true;
     const ellipsisWidth = this.ellipsisWidth(this.elements.ellipsis);
 
@@ -263,7 +263,7 @@ export default class Truncate extends React.Component<TruncateProps, TruncateSta
         continue;
       }
 
-      let resultLine: string | React.JSX.Element = textWords.join(' ');
+      let resultLine: string | React.JSX.Element = textWords.join('');
       if (measureWidth(resultLine) <= targetWidth) {
         if (textLines.length === 1) {
           // Line is end of text and fits without truncating
@@ -278,7 +278,7 @@ export default class Truncate extends React.Component<TruncateProps, TruncateSta
 
       if (line === numLines) {
         // Binary search determining the longest possible line including truncate string
-        const textRest = textWords.join(' ');
+        const textRest = textWords.join('');
 
         let lower = 0;
         let upper = textRest.length - 1;
@@ -329,7 +329,7 @@ export default class Truncate extends React.Component<TruncateProps, TruncateSta
         while (lower <= upper) {
           const middle = Math.floor((lower + upper) / 2);
 
-          const testLine = textWords.slice(0, middle + 1).join(' ');
+          const testLine = textWords.slice(0, middle + 1).join('');
 
           if (measureWidth(testLine) <= targetWidth) {
             lower = middle + 1;
@@ -345,7 +345,7 @@ export default class Truncate extends React.Component<TruncateProps, TruncateSta
           continue;
         }
 
-        resultLine = textWords.slice(0, lower).join(' ');
+        resultLine = textWords.slice(0, lower).join('');
 
         resultLine = restoreReplacedLinks(resultLine);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3152 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
### before:
![before](https://github.com/user-attachments/assets/ce58ba41-a1c3-413f-9fe5-d31f2e2c2301)


### after:
![after](https://github.com/user-attachments/assets/8c49334b-80b5-4c38-8948-ea946c740266)

目前发现个问题，就是每个字符切割的话，会导致英文单词换行时是单个字符换行，需要考虑一下

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Typography): fix `Typography` Ellipsis bug

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
