### PR TITLE
fix(Drawer): use `FooterButton` props define `confirmBtn` and `closeBtn` are invalid

### DIFF
--- a/src/drawer/Drawer.tsx
+++ b/src/drawer/Drawer.tsx
@@ -162,12 +162,10 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
         <div style={footerStyle}>
           {placement === 'right' ? (
             <>
-              {' '}
-              {renderConfirmBtn} {renderCancelBtn}{' '}
+              {renderConfirmBtn} {renderCancelBtn}
             </>
           ) : (
             <>
-              {' '}
               {renderCancelBtn} {renderConfirmBtn}
             </>
           )}

--- a/src/drawer/Drawer.tsx
+++ b/src/drawer/Drawer.tsx
@@ -1,12 +1,16 @@
-import React, { forwardRef, useState, useEffect, useImperativeHandle, useRef, useMemo } from 'react';
+import React, { forwardRef, useState, useEffect, useImperativeHandle, useRef, useMemo, isValidElement } from 'react';
 import classnames from 'classnames';
+import isString from 'lodash/isString';
+import isObject from 'lodash/isObject';
+import isFunction from 'lodash/isFunction';
+
 import { CSSTransition } from 'react-transition-group';
 import { CloseIcon as TdCloseIcon } from 'tdesign-icons-react';
 
 import { useLocaleReceiver } from '../locale/LocalReceiver';
 import { TdDrawerProps, DrawerEventSource } from './type';
 import { StyledProps } from '../common';
-import Button from '../button';
+import Button, { ButtonProps } from '../button';
 import useConfig from '../hooks/useConfig';
 import useGlobalIcon from '../hooks/useGlobalIcon';
 import { drawerDefaultProps } from './defaultProps';
@@ -14,6 +18,7 @@ import useDrag from './hooks/useDrag';
 import Portal from '../common/Portal';
 import useLockStyle from './hooks/useLockStyle';
 import useDefaultProps from '../hooks/useDefaultProps';
+import parseTNode from '../_util/parseTNode';
 
 export const CloseTriggerType: { [key: string]: DrawerEventSource } = {
   CLICK_OVERLAY: 'overlay',
@@ -25,6 +30,12 @@ export const CloseTriggerType: { [key: string]: DrawerEventSource } = {
 export interface DrawerProps extends TdDrawerProps, StyledProps {}
 
 const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
+  // 国际化文本初始化
+  const [local, t] = useLocaleReceiver('drawer');
+  const { CloseIcon } = useGlobalIcon({ CloseIcon: TdCloseIcon });
+  const confirmText = t(local.confirm);
+  const cancelText = t(local.cancel);
+
   const props = useDefaultProps<DrawerProps>(originalProps, drawerDefaultProps);
   const {
     className,
@@ -49,28 +60,22 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
     body,
     footer,
     closeBtn,
-    cancelBtn,
-    confirmBtn,
+    cancelBtn = cancelText,
+    confirmBtn = confirmText,
     zIndex,
     destroyOnClose,
     sizeDraggable,
     forceRender,
   } = props;
 
-  // 国际化文本初始化
-  const [local, t] = useLocaleReceiver('drawer');
-  const { CloseIcon } = useGlobalIcon({ CloseIcon: TdCloseIcon });
   const size = propsSize ?? local.size;
-  const confirmText = t(local.confirm);
-  const cancelText = t(local.cancel);
-
   const { classPrefix } = useConfig();
   const maskRef = useRef<HTMLDivElement>();
   const containerRef = useRef<HTMLDivElement>();
   const drawerWrapperRef = useRef<HTMLElement>(); // 即最终的 attach dom，默认为 document.body
   const prefixCls = `${classPrefix}-drawer`;
 
-  const closeIcon = React.isValidElement(closeBtn) ? closeBtn : <CloseIcon />;
+  const closeIcon = isValidElement(closeBtn) ? closeBtn : <CloseIcon />;
   const { dragSizeValue, enableDrag, draggableLineStyles } = useDrag(placement, sizeDraggable, onSizeDragEnd);
   const [animationStart, setAnimationStart] = useState(visible);
 
@@ -119,37 +124,59 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
     [visible, placement, sizeValue, animationStart],
   );
 
-  function getFooter(): React.ReactNode {
-    if (footer !== true) return footer;
+  const renderDrawerButton = (btn: DrawerProps['cancelBtn'], defaultProps: ButtonProps) => {
+    let result = null;
 
-    const defaultCancelBtn = (
-      <Button theme="default" onClick={onCancelClick} className={`${prefixCls}__cancel`}>
-        {cancelBtn && typeof cancelBtn === 'string' ? cancelBtn : cancelText}
-      </Button>
-    );
+    if (isString(btn)) {
+      result = <Button {...defaultProps}>{btn}</Button>;
+    } else if (isValidElement(btn)) {
+      result = btn;
+    } else if (isObject(btn)) {
+      result = <Button {...defaultProps} {...(btn as {})} />;
+    } else if (isFunction(btn)) {
+      result = btn();
+    }
 
-    const defaultConfirmBtn = (
-      <Button theme="primary" onClick={onConfirmClick} className={`${prefixCls}__confirm`}>
-        {confirmBtn && typeof confirmBtn === 'string' ? confirmBtn : confirmText}
-      </Button>
-    );
+    return result;
+  };
 
-    const renderCancelBtn = cancelBtn && React.isValidElement(cancelBtn) ? cancelBtn : defaultCancelBtn;
-    const renderConfirmBtn = confirmBtn && React.isValidElement(confirmBtn) ? confirmBtn : defaultConfirmBtn;
+  const renderFooter = () => {
+    const defaultFooter = () => {
+      const renderCancelBtn = renderDrawerButton(cancelBtn, {
+        theme: 'default',
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => onCancelClick?.(e),
+        className: `${prefixCls}__cancel`,
+      });
+      const renderConfirmBtn = renderDrawerButton(confirmBtn, {
+        theme: 'primary',
+        onClick: (e: React.MouseEvent<HTMLButtonElement>) => onConfirmClick?.(e),
+        className: `${prefixCls}__confirm`,
+      });
 
-    const footerStyle = {
-      display: 'flex',
-      justifyContent: placement === 'right' ? 'flex-start' : 'flex-end',
+      const footerStyle = {
+        display: 'flex',
+        justifyContent: placement === 'right' ? 'flex-start' : 'flex-end',
+      };
+
+      return (
+        <div style={footerStyle}>
+          {placement === 'right' ? (
+            <>
+              {' '}
+              {renderConfirmBtn} {renderCancelBtn}{' '}
+            </>
+          ) : (
+            <>
+              {' '}
+              {renderCancelBtn} {renderConfirmBtn}
+            </>
+          )}
+        </div>
+      );
     };
 
-    return (
-      <div style={footerStyle}>
-        {placement === 'right' && renderConfirmBtn}
-        {renderCancelBtn}
-        {placement !== 'right' && renderConfirmBtn}
-      </div>
-    );
-  }
+    return <div className={`${prefixCls}__footer`}>{parseTNode(footer, null, defaultFooter())}</div>;
+  };
 
   const renderOverlay = showOverlay && (
     <CSSTransition in={visible} timeout={200} classNames={`${prefixCls}-fade`} nodeRef={maskRef}>
@@ -163,7 +190,6 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
   );
   const renderHeader = header && <div className={`${prefixCls}__header`}>{header}</div>;
   const renderBody = <div className={`${prefixCls}__body`}>{body || children}</div>;
-  const renderFooter = footer && <div className={`${prefixCls}__footer`}>{getFooter()}</div>;
 
   return (
     <CSSTransition
@@ -195,7 +221,7 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((originalProps, ref) => {
             {renderCloseBtn}
             {renderHeader}
             {renderBody}
-            {renderFooter}
+            {!!footer && renderFooter()}
             {sizeDraggable && <div style={draggableLineStyles} onMouseDown={enableDrag}></div>}
           </div>
         </div>

--- a/src/drawer/__tests__/drawer.test.tsx
+++ b/src/drawer/__tests__/drawer.test.tsx
@@ -65,18 +65,56 @@ describe('test Drawer', () => {
     fireEvent.click(getByText('Open'));
     expect(document.querySelector('.t-drawer__mask')).not.toBeInTheDocument();
   });
-  test('Drawer header and footer', () => {
+  test('Drawer header and footer custom', () => {
     const { getByText } = render(<DrawerDemo header={<div>自定义头部</div>} footer={<div>自定义底部</div>} />);
     fireEvent.click(getByText('Open'));
     expect(getByText('自定义头部').parentElement).toHaveClass('t-drawer__header');
     expect(getByText('自定义底部').parentElement).toHaveClass('t-drawer__footer');
   });
-  test('Drawer cancelBtn and confirmBtn', () => {
+  test('Drawer cancelBtn and confirmBtn custom', () => {
     const { getByText } = render(<DrawerDemo cancelBtn={<div>cancelBtn</div>} confirmBtn={<div>confirmBtn</div>} />);
     fireEvent.click(getByText('Open'));
-    expect(getByText('cancelBtn').parentElement.parentElement).toHaveClass('t-drawer__footer');
-    expect(getByText('confirmBtn').parentElement.parentElement).toHaveClass('t-drawer__footer');
+
+    const cancelBtn = getByText('cancelBtn');
+    const confirmBtn = getByText('confirmBtn');
+
+    expect(cancelBtn.parentElement.parentElement).toHaveClass('t-drawer__footer');
+    expect(confirmBtn.parentElement.parentElement).toHaveClass('t-drawer__footer');
   });
+
+  test('Drawer cancelBtn and confirmBtn props', () => {
+    const { getByText } = render(
+      <DrawerDemo
+        confirmBtn={{
+          content: '确认按钮',
+          theme: 'success',
+        }}
+        cancelBtn={{
+          content: '取消按钮',
+          theme: 'danger',
+        }}
+      />,
+    );
+    fireEvent.click(getByText('Open'));
+
+    const confirmBtn = getByText('确认按钮');
+    const cancelBtn = getByText('取消按钮');
+
+    // 是否有这两个元素
+    expect(cancelBtn).toBeInTheDocument();
+    expect(confirmBtn).toBeInTheDocument();
+
+    expect(confirmBtn.parentElement).toHaveClass('t-drawer__confirm');
+    expect(cancelBtn.parentElement).toHaveClass('t-drawer__cancel');
+    expect(confirmBtn.parentElement.parentElement.parentElement).toHaveClass('t-drawer__footer');
+    expect(cancelBtn.parentElement.parentElement.parentElement).toHaveClass('t-drawer__footer');
+
+    expect(confirmBtn.parentElement).toHaveClass(`t-button--theme-success`);
+    expect(cancelBtn.parentElement).toHaveClass(`t-button--theme-danger`);
+    expect(confirmBtn).toMatchSnapshot();
+    expect(cancelBtn).toMatchSnapshot();
+  });
+
   test('Drawer mode push', () => {
     const { getByText } = render(<DrawerDemo attach="body" mode="push" />);
     fireEvent.click(getByText('Open'));

--- a/src/drawer/__tests__/drawer.test.tsx
+++ b/src/drawer/__tests__/drawer.test.tsx
@@ -111,8 +111,6 @@ describe('test Drawer', () => {
 
     expect(confirmBtn.parentElement).toHaveClass(`t-button--theme-success`);
     expect(cancelBtn.parentElement).toHaveClass(`t-button--theme-danger`);
-    expect(confirmBtn).toMatchSnapshot();
-    expect(cancelBtn).toMatchSnapshot();
   });
 
   test('Drawer mode push', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Drawer):  无法使用 `FooterButton` 属性自定义`confirmBtn` 和 `closeBtn`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
