### PR TITLE
fix(Form): setFieldsValue and setFields should trigger onValuesChange

### DIFF
--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -367,7 +367,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
     }
     if (typeof value !== 'undefined') {
       // 手动设置 status 则不需要校验 交给用户判断
-      updateFormValue(value, typeof status === 'undefined' ? true : false);
+      updateFormValue(value, typeof status === 'undefined' ? true : false, true);
     }
   }
 

--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -458,7 +458,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
     value: formValue,
     isUpdated: isUpdatedRef.current,
     getValue: () => valueRef.current,
-    setValue: (newVal: any) => updateFormValue(newVal),
+    setValue: (newVal: any) => updateFormValue(newVal, true, true),
     setField,
     validate,
     validateOnly,

--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -41,6 +41,8 @@ describe('Form 组件测试', () => {
   });
 
   test('form instance', async () => {
+    const fn = vi.fn();
+
     const TestForm = () => {
       const [form] = Form.useForm();
 
@@ -71,7 +73,7 @@ describe('Form 组件测试', () => {
       }
 
       return (
-        <Form form={form} labelWidth={100} colon>
+        <Form form={form} labelWidth={100} colon onValuesChange={fn}>
           <FormItem label="input1" name="input1" rules={[{ required: true, message: 'input1 未填写', type: 'error' }]}>
             <Input placeholder="input1" />
           </FormItem>
@@ -93,8 +95,12 @@ describe('Form 组件测试', () => {
     expect(getByPlaceholderText('input1').value).toEqual('');
     fireEvent.click(getByText('setFields'));
     expect(getByPlaceholderText('input1').value).toEqual('setFields');
+    expect(fn).toHaveBeenCalled();
+
     fireEvent.click(getByText('setFieldsValue'));
     expect(getByPlaceholderText('input1').value).toEqual('setFieldsValue');
+    expect(fn).toHaveBeenCalled();
+
     fireEvent.click(getByText('setValidateMessage'));
     expect(queryByText('message: setValidateMessage')).toBeTruthy();
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): 修复`setFieldsValue`和`setFields` 没有触发`onValuesChange`的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
