### PR TITLE
fix(ImageViewer): when the fix is ​​uncontrolled, onClose is always triggered

### DIFF
--- a/src/image-viewer/ImageViewer.tsx
+++ b/src/image-viewer/ImageViewer.tsx
@@ -22,7 +22,7 @@ const ImageViewer: React.FC<ImageViewerProps> = (originalProps) => {
 
   const imageViewerAttach = useAttach('imageViewer', attach);
   const [visible, setVisible] = useControlled(props, 'visible', (visible, context) => {
-    isFunction(props.onClose) && props.onClose(context);
+    !visible && props.onClose?.(context);
   });
 
   const [visibled, setVisibled] = useState(false);

--- a/src/image-viewer/ImageViewer.tsx
+++ b/src/image-viewer/ImageViewer.tsx
@@ -22,7 +22,7 @@ const ImageViewer: React.FC<ImageViewerProps> = (originalProps) => {
 
   const imageViewerAttach = useAttach('imageViewer', attach);
   const [visible, setVisible] = useControlled(props, 'visible', (visible, context) => {
-    !visible && props.onClose?.(context);
+    !visible && props?.onClose?.(context);
   });
 
   const [visibled, setVisibled] = useState(false);

--- a/src/image-viewer/__tests__/image-viewer.test.tsx
+++ b/src/image-viewer/__tests__/image-viewer.test.tsx
@@ -29,7 +29,7 @@ describe('ImageViewer', () => {
     });
 
     // 鼠标点击后，有元素
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(0);
     const imgModal = document.querySelector('.t-image-viewer__modal-pic');
     expect(imgModal).toBeTruthy();
 
@@ -39,7 +39,7 @@ describe('ImageViewer', () => {
       fireEvent.click(closeBtn);
     });
     // 点击后，没有元素存在
-    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
     await mockTimeout(() => expect(document.querySelector('.t-image-viewer-preview-image')).toBeNull());
   });
 
@@ -122,7 +122,7 @@ describe('ImageViewerMini', () => {
     act(() => {
       fireEvent.click(closeBtn);
     });
-    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -153,7 +153,7 @@ describe('ImageViewerModal', () => {
 
     // 模拟键盘事件
     await user.type(document.body, '{Escape}');
-    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
 
     await user.type(document.body, '{ArrowRight}');
     expect(onIndexChange).toHaveBeenCalledTimes(1);
@@ -166,7 +166,7 @@ describe('ImageViewerModal', () => {
     act(() => {
       fireEvent.click(mask);
     });
-    expect(onClose).toHaveBeenCalledTimes(3);
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 
   test('single', async () => {


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3238 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
when the fix is ​​uncontrolled, onClose is always triggered
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 修复不受控时，`visable`改变时都会触发`onClose`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
