### PR TITLE
fix(Form): fixed setFieldsValue is invalid when prop.name type is array

### DIFF
--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -8,7 +8,7 @@ import Button from '../../button';
 import Radio from '../../radio';
 import { HelpCircleIcon } from 'tdesign-icons-react';
 
-const { FormItem } = Form;
+const { FormItem, FormList } = Form;
 
 describe('Form 组件测试', () => {
   const submitFn = vi.fn();
@@ -114,6 +114,80 @@ describe('Form 组件测试', () => {
     expect(queryByText('input1 未填写')).toBeTruthy();
     fireEvent.click(getByText('clearValidate'));
     expect(queryByText('input1 未填写')).not.toBeTruthy();
+  });
+
+  test('form setFieldsValue', () => {
+    const mockName = 'name';
+    const mockName1 = 'name1';
+    const mockBirthday = '1996-01-24';
+    const mockBirthday1 = '1996-01-25';
+    const mockArea = '北京';
+    const mockArea1 = '北京';
+    const TestForm = () => {
+      const [form] = Form.useForm();
+      const handleSetFormData = () => {
+        form.setFieldsValue({
+          user: {
+            name: mockName1,
+          },
+          birthday: mockBirthday1,
+          address: [
+            {
+              area: mockArea1,
+            },
+          ],
+        });
+      };
+      return (
+        <Form
+          form={form}
+          initialData={{
+            user: {
+              name: mockName,
+            },
+            birthday: mockBirthday,
+            address: [
+              {
+                area: mockArea,
+              },
+            ],
+          }}
+        >
+          <FormItem label="姓名" name={['user', 'name']}>
+            <Input placeholder="name" />
+          </FormItem>
+          <FormItem label="生日" name="birthday">
+            <Input placeholder="birthday" />
+          </FormItem>
+          <FormList name="address">
+            {(fields) => (
+              <>
+                {fields.map(({ key, name, ...restField }) => (
+                  <FormItem key={key}>
+                    <FormItem {...restField} name={[name, 'area']} label="地区">
+                      <Input placeholder="area" />
+                    </FormItem>
+                  </FormItem>
+                ))}
+              </>
+            )}
+          </FormList>
+          <FormItem>
+            <Button onClick={handleSetFormData}>SetFormData</Button>
+          </FormItem>
+        </Form>
+      );
+    };
+
+    const { getByPlaceholderText, getByText } = render(<TestForm />);
+    expect((getByPlaceholderText('name') as HTMLInputElement).value).toBe(mockName);
+    expect((getByPlaceholderText('birthday') as HTMLInputElement).value).toBe(mockBirthday);
+    expect((getByPlaceholderText('area') as HTMLInputElement).value).toBe(mockArea);
+
+    fireEvent.click(getByText('SetFormData'));
+    expect((getByPlaceholderText('name') as HTMLInputElement).value).toBe(mockName1);
+    expect((getByPlaceholderText('birthday') as HTMLInputElement).value).toBe(mockBirthday1);
+    expect((getByPlaceholderText('area') as HTMLInputElement).value).toBe(mockArea1);
   });
 
   test('Form.reset works fine', async () => {

--- a/src/form/hooks/useInstance.tsx
+++ b/src/form/hooks/useInstance.tsx
@@ -1,5 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
+import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
 import set from 'lodash/set';
@@ -155,7 +156,20 @@ export default function useInstance(
 
     nameLists.forEach((nameList) => {
       const fieldValue = get(fields, nameList);
-      const formItemRef = formMapRef.current.get(nameList.length > 1 ? nameList : nameList[0]);
+
+      let formItemRef;
+      if (nameList.length > 1) {
+        // 如果是数组，由于内存地址不一致，不能直接使用 Map.get 获取到 formItemRef
+        for (const [mapNameList, _formItemRef] of formMapRef.current.entries()) {
+          if (isEqual(nameList, mapNameList)) {
+            formItemRef = _formItemRef;
+            break;
+          }
+        }
+      } else {
+        formItemRef = formMapRef.current.get(nameList[0]);
+      }
+
       if (formItemRef?.current) {
         formItemRef?.current?.setValue?.(fieldValue, fields);
       } else {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

当 FormItem prop.name 是数组时，使用 setFieldsValue 赋值无效

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

如果 props.name 是数组，遍历 formMapRef.current.entries()，使用 lodash/isEqual 比较两个数组内容是否一致

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): 修复`1.9.3`版本后多级表单字段使用 `setFieldValues` 功能异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
