### PR TITLE
feat(alert): optimize collapse behavior

### DIFF
--- a/src/alert/Alert.tsx
+++ b/src/alert/Alert.tsx
@@ -47,7 +47,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   } = useDefaultProps(props, alertDefaultProps);
 
   const [closed, setClosed] = React.useState(false);
-  const [collapsed, setCollapsed] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(true);
 
   const iconMap = {
     success: CheckCircleFilledIcon,
@@ -62,7 +62,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   };
 
   const handleCollapse = () => {
-    setCollapsed(!collapsed);
+    setCollapsed((collapsed) => !collapsed);
   };
 
   const renderIconNode = () => {
@@ -75,8 +75,8 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
       return (
         <div className={`${classPrefix}-alert__description`}>
           {message.map((item, index) => {
-            if (!collapsed) {
-              if (index < maxLine) {
+            if (collapsed) {
+              if (index < +maxLine) {
                 return <div key={index}>{item}</div>;
               }
             } else {
@@ -84,9 +84,11 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
             }
             return true;
           })}
-          <div className={`${classPrefix}-alert__collapse`} onClick={handleCollapse}>
-            {!collapsed ? t(local.expandText) : t(local.collapseText)}
-          </div>
+          {+maxLine < message.length && (
+            <div className={`${classPrefix}-alert__collapse`} onClick={handleCollapse}>
+              {collapsed ? t(local.expandText) : t(local.collapseText)}
+            </div>
+          )}
         </div>
       );
     }

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -84,17 +84,20 @@ describe('Alert 组件测试', () => {
   });
 
   test('message not collapsed', () => {
-    const massage = [
+    const message = [
       <div key={0}>{text}</div>,
       <div key={1}>{text}</div>,
       <div key={2} data-testid={testId}>
         {text}
       </div>,
     ];
-    const { container } = render(<Alert title="title content" message={massage} />);
+    const { container } = render(<Alert title="title content" message={message} />);
+    const { container: container1 } = render(<Alert title="title content" message={message} maxLine={4} />);
 
     expect(container.querySelector('.t-alert__collapse')).toBeNull();
     expect(container.querySelector('.t-alert__collapse')).not.toBeInTheDocument();
+    expect(container1.querySelector('.t-alert__collapse')).toBeNull();
+    expect(container1.querySelector('.t-alert__collapse')).not.toBeInTheDocument();
   });
 
   test('Alert 展开收起操作', async () => {


### PR DESCRIPTION
When message's length is less than maxLine prop, it will not show the collapse button.

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

暂无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 当maxLine数量 >= 传入的message数量时，依然会展示【展开更多/收起】按钮，但点击无效果，如图，仅仅是按钮文字变化
![image](https://github.com/user-attachments/assets/f511c315-35b4-44a9-bec3-5d93afc56fce)
![image](https://github.com/user-attachments/assets/aa8d990e-53a4-443e-8d44-db852fdaf08e)
优化：当maxLine数量 < 传入的message数量时，即具备折叠条件时，才显示折叠按钮“
![image](https://github.com/user-attachments/assets/cdda143e-305d-4abd-adb6-6b3cbee465e1)
（注：图中示例的 maxLine 改为了 5）
2. 代码中的 **collpased** 布尔值用反了，collpased应该是【已折叠】的状态，根据组件的行为，初始应该为true
3. 增加了代码中的 maxLine 变量的健壮性处理
4. 补充了对应的单元测试，修正了单元测试代码中 message 误写为 massage 的错误



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Alert): 在 maxLine >= message 数组长度时，不再展示【展开更多/收起】按钮

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
