### PR TITLE
fix(form):  `value: [{ min: 0 }]` invalid and add test

### DIFF
--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -7,6 +7,7 @@ import Input from '../../input';
 import Button from '../../button';
 import Radio from '../../radio';
 import { HelpCircleIcon } from 'tdesign-icons-react';
+import InputNumber from '../../input-number';
 
 const { FormItem, FormList } = Form;
 
@@ -421,6 +422,62 @@ describe('Form 组件测试', () => {
     fireEvent.blur(getByPlaceholderText('username'));
     await mockDelay();
     expect(container.querySelector('.t-input__extra').innerHTML).toBe('please input username');
+  });
+
+  test('FormItem rules min max', async () => {
+    const TestForm = () => {
+      const initialValues = {
+        year1: -2,
+        year2: 1,
+        year3: 4,
+        year4: -4,
+        year5: -1,
+        year6: 2,
+      };
+      return (
+        <Form initialData={initialValues}>
+          <FormItem name="year1" rules={[{ min: -3, message: 'year1  error' }]}>
+            <InputNumber placeholder="year1" />
+          </FormItem>
+          <FormItem name="year2" rules={[{ min: 0, message: 'year2  error' }]}>
+            <InputNumber placeholder="year2" />
+          </FormItem>
+          <FormItem name="year3" rules={[{ min: 3, message: 'year3  error' }]}>
+            <InputNumber placeholder="year3" />
+          </FormItem>
+          <FormItem name="year4" rules={[{ max: -3, message: 'year4  error' }]}>
+            <InputNumber placeholder="year4" />
+          </FormItem>
+          <FormItem name="year5" rules={[{ max: 0, message: 'year5  error' }]}>
+            <InputNumber placeholder="year5" />
+          </FormItem>
+          <FormItem name="year6" rules={[{ max: 3, message: 'year6  error' }]}>
+            <InputNumber placeholder="year6" />
+          </FormItem>
+          <FormItem>
+            <Button type="submit">提交</Button>
+          </FormItem>
+        </Form>
+      );
+    };
+    const { container, getByText, getByPlaceholderText } = render(<TestForm />);
+    fireEvent.click(getByText('提交'));
+    await mockDelay();
+    expect(container.querySelector('.t-input__extra')).toBeNull();
+
+    // 错误验证
+    fireEvent.change(getByPlaceholderText('year1'), { target: { value: -4 } });
+    fireEvent.change(getByPlaceholderText('year2'), { target: { value: -1 } });
+    fireEvent.change(getByPlaceholderText('year3'), { target: { value: 2 } });
+    fireEvent.change(getByPlaceholderText('year4'), { target: { value: -2 } });
+    fireEvent.change(getByPlaceholderText('year5'), { target: { value: 1 } });
+    fireEvent.change(getByPlaceholderText('year6'), { target: { value: 4 } });
+    fireEvent.click(getByText('提交'));
+    await mockDelay();
+    const input__extraList = container.querySelectorAll('.t-input__extra');
+    input__extraList.forEach((item: { innerHTML: string }, index: number) => {
+      expect(item.innerHTML).toBe(`year${index + 1}  error`);
+    });
   });
 
   test('动态渲染并初始赋值', () => {

--- a/src/form/formModel.ts
+++ b/src/form/formModel.ts
@@ -54,7 +54,7 @@ const VALIDATE_MAP = {
   validator: (val: ValueType, validate: CustomValidator): ReturnType<CustomValidator> => validate(val),
 };
 
-export type ValidateFuncType = typeof VALIDATE_MAP[keyof typeof VALIDATE_MAP];
+export type ValidateFuncType = (typeof VALIDATE_MAP)[keyof typeof VALIDATE_MAP];
 
 /**
  * 校验某一条数据的某一条规则，一种校验规则不满足则不再进行校验。
@@ -75,7 +75,7 @@ export async function validateOneRule(value: ValueType, rule: FormRule): Promise
     }
     const validateRule: ValidateFuncType = VALIDATE_MAP[key];
     // 找到一个校验规则，则无需再找，因为参数只允许对一个规则进行校验
-    if (validateRule && rule[key]) {
+    if (validateRule && rule[key] !== undefined && rule[key] !== null) {
       // rule 值为 true 则表示没有校验参数，只是对值进行默认规则校验
       vOptions = rule[key] === true ? undefined : rule[key];
       vValidateFun = validateRule;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

经过排查发现 当前，当规则验证的数字为 0 时，会跳过规则验证

<img width="567" alt="_17344039992713" src="https://github.com/user-attachments/assets/616e72f9-6643-476b-ba4c-d0e7bac1725a" />

`rulelkey]` 为 0 ，则 `(validateRule && rulelkey])` 为 `false` ，实际需求为 `true`
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(form):  修复当规则为 `value: [{ min: 0 }]` 时，验证不生效的问题 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
