### PR TITLE
fix(statistic): decimalPlaces=0时数值动画期间精度错误

### DIFF
--- a/src/statistic/Statistic.tsx
+++ b/src/statistic/Statistic.tsx
@@ -16,7 +16,7 @@ import useIsFirstRender from '../hooks/useIsFirstRender';
 
 import Skeleton from '../skeleton';
 import Tween from '../_common/js/statistic/tween';
-import { COLOR_MAP } from '../_common/js/statistic/utils';
+import { COLOR_MAP, getFormatValue } from '../_common/js/statistic/utils';
 
 export interface StatisticProps extends TdStatisticProps, StyledProps {}
 
@@ -85,13 +85,9 @@ const Statistic = forwardRef<StatisticRef, StatisticProps>((props, ref) => {
     if (isFunction(format)) {
       return format(formatInnerValue);
     }
-    const options = {
-      minimumFractionDigits: decimalPlaces ?? 0,
-      maximumFractionDigits: decimalPlaces ?? 20,
-      useGrouping: !!separator,
-    };
+
     // replace的替换的方案仅能应对大部分地区
-    formatInnerValue = formatInnerValue.toLocaleString(undefined, options).replace(/,|，/g, separator);
+    formatInnerValue = getFormatValue(formatInnerValue, decimalPlaces, separator);
 
     return formatInnerValue;
   }, [innerValue, decimalPlaces, separator, format]);

--- a/src/statistic/Statistic.tsx
+++ b/src/statistic/Statistic.tsx
@@ -86,8 +86,8 @@ const Statistic = forwardRef<StatisticRef, StatisticProps>((props, ref) => {
       return format(formatInnerValue);
     }
     const options = {
-      minimumFractionDigits: decimalPlaces || 0,
-      maximumFractionDigits: decimalPlaces || 20,
+      minimumFractionDigits: decimalPlaces ?? 0,
+      maximumFractionDigits: decimalPlaces ?? 20,
       useGrouping: !!separator,
     };
     // replace的替换的方案仅能应对大部分地区


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-react/issues/3325
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(statistic): decimalPlaces=0时数值动画期间精度错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
