### PR TITLE
fix(Checkbox): fix checkboxGroup onChange context option param

### DIFF
--- a/src/checkbox/CheckboxGroup.tsx
+++ b/src/checkbox/CheckboxGroup.tsx
@@ -138,11 +138,14 @@ const CheckboxGroup = <T extends CheckboxGroupValue = CheckboxGroupValue>(props:
             checkedSet.delete(checkValue);
           }
 
+          const currentOptionChecked = optionsWithoutCheckAll.find((item) => item.value === checkValue);
+
           // 此处 `as` 是因为 `Array.from` 会导致 `checkSet` 的 generic type 丢失
           setInternalValue(Array.from(checkedSet) as T, {
             e,
             current: checkProps.checkAll ? undefined : (checkValue as TdCheckboxProps),
             type: checked ? 'check' : 'uncheck',
+            option: checkProps.checkAll ? undefined : currentOptionChecked,
           });
         },
       };

--- a/src/checkbox/type.ts
+++ b/src/checkbox/type.ts
@@ -118,5 +118,6 @@ export type CheckboxGroupValue = Array<string | number | boolean>;
 export interface CheckboxGroupChangeContext {
   e: ChangeEvent<HTMLDivElement>;
   current: CheckboxOption | TdCheckboxProps;
+  option: CheckboxOption | TdCheckboxProps;
   type: 'check' | 'uncheck';
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
checkbox.group的onChange的context参数缺少option

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CheckboxGroup): 修复onChange的context参数缺少option


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
