### PR TITLE
feat(cascader): support auto scroll to first selected element

### DIFF
--- a/src/cascader/Cascader.tsx
+++ b/src/cascader/Cascader.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import classNames from 'classnames';
-import { pick , omit } from 'lodash-es';
+import { pick, omit } from 'lodash-es';
 import Panel from './components/Panel';
 import SelectInput from '../select-input';
 import FakeArrow from '../common/FakeArrow';
@@ -91,6 +91,30 @@ const Cascader: React.FC<CascaderProps> = (originalProps) => {
   const renderValueDisplay = () => parseContentTNode(props.valueDisplay, valueDisplayParams);
 
   const { setVisible, visible, inputVal, setInputVal } = cascaderContext;
+
+  const updateScrollTop = (content: HTMLDivElement) => {
+    const cascaderMenuList = content.querySelectorAll(`.${COMPONENT_NAME}__menu`);
+    requestAnimationFrame(() => {
+      cascaderMenuList.forEach((menu: HTMLDivElement) => {
+        const firstSelectedNode: HTMLDivElement =
+          menu?.querySelector(`.${classPrefix}-is-selected`) || menu?.querySelector(`.${classPrefix}-is-expanded`);
+        if (!firstSelectedNode || !menu) return;
+
+        const { paddingBottom } = getComputedStyle(firstSelectedNode);
+        const { marginBottom } = getComputedStyle(menu);
+        const elementBottomHeight = parseInt(paddingBottom, 10) + parseInt(marginBottom, 10);
+
+        const updateValue =
+          firstSelectedNode.offsetTop -
+          menu.offsetTop -
+          (menu.clientHeight - firstSelectedNode.clientHeight) +
+          elementBottomHeight;
+        // eslint-disable-next-line no-param-reassign
+        menu.scrollTop = updateValue;
+      });
+    });
+  };
+
   return (
     <SelectInput
       className={classNames(COMPONENT_NAME, props.className)}
@@ -114,6 +138,7 @@ const Cascader: React.FC<CascaderProps> = (originalProps) => {
       valueDisplay={renderValueDisplay()}
       suffix={props.suffix}
       suffixIcon={renderSuffixIcon()}
+      updateScrollTop={updateScrollTop}
       popupProps={{
         ...props.popupProps,
         overlayInnerStyle: panels.length && !props.loading ? { width: 'auto' } : {},

--- a/src/cascader/_example/multiple.tsx
+++ b/src/cascader/_example/multiple.tsx
@@ -3,7 +3,7 @@ import { Cascader } from 'tdesign-react';
 import type { CascaderProps, CascaderValue } from 'tdesign-react';
 
 export default function Example() {
-  const [value, setValue] = useState<CascaderValue>(['1.1']);
+  const [value, setValue] = useState<CascaderValue>(['8.1']);
   const options = [
     {
       label: '选项一',
@@ -34,6 +34,90 @@ export default function Example() {
         {
           label: '子选项二',
           value: '2.2',
+        },
+      ],
+    },
+    {
+      label: '选项三',
+      value: '3',
+      children: [
+        {
+          label: '子选项一',
+          value: '3.1',
+        },
+        {
+          label: '子选项二',
+          value: '3.2',
+        },
+      ],
+    },
+    {
+      label: '选项四',
+      value: '4',
+      children: [
+        {
+          label: '子选项一',
+          value: '4.1',
+        },
+        {
+          label: '子选项二',
+          value: '4.2',
+        },
+      ],
+    },
+    {
+      label: '选项五',
+      value: '5',
+      children: [
+        {
+          label: '子选项一',
+          value: '5.1',
+        },
+        {
+          label: '子选项二',
+          value: '5.2',
+        },
+      ],
+    },
+    {
+      label: '选项六',
+      value: '6',
+      children: [
+        {
+          label: '子选项一',
+          value: '6.1',
+        },
+        {
+          label: '子选项二',
+          value: '6.2',
+        },
+      ],
+    },
+    {
+      label: '选项七',
+      value: '7',
+      children: [
+        {
+          label: '子选项一',
+          value: '7.1',
+        },
+        {
+          label: '子选项二',
+          value: '7.2',
+        },
+      ],
+    },
+    {
+      label: '选项8',
+      value: '8',
+      children: [
+        {
+          label: '子选项一',
+          value: '8.1',
+        },
+        {
+          label: '子选项二',
+          value: '8.2',
         },
       ],
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Cascader):  支持在打开菜单时滚动到首个已选项所在节点的能力

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
