### PR TITLE
fix(Textarea): fix autofocus cursor at the end

### DIFF
--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -130,8 +130,14 @@ const Textarea = forwardRef<TextareaRefInterface, TextareaProps>((originalProps,
 
   useIsomorphicLayoutEffect(() => {
     adjustTextareaHeight();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [textareaRef?.current]);
+    if (autofocus && textareaRef.current) {
+      const textarea = textareaRef.current;
+      textarea.focus();
+      // 将光标移到内容的末尾
+      textarea.selectionStart = textarea.value.length;
+      textarea.selectionEnd = textarea.value.length;
+    }
+  }, []);
 
   useIsomorphicLayoutEffect(() => {
     // 当未设置 autosize 时，需要将 textarea 的 height 设置为 auto，以支持原生的 textarea rows 属性

--- a/src/textarea/__tests__/textarea.test.tsx
+++ b/src/textarea/__tests__/textarea.test.tsx
@@ -85,4 +85,11 @@ describe('Textarea 组件测试', () => {
     expect(changeValue).not.toBeNull();
     expect(event).not.toBeNull();
   });
+
+  test('autofocus cursor end', async () => {
+    const value = 'test autofocus';
+    const { container } = render(<Textarea value={value} autofocus />);
+
+    expect(container.getElementsByTagName('textarea')[0].selectionStart).toBe(value.length);
+  });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3355

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
fix `autofocus`,`value` cursor not at the end bug
修复`autofocus`，`value`有值时的光标不在内容后面的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): 修复`autofocus`，`value`有值时光标不在内容后面的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
