### PR TITLE
fix(Radio): fix React19 radio-group stuck

### DIFF
--- a/src/radio/RadioGroup.tsx
+++ b/src/radio/RadioGroup.tsx
@@ -7,7 +7,6 @@ import useCommonClassName from '../hooks/useCommonClassName';
 import { StyledProps } from '../common';
 import { CheckContext, CheckContextValue } from '../common/Check';
 import Radio from './Radio';
-import useMutationObservable from '../hooks/useMutationObserver';
 import { radioGroupDefaultProps } from './defaultProps';
 import useDefaultProps from '../hooks/useDefaultProps';
 import useKeyboard from './useKeyboard';
@@ -86,8 +85,6 @@ const RadioGroup: React.FC<RadioGroupProps> = (originalProps) => {
   useEffect(() => {
     calcBarStyle();
   }, [radioGroupRef.current, internalValue]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useMutationObservable(radioGroupRef.current, calcBarStyle);
 
   const renderBlock = () => {
     if (!variant.includes('filled')) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3359
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在`React19`下，`mutationObserver` 会监听到`input`的`attributes` 属性变化，导致死循环

### React18
![image](https://github.com/user-attachments/assets/fa7472e5-f72f-4354-b2ba-5fd7f0abfc6b)

### React19
![image](https://github.com/user-attachments/assets/eac98045-7347-4193-8b60-81f605196fa6)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Radio): 修复`RadioGroup` 在 React 19 版本下异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
