### PR TITLE
fix(reactRender): fix React19 reactRender error

### DIFF
--- a/src/_util/react-render.ts
+++ b/src/_util/react-render.ts
@@ -2,6 +2,7 @@
 // @ts-ignore
 import type * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { createRoot as createRootClient } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 
 // Let compiler not to search module usage
@@ -16,13 +17,16 @@ const fullClone = {
 
 type CreateRoot = (container: ContainerType) => Root;
 
+// @ts-ignore
 const { version, render: reactRender, unmountComponentAtNode } = fullClone;
 
 let createRoot: CreateRoot;
 try {
   const mainVersion = Number((version || '').split('.')[0]);
-  if (mainVersion >= 18) {
+  if (mainVersion >= 18 && mainVersion < 19) {
     ({ createRoot } = fullClone);
+  } else if (mainVersion >= 19) {
+    createRoot = createRootClient;
   }
 } catch (e) {
   // Do nothing;

--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -110,8 +110,8 @@ const NotificationList = forwardRef<NotificationListInstance, NotificationListPr
           return (
             <NotificationComponent
               ref={props.ref}
-              key={props.key}
               {...props}
+              key={props.key}
               onDurationEnd={() => {
                 remove(props.key);
                 onDurationEnd();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #3375 
- #3378
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

React18和19导出createRoot是在`react-dom/client`中的；
为了兼容React17的reactRender，导出createRoot是在`react-dom`中的；

是否还要兼容React17及以下的渲染？
现在这种写法是为了兼容的，不兼容的话就改成react-dom/client现代的写法来处理

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(reactRender): fix `React19` `reactRender` error

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
