### PR TITLE
feat(ImageViewer): add download callback

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -5,7 +5,7 @@ import { ReactElement, ReactNode, CSSProperties, FormEvent, DragEvent, Synthetic
 // TElement 表示 API 只接受传入组件
 export type TElement<T = undefined> = T extends undefined ? ReactElement : (props: T) => ReactElement;
 // 1. TNode = ReactNode; 2. TNode<T> = (props: T) => ReactNode
-export type TNode<T = undefined> = T extends undefined ? ReactNode : ReactNode | ((props: T) => ReactNode);
+export type TNode<T = undefined> = T extends undefined ? ReactNode | (() => ReactNode) : ReactNode | ((props: T) => ReactNode);
 
 export type AttachNodeReturnValue = HTMLElement | Element | Document;
 export type AttachNode = CSSSelector | ((triggerNode?: HTMLElement) => AttachNodeReturnValue);

--- a/src/image-viewer/ImageViewer.tsx
+++ b/src/image-viewer/ImageViewer.tsx
@@ -73,6 +73,7 @@ const ImageViewer: React.FC<ImageViewerProps> = (originalProps) => {
             defaultIndex={props.defaultIndex}
             index={props.index}
             onIndexChange={props.onIndexChange}
+            onDownload={props.onDownload}
             draggable={props.draggable}
             closeOnOverlay={props.closeOnOverlay}
             closeBtn={props.closeBtn}

--- a/src/image-viewer/ImageViewerModal.tsx
+++ b/src/image-viewer/ImageViewerModal.tsx
@@ -234,6 +234,7 @@ interface ImageViewerUtilsProps {
     rotate: string;
     originsize: string;
   };
+  onDownload: TdImageViewerProps['onDownload'];
 }
 
 export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
@@ -245,6 +246,7 @@ export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
   onMirror,
   onReset,
   tipText,
+  onDownload
 }) => {
   const { classPrefix } = useConfig();
   const { MirrorIcon, RotationIcon, ImageIcon } = useGlobalIcon({
@@ -293,6 +295,10 @@ export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
             size="medium"
             name="download"
             onClick={() => {
+              if(isFunction(onDownload)){
+                onDownload(currentImage.mainImage)
+                return;
+              }
               downloadFile(currentImage.mainImage);
             }}
           />
@@ -387,6 +393,7 @@ export interface ImageModalProps {
   draggable: boolean;
   closeBtn: boolean | TNode;
   closeOnEscKeydown?: boolean;
+  onDownload?: TdImageViewerProps['onDownload'];
   onIndexChange?: (index: number, context: { trigger: 'prev' | 'next' }) => void;
   imageReferrerpolicy?: ImageViewerProps['imageReferrerpolicy'];
 }
@@ -409,6 +416,7 @@ export const ImageModal: React.FC<ImageModalProps> = (props) => {
     title,
     closeOnEscKeydown,
     imageReferrerpolicy,
+    onDownload,
     ...resProps
   } = props;
   const { classPrefix } = useConfig();
@@ -574,6 +582,7 @@ export const ImageModal: React.FC<ImageModalProps> = (props) => {
         currentImage={currentImage}
         onRotate={onRotate}
         onMirror={onMirror}
+        onDownload={onDownload}
         onReset={onReset}
         tipText={tipText}
       />

--- a/src/image-viewer/defaultProps.ts
+++ b/src/image-viewer/defaultProps.ts
@@ -5,6 +5,7 @@
 import { TdImageViewerProps } from './type';
 
 export const imageViewerDefaultProps: TdImageViewerProps = {
+  attach: 'body',
   closeBtn: true,
   closeOnEscKeydown: true,
   draggable: undefined,

--- a/src/image-viewer/image-viewer.en-US.md
+++ b/src/image-viewer/image-viewer.en-US.md
@@ -28,4 +28,5 @@ visible | Boolean | false | hide or show image viewer | N
 defaultVisible | Boolean | false | hide or show image viewer。uncontrolled property | N
 zIndex | Number | - | \- | N
 onClose | Function |  | Typescript：`(context: { trigger: 'close-btn' \| 'overlay' \| 'esc'; e: MouseEvent \| KeyboardEvent }) => void`<br/> | N
+onDownload | Function |  | Typescript：`(url: string \| File) => void`<br/> | N
 onIndexChange | Function |  | Typescript：`(index: number, context: { trigger: 'prev' \| 'next' \| 'current' }) => void`<br/> | N

--- a/src/image-viewer/image-viewer.md
+++ b/src/image-viewer/image-viewer.md
@@ -8,7 +8,7 @@
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
-attach | String / Function | 'body' | 制定挂载节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body。TS 类型：`AttachNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
+attach | String / Function | 'body' | 指定挂载节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body。TS 类型：`AttachNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 closeBtn | TNode | true | 是否展示关闭按钮，值为 `true` 显示默认关闭按钮；值为 `false` 则不显示关闭按钮；也可以完全自定义关闭按钮。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/src/common.ts) | N
 closeOnEscKeydown | Boolean | true | 按下 ESC 时是否触发图片预览器关闭事件 | N
 closeOnOverlay | Boolean | - | 是否在点击遮罩层时，触发预览关闭 | N
@@ -28,4 +28,5 @@ visible | Boolean | false | 隐藏/显示预览 | N
 defaultVisible | Boolean | false | 隐藏/显示预览。非受控属性 | N
 zIndex | Number | - | 层级，默认为 2000 | N
 onClose | Function |  | TS 类型：`(context: { trigger: 'close-btn' \| 'overlay' \| 'esc'; e: MouseEvent \| KeyboardEvent }) => void`<br/>关闭时触发，事件参数包含触发关闭的来源：关闭按钮、遮罩层、ESC 键 | N
+onDownload | Function |  | TS 类型：`(url: string \| File) => void`<br/>自定义预览图片下载操作，url为图片链接 | N
 onIndexChange | Function |  | TS 类型：`(index: number, context: { trigger: 'prev' \| 'next' \| 'current' }) => void`<br/>预览图片切换时触发，`context.prev` 切换到上一张图片，`context.next` 切换到下一张图片 | N

--- a/src/image-viewer/type.ts
+++ b/src/image-viewer/type.ts
@@ -9,7 +9,7 @@ import { MouseEvent, KeyboardEvent } from 'react';
 
 export interface TdImageViewerProps {
   /**
-   * 制定挂载节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body
+   * 指定挂载节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body
    * @default 'body'
    */
   attach?: AttachNode;
@@ -106,6 +106,10 @@ export interface TdImageViewerProps {
    * 关闭时触发，事件参数包含触发关闭的来源：关闭按钮、遮罩层、ESC 键
    */
   onClose?: (context: { trigger: 'close-btn' | 'overlay' | 'esc'; e: MouseEvent<HTMLElement> | KeyboardEvent }) => void;
+  /**
+   * 自定义预览图片下载操作，url为图片链接
+   */
+  onDownload?: (url: string | File) => void;
   /**
    * 预览图片切换时触发，`context.prev` 切换到上一张图片，`context.next` 切换到下一张图片
    */


### PR DESCRIPTION
增加download 预览图片下载回调

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [X] 新特性提交
- [X] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
解决图片预览时，用户需要自己定义图片下载的处理方式，增加对应的回调函数，如下onDownload
<ImageViewer trigger={trigger} images={[img]} onDownload={(url)=>{
        console.log(url)
      }}/>

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ImageViewer): 增加download 预览图片下载回调

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
