### PR TITLE
fix(drawer): fix drawer width value when dragging 

### DIFF
--- a/packages/components/drawer/hooks/useDrag.ts
+++ b/packages/components/drawer/hooks/useDrag.ts
@@ -10,10 +10,13 @@ const useDrag = (
 ) => {
   const [dragSizeValue, changeDragSizeValue] = useState<string>(null);
   // 使用 ref 来存储当前拖拽的宽度值
-  const dragSizeNumberRef = useRef<number>(0);
+  const dragSizeRef = useRef<number>(0);
 
   const handleMousemove = useCallback(
     (e: MouseEvent) => {
+      // 如果 sizeDraggable 是 boolean 值的 false，则不进行后续的计算
+      if (sizeDraggable === false) return;
+
       // 鼠标移动时计算draggedSizeValue的值
       const { x, y } = e;
 
@@ -26,9 +29,7 @@ const useDrag = (
       // x 轴方向使用默认最小宽度，y轴方向使用默认最小高度
       const min = placement === 'left' || placement === 'right' ? offsetWidth : offsetHeight;
 
-      const { allowSizeDraggable, max: limitMax, min: limitMin } = getSizeDraggable(sizeDraggable, { max, min });
-
-      if (!allowSizeDraggable) return;
+      const { max: limitMax, min: limitMin } = getSizeDraggable(sizeDraggable, { max, min });
 
       const moveSize = calcMoveSize(placement, {
         x,
@@ -41,7 +42,7 @@ const useDrag = (
 
       if (typeof moveSize === 'undefined') return;
       changeDragSizeValue(`${moveSize}px`);
-      dragSizeNumberRef.current = moveSize;
+      dragSizeRef.current = moveSize;
     },
     [placement, sizeDraggable],
   );
@@ -73,7 +74,7 @@ const useDrag = (
       onSizeDragEnd?.({
         e,
         // 此处不要使用 dragSizeValue，useState 的更新是异步的，在鼠标拖拽的同步操作中取不到最新的值
-        size: dragSizeNumberRef.current,
+        size: dragSizeRef.current,
       });
     },
     [handleMousemove, onSizeDragEnd],

--- a/packages/components/drawer/hooks/useDrag.ts
+++ b/packages/components/drawer/hooks/useDrag.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { TdDrawerProps } from '../type';
 import { Styles } from '../../common';
 import { getSizeDraggable, calcMoveSize } from '../../../common/js/drawer/utils';
@@ -9,36 +9,43 @@ const useDrag = (
   onSizeDragEnd: TdDrawerProps['onSizeDragEnd'],
 ) => {
   const [dragSizeValue, changeDragSizeValue] = useState<string>(null);
+  // 使用 ref 来存储当前拖拽的宽度值
+  const dragSizeNumberRef = useRef<number>(0);
 
-  const handleMousemove = (e: MouseEvent) => {
-    // 鼠标移动时计算draggedSizeValue的值
-    const { x, y } = e;
+  const handleMousemove = useCallback(
+    (e: MouseEvent) => {
+      // 鼠标移动时计算draggedSizeValue的值
+      const { x, y } = e;
 
-    const maxHeight = document.documentElement.clientHeight;
-    const maxWidth = document.documentElement.clientWidth;
-    const offsetHeight = 8;
-    const offsetWidth = 8;
-    // x 轴方向使用最大宽度，y轴方向使用最大高度
-    const max = placement === 'left' || placement === 'right' ? maxWidth : maxHeight;
-    // x 轴方向使用默认最小宽度，y轴方向使用默认最小高度
-    const min = placement === 'left' || placement === 'right' ? offsetWidth : offsetHeight;
+      const maxHeight = document.documentElement.clientHeight;
+      const maxWidth = document.documentElement.clientWidth;
+      const offsetHeight = 8;
+      const offsetWidth = 8;
+      // x 轴方向使用最大宽度，y轴方向使用最大高度
+      const max = placement === 'left' || placement === 'right' ? maxWidth : maxHeight;
+      // x 轴方向使用默认最小宽度，y轴方向使用默认最小高度
+      const min = placement === 'left' || placement === 'right' ? offsetWidth : offsetHeight;
 
-    const { allowSizeDraggable, max: limitMax, min: limitMin } = getSizeDraggable(sizeDraggable, { max, min });
+      const { allowSizeDraggable, max: limitMax, min: limitMin } = getSizeDraggable(sizeDraggable, { max, min });
 
-    if (!allowSizeDraggable) return;
+      if (!allowSizeDraggable) return;
 
-    const moveSize = calcMoveSize(placement, {
-      x,
-      y,
-      maxWidth,
-      maxHeight,
-      max: limitMax,
-      min: limitMin,
-    });
+      const moveSize = calcMoveSize(placement, {
+        x,
+        y,
+        maxWidth,
+        maxHeight,
+        max: limitMax,
+        min: limitMin,
+      });
 
-    if (typeof moveSize === 'undefined') return;
-    changeDragSizeValue(`${moveSize}px`);
-  };
+      if (typeof moveSize === 'undefined') return;
+      changeDragSizeValue(`${moveSize}px`);
+      dragSizeNumberRef.current = moveSize;
+    },
+    [placement, sizeDraggable],
+  );
+
   const draggableLineStyles: Styles = useMemo(() => {
     // 设置拖拽control的样式
     const isHorizontal = ['right', 'left'].includes(placement);
@@ -58,20 +65,25 @@ const useDrag = (
       cursor: isHorizontal ? 'col-resize' : 'row-resize',
     };
   }, [placement]);
-  const handleMouseup = (e: MouseEvent) => {
-    document.removeEventListener('mouseup', handleMouseup, true);
-    document.removeEventListener('mousemove', handleMousemove, true);
-    onSizeDragEnd?.({
-      e,
-      size: parseInt(dragSizeValue, 10),
-    });
-  };
 
-  const enableDrag = () => {
-    // mousedown绑定mousemove和mouseup事件
+  const handleMouseup = useCallback(
+    (e: MouseEvent) => {
+      document.removeEventListener('mouseup', handleMouseup, true);
+      document.removeEventListener('mousemove', handleMousemove, true);
+      onSizeDragEnd?.({
+        e,
+        // 此处不要使用 dragSizeValue，useState 的更新是异步的，在鼠标拖拽的同步操作中取不到最新的值
+        size: dragSizeNumberRef.current,
+      });
+    },
+    [handleMousemove, onSizeDragEnd],
+  );
+
+  const enableDrag = useCallback(() => {
+    // mousedown 绑定 mousemove 和 mouseup 事件
     document.addEventListener('mouseup', handleMouseup, true);
     document.addEventListener('mousemove', handleMousemove, true);
-  };
+  }, [handleMousemove, handleMouseup]);
 
   return { dragSizeValue, enableDrag, draggableLineStyles };
 };


### PR DESCRIPTION
解决Drawer抽屉在拖拽改变大小的时候获取宽度可能不正确的问题

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
在 `useDrag.ts` 文件中， handleMouseup 函数中的 dragSizeValue 每次取值不正确的问题，是由于 dragSizeValue 的状态更新不及时导致的。 useState 的更新是异步的，因此在 handleMouseup 中直接使用 dragSizeValue 会导致获取到的值不是最新的。

解决方案是使用 useRef 来存储最新的 dragSizeValue ，这样可以确保在 handleMouseup 中获取到的值是最新的。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Drawer): 解决Drawer抽屉在拖拽改变大小的时候获取宽度可能不正确的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
