### PR TITLE
fix(popup): 解决popup组件修饰符arrow属性设置不生效的问题

### DIFF
--- a/packages/components/guide/__tests__/__snapshots__/vitest-guide.test.jsx.snap
+++ b/packages/components/guide/__tests__/__snapshots__/vitest-guide.test.jsx.snap
@@ -169,7 +169,8 @@ exports[`Guide Component > GuideStep.body works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          style=""
+          data-popper-arrow="true"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
         />
       </div>
     </div>
@@ -623,7 +624,8 @@ exports[`Guide Component > GuideStep.highlightContent works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          style=""
+          data-popper-arrow="true"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
         />
       </div>
     </div>
@@ -992,7 +994,8 @@ exports[`Guide Component > GuideStep.placement is equal to bottom-left 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          style=""
+          data-popper-arrow="true"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
         />
       </div>
     </div>
@@ -1165,7 +1168,8 @@ exports[`Guide Component > GuideStep.stepOverlayClass is equal to t-test-guide-s
         </div>
         <div
           class="t-popup__arrow"
-          style=""
+          data-popper-arrow="true"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
         />
       </div>
     </div>
@@ -1342,7 +1346,8 @@ exports[`Guide Component > GuideStep.title works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          style=""
+          data-popper-arrow="true"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
         />
       </div>
     </div>

--- a/packages/components/popup/Popup.tsx
+++ b/packages/components/popup/Popup.tsx
@@ -221,7 +221,10 @@ const Popup = forwardRef<PopupRef, PopupProps>((originalProps, ref) => {
               onScroll={handleScroll}
             >
               {content}
-              {showArrow ? <div style={styles.arrow} className={`${classPrefix}-popup__arrow`} /> : null}
+              {showArrow ? (
+                // popper.js 修饰符(modifiers)的高级功能 arrow 会自动根据属性 data-popper-arrow 来识别箭头元素，从而支持调整箭头位置(padding)
+                <div style={styles.arrow} className={`${classPrefix}-popup__arrow`} data-popper-arrow />
+              ) : null}
             </div>
           </div>
         </CSSTransition>

--- a/packages/components/popup/PopupPlugin.tsx
+++ b/packages/components/popup/PopupPlugin.tsx
@@ -141,7 +141,8 @@ const Overlay: React.FC<OverlayProps> = (originalProps) => {
     >
       <div ref={overlayRef} className={classNames(overlayClasses)} style={overlayInnerStyleMerge()}>
         {content}
-        {showArrow && <div className={`${componentName}__arrow`}></div>}
+        {/* popper.js 修饰符(modifiers)的高级功能 arrow 会自动根据属性 data-popper-arrow 来识别箭头元素，从而支持调整箭头位置(padding) */}
+        {showArrow && <div className={`${componentName}__arrow`} data-popper-arrow></div>}
       </div>
     </div>
   );


### PR DESCRIPTION
解决popup组件修饰符arrow属性设置不生效的问题

fix #3340

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/3340

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

对于arrow修饰符，options中需要显式指定element属性，如果没有指定这个属性，Popper会自动寻找“data-popper-arrow”的元素作为element，如果最终没找到element，则其它设置无法生效，例如padding。解决方案：给arrow页面元素增加data-popper-arrow属性，以便用户不需要额外编码即可支持arrow修饰符

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 解决popup组件修饰符arrow属性设置不生效的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
