### PR TITLE
fix(RadioGroup): recalculate bar style on visibility change

### DIFF
--- a/packages/components/radio/RadioGroup.tsx
+++ b/packages/components/radio/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect, useRef } from 'react';
+import React, { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import observe from '@tdesign/common-js/utils/observe';
 import useConfig from '../hooks/useConfig';
@@ -30,7 +30,7 @@ const RadioGroup: React.FC<RadioGroupProps> = (originalProps) => {
   const { disabled, readonly, children, onChange, size, variant, options = [], className, style, theme } = props;
 
   const [internalValue, setInternalValue] = useControlled(props, 'value', onChange);
-  const [barStyle, setBarStyle] = useState({});
+  const [barStyle, setBarStyle] = useState<Partial<CSSProperties>>({});
   const radioGroupRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<IntersectionObserver>(null);
 
@@ -89,13 +89,21 @@ const RadioGroup: React.FC<RadioGroupProps> = (originalProps) => {
 
     if (!radioGroupRef.current) return;
 
+    const clearObserver = () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    }
+
+    if(barStyle.width !== '0px' && barStyle.width !== 0) {
+      clearObserver();
+      return;
+    }
+
     const observer = observe(radioGroupRef.current, null, calcBarStyle, 0);
     observerRef.current = observer;
 
     return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      observerRef.current?.unobserve(radioGroupRef.current);
-      observerRef.current = null;
+      clearObserver();
     };
   }, [radioGroupRef.current, internalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/components/radio/RadioGroup.tsx
+++ b/packages/components/radio/RadioGroup.tsx
@@ -84,6 +84,26 @@ const RadioGroup: React.FC<RadioGroupProps> = (originalProps) => {
 
   useEffect(() => {
     calcBarStyle();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          calcBarStyle();
+        }
+      },
+      {
+        threshold: 0,
+      },
+    );
+
+    if (radioGroupRef.current) {
+      observer.observe(radioGroupRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+
   }, [radioGroupRef.current, internalValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const renderBlock = () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

**场景：** `ColorPickerPanel`「单色 / 渐变」的 `Ratio` 高亮异常。

![异常例子](https://github.com/user-attachments/assets/29388d02-224e-4d71-ad8d-aeaba99bdfa6)

**原因：** 初始化时父容器被 `hidden`，但 `Ratio` 的元素已经渲染在页面上，只是不在可视区域，所以 `calcBarStyle()` 首次获取到的 `offsetXxxx` 相关数值为 0 。后面切换显示该组件时，`calcBarStyle()` 没能触发重新计算，而是一直保留之前得到的 0。
```tsx
{navList.map((nav) => (
  <div
    key={nav.id}
    id={nav.id}
    hidden={nav.id !== activeNav}
  >
    {nav.component}
  </div>
))}
```
（`ColorPickerPanel` 作为 `navList` 的子组件，且不在第一个）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(RadioGroup): recalculate bar style on visibility change

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
