### PR TITLE
chore: add preinstall script to skip init submodule in common repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tdesign-react-mono",
-  "packageManager": "pnpm@9.5.0",
+  "packageManager": "pnpm@9.15.9",
   "private": true,
   "purename": "tdesign",
   "version": "1.11.1",
@@ -36,7 +36,7 @@
     "excludeAfterRemap": false
   },
   "scripts": {
-    "pnpm:devPreinstall": "pnpm run init",
+    "pnpm:devPreinstall": "node script/pnpm-dev-preinstall.js",
     "init": "git submodule init && git submodule update",
     "start": "pnpm run dev",
     "dev": "pnpm -C packages/tdesign-react/site dev",

--- a/script/pnpm-dev-preinstall.js
+++ b/script/pnpm-dev-preinstall.js
@@ -1,0 +1,15 @@
+const child_process = require('child_process');
+
+function initSubmodule() {
+  if (process.env.CI) {
+    return;
+  }
+  try {
+    child_process.execSync('git submodule update --init', { stdio: 'inherit' });
+    console.log('子模块初始化成功');
+  } catch (error) {
+    console.error(`子模块初始化失败: ${error.message}`);
+  }
+}
+
+initSubmodule();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://github.com/Tencent/tdesign-common/actions/runs/14008551849/job/39225878584
common 仓库 集成 ui 仓库测试流程
1. 检出 UI 仓库代码，不初始化 common 子模块
2. 检出 common 仓库 PR 代码到 UI 仓库的 common 子模块代码位置
3. 进行 lint 、test、build 进行测试

UI 仓库加了 pnpm:devPreinstall，在运行 pnpm install 会初始化一次 common 子模块，破坏 common 仓库集成测试的第二步流程，把 common 子模块代码重置还原为 UI 仓库记录的 commit id
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/3df5e903-911d-414e-80e8-faa1135b7458" />

解决方式 :
判断是否为 CI 环境，如果是 pnpm:devPreinstall 运行不初始化 common 子模块


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
