### PR TITLE
fix(tree-select): prevent redundant `onChange`, it and valueDisplay parameters undefined

### DIFF
--- a/packages/components/tree-select/TreeSelect.tsx
+++ b/packages/components/tree-select/TreeSelect.tsx
@@ -160,7 +160,7 @@ const TreeSelect = forwardRef<TreeSelectRefType, TreeSelectProps>((originalProps
       ? valueDisplay({ value: normalizedValue[0], onClose: noop })
       : valueDisplay;
     return normalizedValue.length ? displayNode : '';
-  }, [valueDisplay, multiple, normalizedValue]);
+  }, [valueDisplay, multiple, normalizedValue, popupVisible]);
 
   const internalInputValueDisplay: SelectInputProps['valueDisplay'] = useMemo(() => {
     // 只有单选且下拉展开时需要隐藏 valueDisplay
@@ -195,11 +195,14 @@ const TreeSelect = forwardRef<TreeSelectRefType, TreeSelectProps>((originalProps
 
   const handleSingleChange = usePersistFn<TreeProps['onActive']>((value, context) => {
     const $value = Array.isArray(value) && value.length ? value[0] : undefined;
-    onChange(formatValue($value, context.node.label), {
-      ...context,
-      data: context.node.data,
-      trigger: 'check',
-    });
+
+    if ($value !== undefined) {
+      onChange(formatValue($value, context.node.label), {
+        ...context,
+        data: context.node.data,
+        trigger: 'check',
+      });
+    }
     // 单选选择后收起弹框
     setPopupVisible(false, { ...context, trigger: 'trigger-element-click' });
   });


### PR DESCRIPTION


<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当前点击已选中项时，仍能触发 `onChange` 事件，且此时 `onChange` 和 `valueDisplay` 参数均为 undefined。
修正和 vue-next 表现一致:
1. 点击已选中项时不触发 `onChange`。
2. 单选状态下，每次点击任何值时都更新  `valueDisplay` 参数。

<img width="495" alt="743068296802" src="https://github.com/user-attachments/assets/e816fd59-4669-4617-a860-e8a6f379d491" />

![image](https://github.com/user-attachments/assets/f36bbd6d-7a8a-4429-82bf-8e8c96e6ee23)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select): 修复点击已选中项时，仍能触发 `onChange` 事件，且此时传递参数为 undefined
- fix(tree-select): 修复点击已选中项时，valueDisplay 参数为 undefined

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
