### PR TITLE
fix(Tree):  getParents error when tree data update

### DIFF
--- a/packages/components/tree/hooks/useStore.ts
+++ b/packages/components/tree/hooks/useStore.ts
@@ -89,7 +89,7 @@ export function useStore(
       expandedMap.set(val, true);
       if (expandParent) {
         const node = store.getNode(val);
-        node.getParents().forEach((tn) => {
+        node?.getParents?.()?.forEach?.((tn) => {
           expandedMap.set(tn.value, true);
         });
       }

--- a/packages/components/tree/hooks/useStore.ts
+++ b/packages/components/tree/hooks/useStore.ts
@@ -89,7 +89,7 @@ export function useStore(
       expandedMap.set(val, true);
       if (expandParent) {
         const node = store.getNode(val);
-        node?.getParents?.()?.forEach?.((tn) => {
+        node?.getParents().forEach((tn) => {
           expandedMap.set(tn.value, true);
         });
       }


### PR DESCRIPTION
✅ Closes: 3461

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/3461

### 💡 需求背景和解决方案

前提：
1、tree的某些节点可能会被移除，比如远端拉取数据后某些节点被删掉了
2、设置了expandParent属性
3、expanded属性中包含了被移除的节点value，且在数据更新后没有被手动移除

点击移除按钮即可，即可复现白屏


组件内部冗余这种错误，在查找父节点不存在时中断后续处理逻辑。
在使用时处理这种逻辑相对较复杂,需要遍历整棵树

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
