### PR TITLE
fix(tooltip): 修复 react 16 下，tooltip-lite mouse 计算位置

### DIFF
--- a/packages/components/tooltip/TooltipLite.tsx
+++ b/packages/components/tooltip/TooltipLite.tsx
@@ -39,13 +39,15 @@ const TooltipLite: React.FC<TooltipLiteProps> = (originalProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triggerRef.current, contentRef.current, placement, hover, clientX, clientY]);
 
-  const updatePosition = (e: MouseEvent) => {
-    setHoverClientX(e.clientX);
-    setHoverClientY(e.clientY);
+  const updatePosition = (position: Pick<MouseEvent, 'clientX' | 'clientY'>) => {
+    const { clientX, clientY } = position;
+    setHoverClientX(clientX);
+    setHoverClientY(clientY);
   };
 
   const onSwitchHover = (action: String, e: MouseEvent) => {
-    updatePosition(e);
+    const { clientX, clientY } = e;
+    updatePosition({ clientX, clientY });
     hoverAction.set(action === 'on');
   };
 
@@ -60,7 +62,10 @@ const TooltipLite: React.FC<TooltipLiteProps> = (originalProps) => {
   const getTriggerChildren = (children) => {
     const appendProps = {
       ref: triggerRef,
-      onMouseMove: onSwitchMove,
+      onMouseMove: (e) => {
+        const { clientX, clientY } = e;
+        return onSwitchMove({ clientX, clientY });
+      },
       onMouseEnter: (e) => onSwitchHover('on', e),
       onMouseLeave: (e) => onSwitchHover('off', e),
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

背景：
在 react 16 中，事件池机制会导致拿不到 `e.clientX` 和 `e.clientY`，导致 tooltip-lite 的位置计算不正确，导致位置闪动。
<img width="953" alt="Clipboard_Screenshot_1743155897" src="https://github.com/user-attachments/assets/6cb34488-b146-46c7-877a-406e182c8a6f" />

解决方案：在异步操作前，将需要的属性保存到变量中。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tooltip): 修复 react 16 下，tooltip-lite mouse 计算位置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
