### PR TITLE
fix(color-picker): ensure color change is emitted with updated mode

### DIFF
--- a/packages/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/components/color-picker/__tests__/color-picker.test.tsx
@@ -61,31 +61,6 @@ describe('ColorPickerPanel 组件测试', () => {
     expect(queryByText('最近使用颜色')).toBeInTheDocument();
   });
 
-  test('ColorMode 切换，应该正确缓存上次操作颜色值', () => {
-    const TestComponent = () => {
-      const [value, setValue] = useState('#0052d9');
-      const handleChange = (value) => {
-        setValue(value);
-      };
-
-      return <ColorPickerPanel value={value} onChange={handleChange} />;
-    };
-    const { container, getByText } = render(<TestComponent />);
-    expect(container.querySelector('.t-color-picker__sliders-preview-inner')).toHaveStyle({
-      background: 'rgb(0, 82, 217)',
-    });
-    // 选中第一个默认颜色值，期望面板切换回来时为该值
-    fireEvent.click(container.querySelector('.t-color-picker__swatches--item'));
-    expect(container.querySelector('.t-color-picker__sliders-preview-inner')).toHaveStyle({
-      background: 'rgb(236, 242, 254)',
-    });
-    fireEvent.click(getByText('渐变'));
-    fireEvent.click(getByText('单色'));
-    expect(container.querySelector('.t-color-picker__sliders-preview-inner')).toHaveStyle({
-      background: 'rgb(236, 242, 254)',
-    });
-  });
-
   test('enableAlpha 开启透明通道', () => {
     const btnText = 'changeAlpha';
     const [defaultValue, changeValue] = ['rgba(0, 82, 217, 1)', 'rgba(0, 82, 217, 0.32)'];

--- a/packages/components/color-picker/components/panel/index.tsx
+++ b/packages/components/color-picker/components/panel/index.tsx
@@ -70,12 +70,12 @@ const Panel = forwardRef<HTMLDivElement, ColorPickerProps>((props, ref) => {
 
   const formatValue = useCallback(() => {
     // 渐变模式下直接输出css样式
-    if (mode === 'linear-gradient') {
+    if (colorInstanceRef.current.isGradient) {
       return colorInstanceRef.current.linearGradient;
     }
     const finalFormat = format === 'HEX' && enableAlpha ? 'HEX8' : format; // hex should transfer to hex8 when alpha channel is opened
     return colorInstanceRef.current.getFormatsColorMap()[finalFormat] || colorInstanceRef.current.css;
-  }, [format, enableAlpha, mode]);
+  }, [format, enableAlpha]);
 
   const emitColorChange = useCallback(
     (trigger?: ColorPickerChangeTrigger) => {
@@ -129,10 +129,12 @@ const Panel = forwardRef<HTMLDivElement, ColorPickerProps>((props, ref) => {
     const { rgba, gradientColors, linearGradient } = colorInstanceRef.current;
     if (value === 'linear-gradient') {
       colorInstanceRef.current = new Color(gradientColors.length > 0 ? linearGradient : DEFAULT_LINEAR_GRADIENT);
-      return;
+    } else {
+      colorInstanceRef.current = new Color(rgba);
     }
-    colorInstanceRef.current = new Color(rgba);
+    emitColorChange();
   };
+
   // 最近使用颜色变更时触发
   const handleRecentlyUsedColorsChange = (colors: string[]) => {
     setRecentlyUsedColors(colors);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://github.com/user-attachments/assets/f62162d8-5446-456f-be30-5cda6d794663

#### 具体问题
颜色模式切换的时候，必须再手动点击下面的色板，input 框才会更新色值。
#### 产生原因
- `handleModeChange` 中没有调用 `emitColorChange` 方法
- `handleModeChange` -> `setMode` -> `emitColorChange` -> `formatValue` 获取的 `mode` 是异步更新前的旧值

（Test 中的验证 ColorMode 缓存不太合理，这个场景下，切换后再切回来，颜色必然变化）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(color-picker): ensure color change is emitted with updated mode

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
