### PR TITLE
fix(Table): fix table col resize header bug

### DIFF
--- a/packages/components/table/hooks/useColumnResize.tsx
+++ b/packages/components/table/hooks/useColumnResize.tsx
@@ -127,6 +127,8 @@ export default function useColumnResize(params: {
     const thRightCursor = targetBoundRect.right - e.pageX <= distance;
     const thLeftCursor = e.pageX - targetBoundRect.left <= distance;
     const isFixedToRight = isColRightFixActive(col);
+
+    // 在单元格分割线的右侧
     if (thRightCursor || isFixedToRight) {
       if (colResizable) {
         target.style.cursor = thRightCursor || (isFixedToRight && thLeftCursor) ? 'col-resize' : '';
@@ -135,7 +137,8 @@ export default function useColumnResize(params: {
         resizeLineParams.effectCol = 'next';
         return;
       }
-    } else if (thLeftCursor) {
+    } // 在单元格分割线的左侧操作
+    else if (thLeftCursor) {
       const prevEl = target.previousElementSibling;
       if (prevEl && colResizable) {
         target.style.cursor = 'col-resize';
@@ -201,6 +204,21 @@ export default function useColumnResize(params: {
     return tableWidth;
   };
 
+  const getSiblingColCanResizable = (
+    newThWidthList: { [key: string]: number },
+    effectNextCol: BaseTableCol,
+    distance: number,
+    index: number,
+  ) => {
+    let isWidthAbnormal = true;
+    if (effectNextCol) {
+      const { minColWidth, maxColWidth } = getMinMaxColWidth(effectNextCol);
+      const targetNextColWidth = newThWidthList[effectNextCol.colKey] + distance;
+      isWidthAbnormal = targetNextColWidth < minColWidth || targetNextColWidth > maxColWidth;
+    }
+    return !(isWidthAbnormal || isWidthOverflow || index === leafColumns.length - 1);
+  };
+
   // 调整表格列宽
   const onColumnMousedown = (
     e: React.MouseEvent<HTMLTableHeaderCellElement, MouseEvent>,
@@ -264,21 +282,17 @@ export default function useColumnResize(params: {
       // 当前列不允许修改宽度，就调整相邻列的宽度
       const tmpCurrentCol = col.resizable !== false ? col : currentSibling;
       // 是否允许调整相邻列宽：列宽未超出时，且并非是最后一列（最后一列的右侧拉伸会认为是表格整体宽度调整）
-      const canResizeSiblingColWidth = !(isWidthOverflow || index === leafColumns.length - 1);
+      const rightCol = resizeLineParams.effectCol === 'next' ? currentCol.nextSibling : col;
+      const canResizeSiblingColWidth = getSiblingColCanResizable(newThWidthList, rightCol, moveDistance, index);
 
-      if (!effectNextCol?.colKey) {
-        // 已经不存在最后一列，比如整个表格只有一列可以调整的场景，需要直接影响到表格本身的宽度
-        if (resizeLineParams.effectCol === 'next') newThWidthList[tmpCurrentCol?.colKey] -= moveDistance;
-        else newThWidthList[tmpCurrentCol?.colKey] += moveDistance;
-        newThWidthList.tableWidth = getTotalTableWidth(newThWidthList);
-      } else if (resizeLineParams.effectCol === 'next') {
+      if (resizeLineParams.effectCol === 'next') {
         // 右侧激活态的固定列，需特殊调整
         if (isColRightFixActive(col)) {
           // 如果不相同，则表示改变相临的右侧列宽
           if (target.dataset.colkey !== col.colKey) {
             newThWidthList[effectNextCol.colKey] += moveDistance;
           } else {
-            newThWidthList[tmpCurrentCol?.colKey] += moveDistance;
+            newThWidthList[tmpCurrentCol.colKey] += moveDistance;
           }
         } else {
           // 非右侧激活态的固定列
@@ -288,11 +302,12 @@ export default function useColumnResize(params: {
           }
         }
       } else if (resizeLineParams.effectCol === 'prev') {
-        if (canResizeSiblingColWidth && effectPrevCol) {
-          newThWidthList[effectPrevCol.colKey] -= moveDistance;
+        if (canResizeSiblingColWidth) {
+          newThWidthList[tmpCurrentCol.colKey] += moveDistance;
         }
-        newThWidthList[tmpCurrentCol.colKey] += moveDistance;
+        effectPrevCol && (newThWidthList[effectPrevCol.colKey] -= moveDistance);
       }
+
       updateThWidthList(newThWidthList);
       const tableWidth = getTotalTableWidth(newThWidthList);
       // 整个表格只有一列可以调整的场景


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- 当前拖拽单元格右侧时，计算逻辑存在错误，导致表格宽度不断变宽，实际应该在此场景下优先计算影响上一列的宽度，同时调整当前列和上一列的宽度，更符合使用习惯
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复可调整列宽表格右侧拖拽调整的异常问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
