### PR TITLE
fix(form): 解决form表单的name路径有数 字的时候赋值失败的问题

### DIFF
--- a/packages/components/form/FormItem.tsx
+++ b/packages/components/form/FormItem.tsx
@@ -5,7 +5,7 @@ import {
   CloseCircleFilledIcon as TdCloseCircleFilledIcon,
   ErrorCircleFilledIcon as TdErrorCircleFilledIcon,
 } from 'tdesign-icons-react';
-import { calcFieldValue } from './utils';
+import { calcFieldValue, convertNamePathToString } from './utils';
 import useConfig from '../hooks/useConfig';
 import useGlobalIcon from '../hooks/useGlobalIcon';
 import type {
@@ -76,11 +76,12 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
 
   const props = useDefaultProps<FormItemProps>(originalProps, formItemDefaultProps);
 
+  const name = useMemo(() => convertNamePathToString(props.name), [props.name]);
+
   const {
     children,
     style,
     label,
-    name,
     status,
     tips,
     help,

--- a/packages/components/form/FormList.tsx
+++ b/packages/components/form/FormList.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useRef, useImperativeHandle } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle, useMemo } from 'react';
 import { merge, get } from 'lodash-es';
 import log from '@tdesign/common-js/log/index';
 import { FormListContext, useFormContext } from './FormContext';
 import { FormItemInstance } from './FormItem';
 import { HOOK_MARK } from './hooks/useForm';
 import { TdFormListProps, FormListFieldOperation, FormListField } from './type';
-import { calcFieldValue } from './utils';
+import { calcFieldValue, convertNamePathToString } from './utils';
 
 let key = 0;
 
@@ -17,7 +17,9 @@ const FormList: React.FC<TdFormListProps> = (props) => {
     initialData: initialDataFromForm,
     resetType: resetTypeFromContext,
   } = useFormContext();
-  const { name, rules, children } = props;
+  const { name: propName, rules, children } = props;
+
+  const name = useMemo(() => convertNamePathToString(propName), [propName]);
 
   const initialData = props.initialData || get(initialDataFromForm, name) || [];
 

--- a/packages/components/form/utils/index.ts
+++ b/packages/components/form/utils/index.ts
@@ -67,3 +67,21 @@ export function travelMapFromObject(
     }
   }
 }
+
+/**
+ * 将表单名成路径中的数字转化为字符串
+ *
+ * 将 name 是 number 类型，转化为字符串
+ * 当 name 是数组格式时，需要将数组中的 number 元素转化为字符串
+ * 覆盖：路径中，数字 1 和字符串 '1' 会被视为同一路径，后者会覆盖前者的值。
+ *
+ * @param {NamePath} name
+ * @returns
+ */
+export function convertNamePathToString(name: NamePath) {
+  if (typeof name === 'number') return `${name}`;
+  if (Array.isArray(name)) {
+    return name.map((item) => (typeof item === 'number' ? `${item}` : item));
+  }
+  return name;
+}


### PR DESCRIPTION
解决form表单的name路径有数 字的时候赋值失败的问题

#3294

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-react/issues/3294

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
如果Form表单的name中包含数字，则setFieldsValue等赋值方法不能正确赋值

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): 解决form表单的name路径有数 字的时候赋值失败的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
