### PR TITLE
fix(DatePicker): trigger `onVisibleChange` when manually closing Popup

### DIFF
--- a/packages/components/date-picker/DatePicker.tsx
+++ b/packages/components/date-picker/DatePicker.tsx
@@ -92,6 +92,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     }
   });
 
+  const handlePopupInvisible = () => {
+    setPopupVisible(false);
+    props.popupProps?.onVisibleChange?.(false, {});
+  };
+
   useUpdateEffect(() => {
     //  日期时间选择器不需要点击确认按钮完成的操作
     onTriggerNeedConfirm.current();
@@ -156,7 +161,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
         dayjsValue: parseToDayjs(date, format),
         trigger: 'pick',
       });
-      setPopupVisible(false);
+      handlePopupInvisible();
     }
   }
   // 头部快速切换
@@ -216,7 +221,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     } else {
       setInputValue(formatDate(value, { format }));
     }
-    setPopupVisible(false);
+    handlePopupInvisible();
   }
 
   // 预设
@@ -230,7 +235,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
       trigger: 'preset',
     });
     props.onPresetClick?.(context);
-    setPopupVisible(false);
+    handlePopupInvisible();
   }
 
   const onYearChange = useCallback((year: number) => {
@@ -279,7 +284,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
 
   const onTagClearClick = ({ e }) => {
     e.stopPropagation();
-    setPopupVisible(false);
+    handlePopupInvisible();
     onChange([], { dayjsValue: dayjs(), trigger: 'clear' });
     onClear?.({ e });
   };

--- a/packages/components/date-picker/DateRangePicker.tsx
+++ b/packages/components/date-picker/DateRangePicker.tsx
@@ -80,6 +80,11 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
   // 记录面板是否选中过
   const [isSelected, setIsSelected] = useState(false);
 
+  const handlePopupInvisible = () => {
+    setPopupVisible(false);
+    props.popupProps?.onVisibleChange?.(false, {});
+  };
+
   useEffect(() => {
     // 面板展开重置数据
     if (popupVisible) {
@@ -174,7 +179,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
       setActiveIndex(nextIndex);
       setIsFirstValueSelected(!!nextValue[0]);
     } else {
-      setPopupVisible(false);
+      handlePopupInvisible();
     }
   }
 
@@ -264,7 +269,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
       setActiveIndex(nextIndex);
       setIsFirstValueSelected(!!nextValue[0]);
     } else if (nextValue.length === 2) {
-      setPopupVisible(false);
+      handlePopupInvisible();
     }
   }
 
@@ -282,7 +287,7 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
         trigger: 'preset',
       });
       props.onPresetClick?.(context);
-      setPopupVisible(false);
+      handlePopupInvisible();
     }
   }
 

--- a/packages/components/date-picker/hooks/useRange.tsx
+++ b/packages/components/date-picker/hooks/useRange.tsx
@@ -47,6 +47,11 @@ export default function useRange(props: TdDateRangePickerProps) {
   // 未真正选中前可能不断变更输入框的内容
   const [inputValue, setInputValue] = useState(() => formatDate(value, { format }));
 
+  const handlePopupInvisible = () => {
+    setPopupVisible(false);
+    props.popupProps?.onVisibleChange?.(false, {});
+  };
+
   // input 设置
   const rangeInputProps = {
     ...props.rangeInputProps,
@@ -69,7 +74,7 @@ export default function useRange(props: TdDateRangePickerProps) {
     },
     onClear: ({ e }) => {
       e.stopPropagation();
-      setPopupVisible(false);
+      handlePopupInvisible();
       onChange([], { dayjsValue: [], trigger: 'clear' });
     },
     onBlur: (newVal: string[], { e, position }) => {
@@ -103,7 +108,7 @@ export default function useRange(props: TdDateRangePickerProps) {
     onEnter: (newVal: string[]) => {
       if (!isValidDate(newVal, format) && !isValidDate(value, format)) return;
 
-      setPopupVisible(false);
+      handlePopupInvisible();
       if (isValidDate(newVal, format)) {
         onChange(formatDate(newVal, { format, targetFormat: valueType, autoSwap: true }) as DateValue[], {
           dayjsValue: newVal.map((v) => parseToDayjs(v, format)),

--- a/packages/components/date-picker/hooks/useSingle.tsx
+++ b/packages/components/date-picker/hooks/useSingle.tsx
@@ -38,6 +38,11 @@ export default function useSingleInput(props: TdDatePickerProps) {
   // 未真正选中前可能不断变更输入框的内容
   const [inputValue, setInputValue] = useState(() => formatDate(value, { format }));
 
+  const handlePopupInvisible = () => {
+    setPopupVisible(false);
+    props.popupProps?.onVisibleChange?.(false, {});
+  };
+
   // input 设置
   let inputProps: TdDatePickerProps['inputProps'] & { ref?: React.MutableRefObject<HTMLInputElement> } = {
     ...props.inputProps,
@@ -54,7 +59,7 @@ export default function useSingleInput(props: TdDatePickerProps) {
     }),
     onClear: ({ e }) => {
       e.stopPropagation();
-      setPopupVisible(false);
+      handlePopupInvisible();
       onChange('', { dayjsValue: dayjs(), trigger: 'clear' });
     },
     onBlur: (val: string, { e }) => {
@@ -80,13 +85,13 @@ export default function useSingleInput(props: TdDatePickerProps) {
     onEnter: (val: string) => {
       if (!val) {
         onChange('', { dayjsValue: dayjs(), trigger: 'enter' });
-        setPopupVisible(false);
+        handlePopupInvisible();
         return;
       }
 
       if (!isValidDate(val, format) && !isValidDate(value, format)) return;
 
-      setPopupVisible(false);
+      handlePopupInvisible();
       if (isValidDate(val, format)) {
         onChange(formatDate(val, { format, targetFormat: valueType }), {
           dayjsValue: parseToDayjs(val, format),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 确保外部组件主动关闭 Popup 的时候，能有对应的 onVisibleChange 回调

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
