### PR TITLE
fix(textarea): handle composing input value correctly

### DIFF
--- a/packages/components/drawer/Drawer.tsx
+++ b/packages/components/drawer/Drawer.tsx
@@ -39,7 +39,8 @@ const Drawer = forwardRef<DrawerInstance, DrawerProps>((originalProps, ref) => {
   const cancelText = t(local.cancel);
 
   const props = useDefaultProps<DrawerProps>(originalProps, drawerDefaultProps);
-  const [state, setState] = useSetState<DrawerProps>({ isPlugin: false, ...props });
+  const { body, children, header, footer, ...restProps } = props;
+  const [state, setState] = useSetState<DrawerProps>({ isPlugin: false, ...restProps });
   const {
     className,
     style,
@@ -60,10 +61,6 @@ const Drawer = forwardRef<DrawerInstance, DrawerProps>((originalProps, ref) => {
     showInAttachedElement,
     closeOnOverlayClick,
     closeOnEscKeydown,
-    children,
-    header,
-    body,
-    footer,
     closeBtn,
     cancelBtn = cancelText,
     confirmBtn = confirmText,

--- a/packages/components/textarea/Textarea.tsx
+++ b/packages/components/textarea/Textarea.tsx
@@ -52,6 +52,7 @@ const Textarea = forwardRef<TextareaRefInterface, TextareaProps>((originalProps,
   const [isOvermax, setIsOvermax] = useState(false);
   const [textareaStyle, setTextareaStyle] = useState<Partial<typeof DEFAULT_TEXTAREA_STYLE>>(DEFAULT_TEXTAREA_STYLE);
   const composingRef = useRef(false);
+  const [composingValue, setComposingValue] = useState<string>('');
   const hasMaxcharacter = typeof maxcharacter !== 'undefined';
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -112,14 +113,20 @@ const Textarea = forwardRef<TextareaRefInterface, TextareaProps>((originalProps,
   function inputValueChangeHandle(e: React.FormEvent<HTMLTextAreaElement>) {
     const { target } = e;
     let val = (target as HTMLInputElement).value;
-    if (!allowInputOverMax && !composingRef.current) {
-      val = limitUnicodeMaxLength(val, maxlength);
-      if (maxcharacter && maxcharacter >= 0) {
-        const stringInfo = getCharacterLength(val, maxcharacter);
-        val = typeof stringInfo === 'object' && stringInfo.characters;
+
+    if (composingRef.current) {
+      setComposingValue(val);
+    } else {
+      if (!allowInputOverMax) {
+        val = limitUnicodeMaxLength(val, maxlength);
+        if (maxcharacter && maxcharacter >= 0) {
+          const stringInfo = getCharacterLength(val, maxcharacter);
+          val = typeof stringInfo === 'object' && stringInfo.characters;
+        }
       }
+      setComposingValue(val);
+      setValue(val, { e });
     }
-    setValue(val, { e });
   }
 
   function handleCompositionStart() {
@@ -195,7 +202,7 @@ const Textarea = forwardRef<TextareaRefInterface, TextareaProps>((originalProps,
         {...textareaProps}
         {...eventProps}
         rows={rows}
-        value={value}
+        value={composingRef.current ? composingValue : value}
         style={textareaStyle}
         className={textareaClassNames}
         readOnly={readonly}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#3542

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): 修复输入中文被中断的问题
- fix(Drawer): `TNode` 重新渲染导致输入光标错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
