### PR TITLE
fixed onValuesChange callback is not triggered when resetting

### DIFF
--- a/packages/components/form/FormItem.tsx
+++ b/packages/components/form/FormItem.tsx
@@ -337,7 +337,7 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
     const resetType = type || resetTypeFromContext;
     const resetValue = getResetValue(resetType);
     // reset 不校验
-    updateFormValue(resetValue, false);
+    updateFormValue(resetValue, false, true);
 
     if (resetValidating) {
       setNeedResetField(true);
@@ -425,9 +425,6 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
     // value 变化通知 watch 事件
     form?.getInternalHooks?.(HOOK_MARK)?.notifyWatch?.(name);
 
-    // 控制是否需要校验
-    if (!shouldValidate.current) return;
-
     // value change event
     if (typeof name !== 'undefined' && shouldEmitChangeRef.current) {
       if (formListName) {
@@ -442,9 +439,12 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
       }
     }
 
-    const filterRules = innerRules.filter((item) => (item.trigger || 'change') === 'change');
+    // 控制是否需要校验
+    if (shouldValidate.current) {
+      const filterRules = innerRules.filter((item) => (item.trigger || 'change') === 'change');
+      filterRules.length && validate('change');
+    }
 
-    filterRules.length && validate('change');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formValue, snakeName]);
 

--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -96,11 +96,14 @@ describe('Form 组件测试', () => {
     expect(getByPlaceholderText('input1').value).toEqual('');
     fireEvent.click(getByText('setFields'));
     expect(getByPlaceholderText('input1').value).toEqual('setFields');
-    expect(fn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
 
     fireEvent.click(getByText('setFieldsValue'));
     expect(getByPlaceholderText('input1').value).toEqual('setFieldsValue');
-    expect(fn).toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(getByText('reset'));
+    expect(fn).toHaveBeenCalledTimes(3);
 
     fireEvent.click(getByText('setValidateMessage'));
     expect(queryByText('message: setValidateMessage')).toBeTruthy();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-react/issues/3472

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): 修复 Form reset 时 onValuesChange 不触发的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
