### PR TITLE
fix(cascader): useEffect is changed to manaul trigger

### DIFF
--- a/packages/components/cascader/hooks.tsx
+++ b/packages/components/cascader/hooks.tsx
@@ -90,10 +90,12 @@ export const useCascaderContext = (props: TdCascaderProps) => {
   useEffect(() => {
     if (!isEqual(optionCurrent.current, options)) {
       optionCurrent.current = options;
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      handleTreeStore();
     }
   }, [options]);
 
-  useEffect(() => {
+  const handleTreeStore = () => {
     if (!treeStore) {
       if (!options.length) return;
       const store = new TreeStore({
@@ -117,8 +119,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
       treeStoreExpendEffect(treeStore, scopeVal, []);
       treeNodesEffect(inputVal, treeStore, setTreeNodes, props.filter, checkStrictly);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [optionCurrent.current]);
+  };
 
   useEffect(() => {
     if (!treeStore) return;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

Cascader初始化后，异步更新options，displayValue无变化。
因为optionCurrent.current变化时没触发useEffect，导致treeStore没有更新。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(cascader): useEffect修改为手动触发

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
