### PR TITLE
fix(Popconfirm):  attribute children of props confirmBtn&cancelBtn is not effective

### DIFF
--- a/packages/components/popconfirm/Popconfirm.tsx
+++ b/packages/components/popconfirm/Popconfirm.tsx
@@ -29,7 +29,7 @@ const Popconfirm = forwardRef<PopupRef, TdPopconfirmProps>((originalProps, ref) 
       {...props}
       visible={visible}
       trigger="click"
-      onVisibleChange={(visible) => setVisible(visible)}
+      onVisibleChange={(visible, context) => setVisible(visible, context as PopconfirmVisibleChangeContext)}
       overlayClassName={classNames(`${classPrefix}-popconfirm`)}
       content={
         <Popcontent

--- a/packages/components/popconfirm/Popcontent.tsx
+++ b/packages/components/popconfirm/Popcontent.tsx
@@ -77,7 +77,7 @@ const Popcontent: React.FC<PopcontentProps & PopconfirmProps> = (props) => {
         }}
         {...(typeof cancelBtn === 'object' ? { ...(cancelBtn as ButtonProps) } : {})}
       >
-        {isString(cancelBtn) && cancelBtn}
+        {typeof cancelBtn === 'object' ? (cancelBtn as ButtonProps)?.children : isString(cancelBtn) && cancelBtn}
       </Button>
     );
   }
@@ -106,7 +106,7 @@ const Popcontent: React.FC<PopcontentProps & PopconfirmProps> = (props) => {
         }}
         {...(typeof confirmBtn === 'object' ? { ...(confirmBtn as ButtonProps) } : {})}
       >
-        {isString(confirmBtn) && confirmBtn}
+        {typeof confirmBtn === 'object' ? (confirmBtn as ButtonProps)?.children : isString(confirmBtn) && confirmBtn}
       </Button>
     );
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

1、confirmBtn和cancelBtn的children属性不生效，只能用content代替
2、onVisibleChange事件有时候没有第二个参数

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popconfirm): 修复 confirmBtn 属性的 children 不生效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
