### PR TITLE
fix(Select): prevent event triggering when `checkAll` is `disabled`

### DIFF
--- a/packages/components/select/base/Select.tsx
+++ b/packages/components/select/base/Select.tsx
@@ -30,7 +30,7 @@ import { TdSelectProps, TdOptionProps, SelectOption, SelectValueChangeTrigger, S
 import { StyledProps } from '../../common';
 import { selectDefaultProps } from '../defaultProps';
 import { PopupVisibleChangeContext } from '../../popup';
-import useOptions from '../hooks/useOptions';
+import useOptions, { isSelectOptionGroup } from '../hooks/useOptions';
 import composeRefs from '../../_util/composeRefs';
 import { parseContentTNode } from '../../_util/parseTNode';
 import useDefaultProps from '../../hooks/useDefaultProps';
@@ -143,7 +143,8 @@ const Select = forwardRefWithStatics(
         let closest = -1;
         let len = index;
         while (len >= 0) {
-          if (!selectedOptions[len]?.disabled) {
+          const option = selectedOptions[len];
+          if (!isSelectOptionGroup(option) && !option.disabled) {
             closest = len;
             break;
           }
@@ -181,20 +182,25 @@ const Select = forwardRefWithStatics(
     };
 
     const onCheckAllChange = (checkAll: boolean, e: React.MouseEvent<HTMLLIElement>) => {
-      if (!multiple) {
+      const isDisabledCheckAll = (opt: TdOptionProps) => opt.checkAll && opt.disabled;
+      if (!multiple || currentOptions.some((opt) => !isSelectOptionGroup(opt) && isDisabledCheckAll(opt))) {
         return;
       }
 
+      const isSelectableOption = (opt: TdOptionProps) => !opt.checkAll && !opt.disabled;
+      const getOptionValue = (option: SelectOption) =>
+        valueType === 'object' ? option : option[keys?.value || 'value'];
+
       const values = [];
       currentOptions.forEach((option) => {
-        if (option.group) {
+        if (isSelectOptionGroup(option)) {
           option.children.forEach((item) => {
-            if (!item.disabled && !item.checkAll) {
-              values.push(valueType === 'object' ? item : item[keys?.value || 'value']);
+            if (isSelectableOption(item)) {
+              values.push(getOptionValue(item));
             }
           });
-        } else if (!option.disabled && !option.checkAll) {
-          values.push(valueType === 'object' ? option : option[keys?.value || 'value']);
+        } else if (isSelectableOption(option)) {
+          values.push(getOptionValue(option));
         }
       });
 
@@ -265,7 +271,7 @@ const Select = forwardRefWithStatics(
 
     // 处理filter逻辑
     const handleFilter = (value: string) => {
-      let filteredOptions: OptionsType = [];
+      let filteredOptions: SelectOption[] = [];
       if (filterable && isFunction(onSearch)) {
         return;
       }
@@ -284,7 +290,7 @@ const Select = forwardRefWithStatics(
       };
 
       tmpPropOptions.forEach((option) => {
-        if (option.group) {
+        if (isSelectOptionGroup(option)) {
           filteredOptions.push({
             ...option,
             children: option.children?.filter((child) => {

--- a/packages/components/select/util/helper.ts
+++ b/packages/components/select/util/helper.ts
@@ -3,15 +3,16 @@ import { isPlainObject, get } from 'lodash-es';
 import OptionGroup from '../base/OptionGroup';
 import Option from '../base/Option';
 
-import { SelectValue, TdOptionProps, SelectKeysType, TdSelectProps, SelectOption, SelectOptionGroup } from '../type';
+import { SelectValue, TdOptionProps, SelectKeysType, TdSelectProps, SelectOption } from '../type';
+import { isSelectOptionGroup } from '../hooks/useOptions';
 
 type SelectLabeledValue = Required<Omit<TdOptionProps, 'disabled'>>;
 
-type ValueToOption = {
+export type ValueToOption = {
   [value: string | number]: TdOptionProps;
 };
 
-function setValueToOptionFormOptionDom(dom: ReactElement<any>, valueToOption: ValueToOption, keys: SelectKeysType) {
+function setValueToOptionFormOptionDom(dom: ReactElement, valueToOption: ValueToOption, keys: SelectKeysType) {
   const { value, label, children } = dom.props;
   // eslint-disable-next-line no-param-reassign
   valueToOption[value] = {
@@ -23,8 +24,8 @@ function setValueToOptionFormOptionDom(dom: ReactElement<any>, valueToOption: Va
 
 // 获取 value => option，用于快速基于 value 找到对应的 option
 export const getValueToOption = (
-  children: ReactElement<any>,
-  options: TdOptionProps[],
+  children: ReactElement,
+  options: SelectOption[],
   keys: SelectKeysType,
 ): ValueToOption => {
   const valueToOption = {};
@@ -32,8 +33,8 @@ export const getValueToOption = (
   // options 优先级高于 children
   if (Array.isArray(options)) {
     options.forEach((option) => {
-      if ((option as SelectOptionGroup).group) {
-        (option as SelectOptionGroup)?.children?.forEach((child) => {
+      if (isSelectOptionGroup(option)) {
+        option.children?.forEach((child) => {
           valueToOption[get(child, keys?.value || 'value')] = {
             ...child,
             value: get(child, keys?.value || 'value'),
@@ -101,7 +102,7 @@ export const getValueToOption = (
 
 // 获取单选的 label
 export const getLabel = (
-  children: ReactElement<any>,
+  children: ReactElement,
   value: SelectValue<TdOptionProps>,
   options: TdOptionProps[],
   keys: SelectKeysType,
@@ -140,7 +141,7 @@ export const getLabel = (
   }
 
   if (Array.isArray(children)) {
-    children.some((item: ReactElement<any>) => {
+    children.some((item: ReactElement) => {
       // 处理分组
       if (item.type === OptionGroup) {
         const groupChildren = item.props.children;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

禁用全选后仍会触发事件：

```tsx
const options1 = [
  { label: "全选", checkAll: true, disabled: true },
   // ...
]
```
https://github.com/user-attachments/assets/b92ee0b7-cd09-43cb-a6ef-8ae7d4cdbc03

核心修改部分是：

```tsx
const isDisabledCheckAll = (opt: TdOptionProps) => opt.checkAll && opt.disabled;
if (!multiple || currentOptions.some((opt) => !isSelectOptionGroup(opt) && isDisabledCheckAll(opt))) {
  return;
}
```

(其他部分是顺手优化了一下写法）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select):  修复 `checkAll` 设为 `disabled` 后依旧会触发选中事件的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
