### PR TITLE
docs: A new contributor graph that evaluates community activities from all dimensions

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -87,6 +87,10 @@ TDesign 欢迎任何愿意参与贡献的参与者。如果需要本地运行代
 
 ## 贡献成员
 
+<a href="https://openomy.app/github/tencent/tdesign-react" target="_blank" style="display: block; width: 100%;" align="center">
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+ </a>
+
 <a href="https://github.com/tencent/tdesign-react/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tencent/tdesign-react" />
 </a>

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -88,7 +88,7 @@ TDesign 欢迎任何愿意参与贡献的参与者。如果需要本地运行代
 ## 贡献成员
 
 <a href="https://openomy.app/github/tencent/tdesign-react" target="_blank" style="display: block; width: 100%;" align="center">
-  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=12" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
  </a>
 
 # 反馈

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -91,10 +91,6 @@ TDesign 欢迎任何愿意参与贡献的参与者。如果需要本地运行代
   <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
  </a>
 
-<a href="https://github.com/tencent/tdesign-react/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tencent/tdesign-react" />
-</a>
-
 # 反馈
 
 有任何问题，建议通过 [Github issues](https://github.com/Tencent/tdesign-react/issues) 反馈或扫码加入用户微信群。

--- a/README.md
+++ b/README.md
@@ -91,11 +91,6 @@ Contributing is welcome. Read [guidelines for contributing](https://github.com/T
   <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
  </a>
 
-
-<a href="https://github.com/tencent/tdesign-react/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tencent/tdesign-react" />
-</a>
-
 # Feedback
 
 Create your [Github issues](https://github.com/Tencent/tdesign-react/issues) or scan the QR code below to join our user groups

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Contributing is welcome. Read [guidelines for contributing](https://github.com/T
 ## Contributors
 
 <a href="https://openomy.app/github/tencent/tdesign-react" target="_blank" style="display: block; width: 100%;" align="center">
-  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=12" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
  </a>
 
 # Feedback

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Contributing is welcome. Read [guidelines for contributing](https://github.com/T
 
 ## Contributors
 
+<a href="https://openomy.app/github/tencent/tdesign-react" target="_blank" style="display: block; width: 100%;" align="center">
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-react&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+ </a>
+
+
 <a href="https://github.com/tencent/tdesign-react/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tencent/tdesign-react" />
 </a>


### PR DESCRIPTION
Hi Tencent/tdesign Community

tdesign-react is a vibrant open-source community where its products and frameworks are loved by lots of users and developers. As people use it, they contribute by raising issues, engaging in discussions, or directly contributing code, all of which help in continuously improving tdesign-react.

However, GitHub's default contributor list simply enumerates users who have committed code, failing to proportionately reflect the broader range of community contributors.

Therefore, we have designed a new chart that showcases active contributors from three perspectives: issues, PRs, and discussions. This is similar to embedding star-history within the README:

![Tencent/tdesign-react](https://www.openomy.app/svg?repo=Tencent/tdesign-react&chart=bubble&latestMonth=3)

By clicking on the link, you can view the specific contributions made by each individual: 

[Tencent/tdesign-react](https://www.openomy.app/github/Tencent/tdesign-react)

Currently, we have received recognition from communities such as [Ant Design (antd)]([GitHub - ant-design/ant-design: An enterprise-class UI design language and React UI library](https://github.com/ant-design/ant-design)). We aim to introduce this solution to more open-source communities and actively seek feedback for ongoing improvement.

We would greatly appreciate it if you could merge this PR. However, if you feel that the style is not appropriate or you don't like this approach, that's perfectly okay as well!