### PR TITLE
fix(Menu): `popupProps.delay` in `SubMenu` not working

### DIFF
--- a/packages/components/menu/SubMenu.tsx
+++ b/packages/components/menu/SubMenu.tsx
@@ -2,7 +2,7 @@ import React, { FC, useContext, useState, ReactElement, useMemo, useRef } from '
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import { StyledProps } from '../common';
-import { TdSubmenuProps } from './type';
+import type { TdSubmenuProps } from './type';
 import useConfig from '../hooks/useConfig';
 import { MenuContext } from './MenuContext';
 import useDomRefCallback from '../hooks/useDomRefCallback';
@@ -46,13 +46,7 @@ const SubAccordion: FC<SubMenuWithCustomizeProps> = (props) => {
     setOpen(visible);
   };
 
-  const handleMouseEvent = (type: 'leave' | 'enter') => {
-    if (!isPopUp) return;
-    if (type === 'enter') setOpen(true);
-    else if (type === 'leave') setOpen(false);
-  };
-
-  const childrens = React.Children.map(children, (child) =>
+  const popupChildren = React.Children.map(children, (child) =>
     React.cloneElement(child as ReactElement<any>, {
       className: classNames(
         `${classPrefix}-menu__item--plain`,
@@ -105,7 +99,7 @@ const SubAccordion: FC<SubMenuWithCustomizeProps> = (props) => {
       key="popup"
       style={childStyle}
     >
-      {childrens}
+      {popupChildren}
     </ul>
   );
 
@@ -116,8 +110,6 @@ const SubAccordion: FC<SubMenuWithCustomizeProps> = (props) => {
         [`${classPrefix}-is-opened`]: isOpen,
       })}
       style={style}
-      onMouseEnter={() => handleMouseEvent('enter')}
-      onMouseLeave={() => handleMouseEvent('leave')}
     >
       <div
         className={classNames(`${classPrefix}-menu__item`, {
@@ -144,7 +136,7 @@ const SubAccordion: FC<SubMenuWithCustomizeProps> = (props) => {
             className={classNames(`${classPrefix}-menu__sub`, `${classPrefix}-slide-down-enter-active`)}
             ref={contentRef}
           >
-            {childrens}
+            {popupChildren}
           </ul>
         </CSSTransition>
       )}
@@ -206,12 +198,6 @@ const SubTitleMenu: FC<SubMenuWithCustomizeProps> = (props) => {
   // 当前二级导航激活
   const isActive = checkSubMenuChildrenActive(children, active) || active === value;
 
-  const handleMouseEvent = (type: 'leave' | 'enter') => {
-    if (!isPopUp) return;
-    if (type === 'enter') setOpen(true);
-    else if (type === 'leave') setOpen(false);
-  };
-
   // 是否展开（popup 与 expand 两种状态）
   const isOpen = useMemo(() => {
     if (disabled) return false;
@@ -241,8 +227,6 @@ const SubTitleMenu: FC<SubMenuWithCustomizeProps> = (props) => {
       className={classNames(`${classPrefix}-submenu`, className, {
         [`${classPrefix}-is-opened`]: open,
       })}
-      onMouseEnter={() => handleMouseEvent('enter')}
-      onMouseLeave={() => handleMouseEvent('leave')}
     >
       <div
         ref={setRefCurrent}

--- a/packages/components/menu/_example/multiple.tsx
+++ b/packages/components/menu/_example/multiple.tsx
@@ -22,7 +22,7 @@ function Multiple() {
         <SubMenu value="0" title="电器">
           <SubMenu value="0-1" title="电视">
             <MenuItem value="xiaomi">小米电视</MenuItem>
-            <MenuItem value="soni">索尼电视</MenuItem>
+            <MenuItem value="sony">索尼电视</MenuItem>
             <MenuItem value="huawei">华为电视</MenuItem>
           </SubMenu>
           <MenuItem value="0-2">


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 内部 visible 是受控的，结合了 mouse 事件，强行把它 open了，导致 `delay` 失效
- 顺便修复了一些英语语法，`childrens` -> `children` 已经是复数；索尼的名字不太对

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): `popupProps` 的 `delay` 属性在 `SubMenu` 中无法生效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
