### PR TITLE
fix(upload): expand the scope of the click event of `theme="display"` to the entire card area

### DIFF
--- a/packages/components/upload/hooks/useUpload.ts
+++ b/packages/components/upload/hooks/useUpload.ts
@@ -340,8 +340,9 @@ export default function useUpload(props: TdUploadProps) {
     props.onRemove?.(p);
   }
 
-  const triggerUpload = () => {
+  const triggerUpload = (e?: MouseEvent) => {
     if (disabled || !inputRef.current) return;
+    e?.stopPropagation?.();
     (inputRef.current as HTMLInputElement).click();
   };
 

--- a/packages/components/upload/themes/CustomFile.tsx
+++ b/packages/components/upload/themes/CustomFile.tsx
@@ -10,7 +10,7 @@ export interface CustomFileProps extends CommonDisplayFileProps {
   // 拖拽区域
   dragContent?: TdUploadProps['dragContent'];
   trigger?: TdUploadProps['trigger'];
-  triggerUpload?: () => void;
+  triggerUpload?: (e: React.MouseEvent<HTMLDivElement>) => void;
   // 非拖拽场景，是触发元素；拖拽场景是拖拽区域
   childrenNode?: ReactNode;
 }

--- a/packages/components/upload/themes/DraggerFile.tsx
+++ b/packages/components/upload/themes/DraggerFile.tsx
@@ -18,7 +18,7 @@ import Image from '../../image';
 
 export interface DraggerProps extends CommonDisplayFileProps {
   trigger?: TdUploadProps['trigger'];
-  triggerUpload?: () => void;
+  triggerUpload?: (e: MouseEvent) => void;
   uploadFiles?: (toFiles?: UploadFile[]) => void;
   cancelUpload?: (context: { e: MouseEvent<HTMLElement>; file: UploadFile }) => void;
   dragEvents: UploadDragEvents;
@@ -166,9 +166,13 @@ const DraggerFile: FC<DraggerProps> = (props) => {
     return dragActive ? activeElement : unActiveElement;
   };
 
-  const getContent = () => {
+  const canTriggerUpload = useMemo(() => {
     const file = displayFiles[0];
-    if (file && (['progress', 'success', 'fail', 'waiting'].includes(file.status) || !file.status)) {
+    return !!file && (['progress', 'success', 'fail', 'waiting'].includes(file.status) || !file.status);
+  }, [displayFiles]);
+
+  const getContent = () => {
+    if (canTriggerUpload) {
       return renderMainPreview();
     }
     return (
@@ -176,6 +180,12 @@ const DraggerFile: FC<DraggerProps> = (props) => {
         {props.children || renderDefaultDragElement()}
       </div>
     );
+  };
+
+  const handleDraggerClick = (e: MouseEvent) => {
+    if (canTriggerUpload) {
+      props.triggerUpload?.(e);
+    }
   };
 
   return (
@@ -186,6 +196,7 @@ const DraggerFile: FC<DraggerProps> = (props) => {
       onDragEnter={drag.handleDragenter}
       onDragOver={drag.handleDragover}
       onDragLeave={drag.handleDragleave}
+      onClick={handleDraggerClick}
     >
       {parseContentTNode?.(trigger, { files: displayFiles, dragActive }) || getContent()}
     </div>

--- a/packages/components/upload/themes/ImageCard.tsx
+++ b/packages/components/upload/themes/ImageCard.tsx
@@ -21,7 +21,7 @@ export interface ImageCardUploadProps extends CommonDisplayFileProps {
   max: TdUploadProps['max'];
   disabled?: TdUploadProps['disabled'];
   showUploadProgress: TdUploadProps['showUploadProgress'];
-  triggerUpload?: () => void;
+  triggerUpload?: (e: MouseEvent) => void;
   uploadFiles?: (toFiles?: UploadFile[]) => void;
   cancelUpload?: (context: { e: MouseEvent<HTMLElement>; file: UploadFile }) => void;
   onPreview?: TdUploadProps['onPreview'];


### PR DESCRIPTION
chore: 上传事件添加 `stopPropagation`

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 将 `theme="display"` 的点击事件触发范围扩大至整个卡片区域

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
