### PR TITLE
fix(Form): update field value when reopening the form component

### DIFF
--- a/packages/components/form/hooks/useForm.ts
+++ b/packages/components/form/hooks/useForm.ts
@@ -109,6 +109,8 @@ export default function useForm(form?: InternalFormInstance) {
   // eslint-disable-next-line
   if (!formRef.current._init) {
     if (form) {
+      // Reset store when reopening
+      form.store = {};
       formRef.current = form;
     } else {
       // Create a new FormStore if not provided


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
When I open the form component for the second time, the form field echoes the last input content. 

For example

```javascript
import { useState } from 'react';
import { Button, Drawer, Form, Input } from 'tdesign-react';

const Demo = () => {
  const [visible, setVisible] = useState(false);
  const [form] = Form.useForm();

  const openDrawer = () => {
    setVisible(true);
  };

  return (
    <>
      <Drawer destroyOnClose visible={visible} onClose={() => setVisible(false)}>
        <Form form={form}>
          <Form.FormItem name='name' initialData='Initial Name'>
            <Input />
          </Form.FormItem>
        </Form>
      </Drawer>
      <Button onClick={() => openDrawer()}>Open Drawer</Button>
    </>
  );
};

export default Demo;
```

If I modify this value to "New Name", it will echo "New Name" instead of "Initial Name" when I reopen the Drawer

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): update field value when reopening the form component

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
