### PR TITLE
fix(alert): close属性同步为closeBtn，close即将废弃

### DIFF
--- a/packages/components/alert/Alert.tsx
+++ b/packages/components/alert/Alert.tsx
@@ -7,6 +7,7 @@ import {
   ErrorCircleFilledIcon as TdErrorCircleFilledIcon,
 } from 'tdesign-icons-react';
 import { CSSTransition } from 'react-transition-group';
+import log from '@tdesign/common-js/log/index';
 import noop from '../_util/noop';
 import parseTNode from '../_util/parseTNode';
 import useConfig from '../hooks/useConfig';
@@ -39,6 +40,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
     theme,
     icon,
     close,
+    closeBtn,
     maxLine,
     onClose,
     className,
@@ -96,11 +98,20 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
     return <div className={`${classPrefix}-alert__description`}>{message}</div>;
   };
 
-  const renderClose = () => (
-    <div className={`${classPrefix}-alert__close`} onClick={handleClose}>
-      {typeof close === 'boolean' ? <CloseIcon /> : parseTNode(close)}
-    </div>
-  );
+  // close属性变更为closeBtn过渡期使用，close废弃后可删除。（需兼容标签上直接写close和closeBtn的场景）
+  const isUsingClose = close || typeof props.close === 'string';
+  const closeNode = isUsingClose ? close : closeBtn;
+  if (isUsingClose) {
+    log.warnOnce('TAlert', 'prop `close` is going to be deprecated, please use `closeBtn` instead.');
+  }
+  const renderClose = () => {
+    if (closeNode === false) return null;
+    return (
+      <div className={`${classPrefix}-alert__close`} onClick={handleClose}>
+        {parseTNode(closeNode, undefined, <CloseIcon />)}
+      </div>
+    );
+  };
 
   return (
     <CSSTransition
@@ -126,7 +137,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
             {operation ? <div className={`${classPrefix}-alert__operation`}>{parseTNode(operation)}</div> : null}
           </div>
         </div>
-        {close ? renderClose() : null}
+        {renderClose()}
       </div>
     </CSSTransition>
   );

--- a/packages/components/alert/__tests__/alert.test.tsx
+++ b/packages/components/alert/__tests__/alert.test.tsx
@@ -15,7 +15,7 @@ describe('Alert 组件测试', () => {
         theme="error"
         title="title content"
         message={text}
-        close={<div data-testid={testId}>{text}</div>}
+        closeBtn={<div data-testid={testId}>{text}</div>}
         onClose={onClose}
         onClosed={onClosed}
         operation={<span id="operation-test">test content</span>}
@@ -45,7 +45,7 @@ describe('Alert 组件测试', () => {
 
   test('custom close icon render', () => {
     const { queryByTestId } = render(
-      <Alert theme="error" title="title content" close={<div data-testid={testId}>{text}</div>} />,
+      <Alert theme="error" title="title content" closeBtn={<div data-testid={testId}>{text}</div>} />,
     );
 
     expect(queryByTestId(testId)).not.toBeNull();
@@ -53,7 +53,7 @@ describe('Alert 组件测试', () => {
   });
 
   test('default close icon render', () => {
-    const { container } = render(<Alert theme="error" title="title content" close />);
+    const { container } = render(<Alert theme="error" title="title content" closeBtn />);
 
     expect(container.querySelector('.t-icon-close')).not.toBeNull();
     expect(container.querySelector('.t-icon-close')).toBeInTheDocument();

--- a/packages/components/alert/alert.en-US.md
+++ b/packages/components/alert/alert.en-US.md
@@ -6,14 +6,15 @@
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
-close | TNode | false | Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
+close | TNode | false | Deprecated, use closeBtn instead.。Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+closeBtn | TNode | false | Close button. Value "true" show the close button. Value "False" hide close button. Value type string display as is. Use TNode to custom the close trigger.。Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 icon | TElement | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 maxLine | Number | 0 | \- | N
 message | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 operation | TElement | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-theme | String | info | options：success/info/warning/error | N
+theme | String | info | options: success/info/warning/error | N
 title | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 onClose | Function |  | Typescript：`(context: { e: MouseEvent }) => void`<br/> | N
 onClosed | Function |  | Typescript：`(context: { e: TransitionEvent }) => void`<br/> | N

--- a/packages/components/alert/alert.md
+++ b/packages/components/alert/alert.md
@@ -1,13 +1,15 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Alert Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
-close | TNode | false | 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+close | TNode | false | 即将废弃，请使用 closeBtn 属性。关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+closeBtn | TNode | false | 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 icon | TElement | - | 图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 maxLine | Number | 0 | 内容显示最大行数，超出的内容会折叠收起，用户点击后再展开。值为 0 表示不折叠 | N
 message | TNode | - | 内容（子元素）。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N

--- a/packages/components/alert/defaultProps.ts
+++ b/packages/components/alert/defaultProps.ts
@@ -4,4 +4,4 @@
 
 import { TdAlertProps } from './type';
 
-export const alertDefaultProps: TdAlertProps = { close: false, maxLine: 0, theme: 'info' };
+export const alertDefaultProps: TdAlertProps = { close: false, closeBtn: false, maxLine: 0, theme: 'info' };

--- a/packages/components/alert/type.ts
+++ b/packages/components/alert/type.ts
@@ -9,10 +9,15 @@ import { MouseEvent, TransitionEvent } from 'react';
 
 export interface TdAlertProps {
   /**
-   * 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
+   * 即将废弃，请使用 closeBtn 属性。关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
    * @default false
    */
   close?: TNode;
+  /**
+   * 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
+   * @default false
+   */
+  closeBtn?: TNode;
   /**
    * 图标
    */


### PR DESCRIPTION
closes #3623

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/3623

### 💡 需求背景和解决方案

增加closeBtn，先保留close，逐渐过渡。

### 📝 更新日志

- fix(alert): close属性同步为closeBtn，close即将废弃

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
