### PR TITLE
fix(ImageViewer): ensure toolbar icons reliably trigger actions

### DIFF
--- a/packages/components/image-viewer/ImageViewerMini.tsx
+++ b/packages/components/image-viewer/ImageViewerMini.tsx
@@ -13,18 +13,10 @@ export interface ImageModalMiniProps {
   scale: number;
   mirror: number;
   images: ImageInfo[];
-  onClose: (context: { trigger: 'close-btn' | 'overlay' | 'esc'; e: MouseEvent<HTMLElement> | KeyboardEvent }) => void;
   imageScale: ImageScale;
   viewerScale: ImageViewerScale;
   rotateZ: number;
   currentImage: ImageInfo;
-  prev: () => void;
-  next: () => void;
-  onMirror: () => void;
-  onZoom: () => void;
-  onZoomOut: () => void;
-  onReset: () => void;
-  onRotate: (red: number) => void;
   zIndex: number;
   errorText: string;
   tipText: {
@@ -33,6 +25,14 @@ export interface ImageModalMiniProps {
     originalSize: string;
   };
   imageReferrerpolicy?: TdImageViewerProps['imageReferrerpolicy'];
+  prev: () => void;
+  next: () => void;
+  onMirror: () => void;
+  onZoom: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+  onRotate: (red: number) => void;
+  onClose: (context: { trigger: 'close-btn' | 'overlay' | 'esc'; e: MouseEvent<HTMLElement> | KeyboardEvent }) => void;
 }
 
 export const ImageModalMiniContent: React.FC<ImageModalMiniProps> = (props) => {
@@ -61,13 +61,13 @@ export const ImageModalMini: React.FC<ImageModalMiniProps> = (props) => {
     scale,
     currentImage,
     draggable,
+    tipText,
     onZoomOut,
     onZoom,
     onClose,
     onRotate,
     onMirror,
     onReset,
-    tipText,
   } = props;
 
   const { classPrefix } = useConfig();
@@ -75,14 +75,15 @@ export const ImageModalMini: React.FC<ImageModalMiniProps> = (props) => {
   const footer = (
     <div className={`${classPrefix}-image-viewer-mini__footer`}>
       <ImageViewerUtils
+        scale={scale}
+        tipText={tipText}
+        currentImage={currentImage}
+        zIndex={props.zIndex + 1}
         onZoom={onZoom}
         onZoomOut={onZoomOut}
-        scale={scale}
-        currentImage={currentImage}
         onRotate={onRotate}
         onMirror={onMirror}
         onReset={onReset}
-        tipText={tipText}
       />
     </div>
   );

--- a/packages/components/image-viewer/ImageViewerMini.tsx
+++ b/packages/components/image-viewer/ImageViewerMini.tsx
@@ -1,11 +1,9 @@
 import React, { KeyboardEvent, MouseEvent } from 'react';
 import { TNode } from '../common';
 import Dialog from '../dialog';
-import { ImageInfo, ImageScale, ImageViewerScale } from './type';
-import { ImageModalItem, ImageViewerUtils } from './ImageViewerModal';
 import useConfig from '../hooks/useConfig';
-
-import type { TdImageViewerProps } from './type';
+import { ImageModalItem, ImageViewerUtils } from './ImageViewerModal';
+import type { ImageInfo, ImageScale, ImageViewerScale, TdImageViewerProps } from './type';
 
 export interface ImageModalMiniProps {
   visible: boolean;
@@ -32,7 +30,7 @@ export interface ImageModalMiniProps {
   tipText: {
     mirror: string;
     rotate: string;
-    originsize: string;
+    originalSize: string;
   };
   imageReferrerpolicy?: TdImageViewerProps['imageReferrerpolicy'];
 }

--- a/packages/components/image-viewer/ImageViewerModal.tsx
+++ b/packages/components/image-viewer/ImageViewerModal.tsx
@@ -1,32 +1,31 @@
-import React, { useState, useEffect, useCallback, MouseEvent, KeyboardEvent, useRef } from 'react';
+import classNames from 'classnames';
 import { isArray, isFunction } from 'lodash-es';
+import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 import {
   ImageErrorIcon as TdImageErrorIcon,
   ImageIcon as TdImageIcon,
   MirrorIcon as TdMirrorIcon,
   RotationIcon as TdRotationIcon,
 } from 'tdesign-icons-react';
-import classNames from 'classnames';
 import { largeNumberToFixed } from '@tdesign/common-js/input-number/large-number';
-import useImagePreviewUrl from '../hooks/useImagePreviewUrl';
-import { TooltipLite } from '../tooltip';
-import useConfig from '../hooks/useConfig';
-import { useLocaleReceiver } from '../locale/LocalReceiver';
 import { TNode } from '../common';
-import { downloadFile } from './utils';
-import { ImageInfo, ImageScale, ImageViewerScale } from './type';
+import useConfig from '../hooks/useConfig';
+import useGlobalIcon from '../hooks/useGlobalIcon';
+import useImagePreviewUrl from '../hooks/useImagePreviewUrl';
+import Image from '../image';
+import { useLocaleReceiver } from '../locale/LocalReceiver';
+import { TooltipLite } from '../tooltip';
+import { ImageViewerProps } from './ImageViewer';
 import { ImageModalMini } from './ImageViewerMini';
+import useIconMap from './hooks/useIconMap';
+import useIndex from './hooks/useIndex';
 import useMirror from './hooks/useMirror';
 import usePosition from './hooks/usePosition';
-import useIndex from './hooks/useIndex';
 import useRotate from './hooks/useRotate';
 import useScale from './hooks/useScale';
-import useGlobalIcon from '../hooks/useGlobalIcon';
-import useIconMap from './hooks/useIconMap';
-import Image from '../image';
+import { downloadFile } from './utils';
 
-import type { TdImageViewerProps } from './type';
-import { ImageViewerProps } from './ImageViewer';
+import type { ImageInfo, ImageScale, ImageViewerScale, TdImageViewerProps } from './type';
 
 const ImageError = ({ errorText }: { errorText: string }) => {
   const { classPrefix } = useConfig();
@@ -34,7 +33,6 @@ const ImageError = ({ errorText }: { errorText: string }) => {
 
   return (
     <div className={`${classPrefix}-image-viewer__img-error`}>
-      {/* 脱离文档流 */}
       <div className={`${classPrefix}-image-viewer__img-error-content`}>
         <ImageErrorIcon size="4em" />
         <div className={`${classPrefix}-image-viewer__img-error-text`}>{errorText}</div>
@@ -233,7 +231,7 @@ interface ImageViewerUtilsProps {
   tipText: {
     mirror: string;
     rotate: string;
-    originsize: string;
+    originalSize: string;
   };
   onDownload?: TdImageViewerProps['onDownload'];
 }
@@ -260,13 +258,13 @@ export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
     <div className={`${classPrefix}-image-viewer__utils`}>
       <div className={`${classPrefix}-image-viewer__utils-content`}>
         <TooltipLite className={`${classPrefix}-image-viewer__utils--tip`} content={tipText.mirror} showShadow={false}>
-          <div className={`${classPrefix}-image-viewer__modal-icon`}>
-            <MirrorIcon size="medium" onClick={onMirror} />
+          <div className={`${classPrefix}-image-viewer__modal-icon`} onClick={onMirror}>
+            <MirrorIcon size="medium" />
           </div>
         </TooltipLite>
         <TooltipLite className={`${classPrefix}-image-viewer__utils--tip`} content={tipText.rotate} showShadow={false}>
-          <div className={`${classPrefix}-image-viewer__modal-icon`}>
-            <RotationIcon size="medium" onClick={() => onRotate(-ROTATE_COUNT)} />
+          <div className={`${classPrefix}-image-viewer__modal-icon`} onClick={() => onRotate(-ROTATE_COUNT)}>
+            <RotationIcon size="medium" />
           </div>
         </TooltipLite>
         <ImageModalIcon size="medium" name="zoom-out" onClick={onZoomOut} />
@@ -278,17 +276,11 @@ export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
         <ImageModalIcon size="medium" name="zoom-in" onClick={onZoom} />
         <TooltipLite
           className={`${classPrefix}-image-viewer__utils--tip`}
-          content={tipText.originsize}
+          content={tipText.originalSize}
           showShadow={false}
         >
-          <div className={`${classPrefix}-image-viewer__modal-icon`}>
-            <ImageIcon
-              size="medium"
-              name="image"
-              onClick={() => {
-                onReset();
-              }}
-            />
+          <div className={`${classPrefix}-image-viewer__modal-icon`} onClick={onReset}>
+            <ImageIcon size="medium" name="image" />
           </div>
         </TooltipLite>
         {currentImage.download && (
@@ -306,7 +298,6 @@ export const ImageViewerUtils: React.FC<ImageViewerUtilsProps> = ({
           />
         )}
       </div>
-      {/* <IconFont size="3em" name="page-last" onClick={() => onRotate(ROTATE_COUNT)} /> */}
     </div>
   );
 };
@@ -489,7 +480,7 @@ export const ImageModal: React.FC<ImageModalProps> = (props) => {
   const tipText = {
     mirror: t(locale.mirrorTipText),
     rotate: t(locale.rotateTipText),
-    originsize: t(locale.originalSizeTipText),
+    originalSize: t(locale.originalSizeTipText),
   };
   const errorText = t(locale.errorText);
 

--- a/packages/components/image-viewer/ImageViewerModal.tsx
+++ b/packages/components/image-viewer/ImageViewerModal.tsx
@@ -430,7 +430,7 @@ export const ImageModal: React.FC<ImageModalProps> = (props) => {
   if (resProps.index === undefined) delete resProps.index;
   const { index, next, prev, setIndex } = useIndex(resProps, images);
   const { rotateZ, onResetRotate, onRotate } = useRotate();
-  const { scale, onZoom, onZoomOut, onResetScale } = useScale(imageScale);
+  const { scale, onZoom, onZoomOut, onResetScale } = useScale(imageScale, visible);
   const { mirror, onResetMirror, onMirror } = useMirror();
 
   const onReset = useCallback(() => {

--- a/packages/components/image-viewer/_example/album.tsx
+++ b/packages/components/image-viewer/_example/album.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Image, ImageViewer, Space } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Space } from 'tdesign-react';
 import type { ImageViewerProps } from 'tdesign-react';
 
 const imgH = 'https://tdesign.gtimg.com/demo/demo-image-3.png';
@@ -73,7 +73,7 @@ export default function BasicImageViewer() {
 
   return (
     <Space breakLine size={16}>
-      <ImageViewer trigger={trigger} images={images} title="相册封面标题" />
+      <ImageViewer trigger={trigger} images={images} title="相册封面标题" zIndex={10000} />
     </Space>
   );
 }

--- a/packages/components/image-viewer/_example/albumIcons.tsx
+++ b/packages/components/image-viewer/_example/albumIcons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Image, ImageViewer, Popup, Space } from 'tdesign-react';
 import { BrowseIcon, EllipsisIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Popup, Space } from 'tdesign-react';
 import type { ImageViewerProps } from 'tdesign-react';
 
 const imgH = 'https://tdesign.gtimg.com/demo/demo-image-3.png';
@@ -119,7 +119,7 @@ export default function BasicImageViewer() {
 
   return (
     <Space breakLine size={16}>
-      <ImageViewer trigger={trigger} images={images} title="相册封面标题" />
+      <ImageViewer trigger={trigger} images={images} title="相册封面标题" zIndex={10000} />
     </Space>
   );
 }

--- a/packages/components/image-viewer/_example/base.tsx
+++ b/packages/components/image-viewer/_example/base.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ImageViewer, Image, Space } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Space } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -46,7 +46,7 @@ export default function BasicImageViewer() {
 
   return (
     <Space breakLine size={16}>
-      <ImageViewer trigger={trigger} images={[img]} />
+      <ImageViewer trigger={trigger} images={[img]} zIndex={10000} />
     </Space>
   );
 }

--- a/packages/components/image-viewer/_example/block.tsx
+++ b/packages/components/image-viewer/_example/block.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Image, Space, ImageViewer } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Space } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -54,8 +54,8 @@ export default function BasicImageViewer() {
 
   return (
     <Space breakLine size={16}>
-      <ImageViewer trigger={trigger} images={images} />
-      <ImageViewer trigger={trigger} images={[images[0].mainImage]} />
+      <ImageViewer trigger={trigger} images={images} zIndex={10000} />
+      <ImageViewer trigger={trigger} images={[images[0].mainImage]} zIndex={10000} />
     </Space>
   );
 }

--- a/packages/components/image-viewer/_example/button.tsx
+++ b/packages/components/image-viewer/_example/button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ImageViewer, Button } from 'tdesign-react';
+import { Button, ImageViewer } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -7,5 +7,5 @@ const img = 'https://tdesign.gtimg.com/demo/demo-image-1.png';
 
 export default function BasicImageViewer() {
   const trigger: ImageViewerProps['trigger'] = ({ open }) => <Button onClick={open}>预览单张图片</Button>;
-  return <ImageViewer trigger={trigger} images={[img]} />;
+  return <ImageViewer trigger={trigger} images={[img]} zIndex={10000} />;
 }

--- a/packages/components/image-viewer/_example/error.tsx
+++ b/packages/components/image-viewer/_example/error.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Image, ImageViewer, Space } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Space } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -54,7 +54,7 @@ export default function BasicImageViewer() {
           );
         };
 
-        return <ImageViewer key={imgSrc} trigger={trigger} images={images} defaultIndex={index} />;
+        return <ImageViewer key={imgSrc} trigger={trigger} images={images} defaultIndex={index} zIndex={10000} />;
       })}
     </Space>
   );

--- a/packages/components/image-viewer/_example/multiple.tsx
+++ b/packages/components/image-viewer/_example/multiple.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Image, ImageViewer, Space } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer, Space } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -59,7 +59,7 @@ export default function BasicImageViewer() {
           );
         };
 
-        return <ImageViewer key={index} trigger={trigger} images={images} defaultIndex={index} />;
+        return <ImageViewer key={index} trigger={trigger} images={images} defaultIndex={index} zIndex={10000} />;
       })}
     </Space>
   );

--- a/packages/components/image-viewer/_example/svg.tsx
+++ b/packages/components/image-viewer/_example/svg.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ImageViewer, Image } from 'tdesign-react';
 import { BrowseIcon } from 'tdesign-icons-react';
+import { Image, ImageViewer } from 'tdesign-react';
 
 import type { ImageViewerProps } from 'tdesign-react';
 
@@ -53,7 +53,7 @@ const Svg = () => {
   };
   return (
     <div>
-      <ImageViewer trigger={trigger} images={img} />
+      <ImageViewer trigger={trigger} images={img} zIndex={10000} />
     </div>
   );
 };

--- a/packages/components/image-viewer/hooks/useScale.ts
+++ b/packages/components/image-viewer/hooks/useScale.ts
@@ -1,28 +1,80 @@
-// 缩放控制
-import { useCallback, useState } from 'react';
-import { ImageScale } from '../type';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ImageScale } from '../type';
 
-const useScale = (imageScale: ImageScale) => {
-  const [scale, setScale] = useState(() => imageScale.defaultScale ?? 1);
+const useScale = (imageScale: ImageScale, visible: boolean) => {
+  const { max = Infinity, min = 0, step = 0.1, defaultScale = 1 } = imageScale;
+
+  const calcDefaultScale = useCallback(() => Math.max(Math.min(defaultScale, max), min), [defaultScale, max, min]);
+
+  const distance = useRef(0);
+  const [scale, setScale] = useState(calcDefaultScale());
+
   const onZoom = useCallback(() => {
     setScale((scale) => {
-      const newScale = scale + imageScale.step;
-      if (newScale < imageScale.min) return imageScale.min;
-      if (newScale > imageScale.max) return imageScale.max;
+      const newScale = scale + step;
+      if (newScale < min) return min;
+      if (newScale > max) return max;
       return newScale;
     });
-  }, [imageScale]);
+  }, [max, min, step]);
 
   const onZoomOut = useCallback(() => {
     setScale((scale) => {
-      const newScale = scale - imageScale.step;
-      if (newScale < imageScale.min) return imageScale.min;
-      if (newScale > imageScale.max) return imageScale.max;
+      const newScale = scale - step;
+      if (newScale < min) return min;
+      if (newScale > max) return max;
       return newScale;
     });
-  }, [imageScale]);
+  }, [max, min, step]);
 
-  const onResetScale = useCallback(() => setScale(imageScale.defaultScale ?? 1), [imageScale]);
+  const onResetScale = useCallback(() => {
+    setScale(calcDefaultScale());
+  }, [calcDefaultScale]);
+
+  // 鼠标滚轮缩放
+  const onWheel = useCallback((e: WheelEvent) => {
+    e.preventDefault();
+    e.deltaY < 0 ? onZoom() : onZoomOut();
+  }, [onZoom, onZoomOut]);
+
+  // 双指缩放
+  const onTouchStart = useCallback((e: TouchEvent) => {
+    if (e.touches.length !== 2) return;
+    e.preventDefault();
+    const [touch1, touch2] = Array.from(e.touches);
+    distance.current = Math.hypot(touch2.pageX - touch1.pageX, touch2.pageY - touch1.pageY);
+  }, []);
+
+  const onTouchMove = useCallback((e: TouchEvent) => {
+    if (e.touches.length !== 2) return;
+    e.preventDefault();
+    const [touch1, touch2] = Array.from(e.touches);
+    const currentDistance = Math.hypot(touch2.pageX - touch1.pageX, touch2.pageY - touch1.pageY);
+    if (currentDistance > distance.current) {
+      onZoom();
+    } else {
+      onZoomOut();
+    }
+    distance.current = currentDistance;
+  }, [onZoom, onZoomOut]);
+
+  const onTouchEnd = useCallback(() => {
+    distance.current = 0;
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    document.addEventListener('wheel', onWheel, { passive: false });
+    document.addEventListener('touchstart', onTouchStart, { passive: false });
+    document.addEventListener('touchmove', onTouchMove, { passive: false });
+    document.addEventListener('touchend', onTouchEnd);
+    return () => {
+      document.removeEventListener('wheel', onWheel);
+      document.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [visible, onWheel, onTouchStart, onTouchMove, onTouchEnd]);
 
   return {
     scale,

--- a/packages/components/tooltip/TooltipLite.tsx
+++ b/packages/components/tooltip/TooltipLite.tsx
@@ -1,20 +1,21 @@
-import React, { ReactNode, useState, useRef, useEffect, useCallback } from 'react';
 import classnames from 'classnames';
-import { CSSTransition } from 'react-transition-group';
 import { throttle } from 'lodash-es';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { CSSTransition } from 'react-transition-group';
 import getPosition from '@tdesign/common-js/utils/getPosition';
 import { StyledProps } from '../common';
-import useSwitch from '../hooks/useSwitch';
-import useAnimation from '../hooks/useAnimation';
 import Portal from '../common/Portal';
+import useAnimation from '../hooks/useAnimation';
 import useConfig from '../hooks/useConfig';
-import { TdTooltipLiteProps } from './type';
-import { tooltipLiteDefaultProps } from './defaultProps';
-import { getTransitionParams } from '../popup/utils/transition';
 import useDefaultProps from '../hooks/useDefaultProps';
+import useSwitch from '../hooks/useSwitch';
+import { getTransitionParams } from '../popup/utils/transition';
+import { tooltipLiteDefaultProps } from './defaultProps';
+import type { TdTooltipLiteProps } from './type';
 
 export interface TooltipLiteProps extends TdTooltipLiteProps, StyledProps {
   children?: ReactNode;
+  zIndex?: number;
 }
 
 const DEFAULT_TRANSITION_TIMEOUT = 180;
@@ -59,15 +60,15 @@ const TooltipLite: React.FC<TooltipLiteProps> = (originalProps) => {
     [],
   );
 
-  const getTriggerChildren = (children) => {
+  const getTriggerChildren = (children: ReactNode) => {
     const appendProps = {
       ref: triggerRef,
-      onMouseMove: (e) => {
+      onMouseMove: (e: MouseEvent) => {
         const { clientX, clientY } = e;
         return onSwitchMove({ clientX, clientY });
       },
-      onMouseEnter: (e) => onSwitchHover('on', e),
-      onMouseLeave: (e) => onSwitchHover('off', e),
+      onMouseEnter: (e: MouseEvent) => onSwitchHover('on', e),
+      onMouseLeave: (e: MouseEvent) => onSwitchHover('off', e),
     };
     if (!React.isValidElement(children)) {
       return React.cloneElement(<div>{children}</div>, { ...appendProps });
@@ -106,6 +107,7 @@ const TooltipLite: React.FC<TooltipLiteProps> = (originalProps) => {
                 position: 'absolute',
                 left: position?.left,
                 top: position?.top,
+                zIndex: props.zIndex,
               }}
               data-popper-placement={placement}
               ref={popupRef}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- ***`Fix 1`***：工具栏的 `onMirror`、`onRotate` 等方法是直接绑定在 `Icon` 上面，导致点击 `Icon` 边缘的时候无法触发操作，因此改为绑定在 `Icon` 外层的 `div`。

- ***`Fix 2`***：主题生成器的 `zIndex` 过高了，于是调整了 `ImageViewer` Demo 的 `zIndex`，却又发现了 `TooltipLite` 层级过低。因此给 `TooltipLite` 新增一个 `zIndex` Prop，将当前 ImageViewer 的 `zIndex + 1` 传给 `TooltipLite`。

  <img src="https://github.com/user-attachments/assets/0c77135d-336e-4424-827c-ad49bb2a462d" width="300" />
  <img src="https://github.com/user-attachments/assets/2ac30840-47c4-4a70-801e-be36209ecf13" width="300" />

- 还有一条相关的修复，可以等 https://github.com/Tencent/tdesign-common/pull/2179 合并后，顺便在这条 PR 下 `/update-common`

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 修复点击工具栏的图标边缘时无法触发对应的操作
- fix(ImageViewer): 修复由于 `TooltipLite` 引起的 `z-index` 层级关系异常
- feat(ImageViewer): 移动端支持通过双指进行缩放图片

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
