### PR TITLE
fix(Table): `tree.defaultExpandAll` not work

### DIFF
--- a/packages/components/table/hooks/useTreeData.tsx
+++ b/packages/components/table/hooks/useTreeData.tsx
@@ -1,17 +1,17 @@
+import classNames from 'classnames';
+import { get } from 'lodash-es';
 import React, { MouseEvent, useEffect, useMemo, useState } from 'react';
 import {
   AddRectangleIcon as TdAddRectangleIcon,
   MinusRectangleIcon as TdMinusRectangleIcon,
 } from 'tdesign-icons-react';
-import { get } from 'lodash-es';
-import classNames from 'classnames';
 import TableTreeStore, { SwapParams } from '@tdesign/common-js/table/tree-store';
-import { TdEnhancedTableProps, PrimaryTableCol, TableRowData, TableRowValue, TableRowState } from '../type';
-import useClassName from './useClassName';
-import { renderCell } from '../Cell';
-import { useLocaleReceiver } from '../../locale/LocalReceiver';
-import useGlobalIcon from '../../hooks/useGlobalIcon';
 import { parseContentTNode } from '../../_util/parseTNode';
+import useGlobalIcon from '../../hooks/useGlobalIcon';
+import { useLocaleReceiver } from '../../locale/LocalReceiver';
+import { renderCell } from '../Cell';
+import type { PrimaryTableCol, TableRowData, TableRowState, TableRowValue, TdEnhancedTableProps } from '../type';
+import useClassName from './useClassName';
 import useTreeDataExpand from './useTreeDataExpand';
 
 export interface UseSwapParams<T> extends SwapParams<T> {
@@ -38,15 +38,12 @@ export default function useTreeData(props: TdEnhancedTableProps) {
     [rowKey, tree?.childrenKey],
   );
 
-  const [isDefaultExpandedTreeNodesExecute, setIsDefaultExpandedTreeNodesExecute] = useState(false);
-  const {
-    tExpandedTreeNode,
-    isDefaultExpandAllExecute,
-    expandAll,
-    foldAll,
-    updateExpandOnDataChange,
-    onExpandFoldIconClick,
-  } = useTreeDataExpand(props, { store, dataSource, rowDataKeys, setDataSource });
+  const { expandAll, foldAll, updateExpandOnDataChange, onExpandFoldIconClick } = useTreeDataExpand(props, {
+    store,
+    dataSource,
+    rowDataKeys,
+    setDataSource,
+  });
 
   const checkedColumn = useMemo(() => columns.find((col) => col.colKey === 'row-select'), [columns]);
 
@@ -83,16 +80,9 @@ export default function useTreeData(props: TdEnhancedTableProps) {
   );
 
   function resetData(data: TableRowData[]) {
-    const { columns, expandedTreeNodes, defaultExpandedTreeNodes } = props;
+    const { columns } = props;
     store.initialTreeStore(data, columns, rowDataKeys);
-    const defaultNeedExpand = Boolean(!isDefaultExpandedTreeNodesExecute && defaultExpandedTreeNodes?.length);
-    const needExpandAll = Boolean(tree?.defaultExpandAll && !isDefaultExpandAllExecute);
-    if ((tExpandedTreeNode?.length && !!(expandedTreeNodes || defaultNeedExpand)) || needExpandAll) {
-      updateExpandOnDataChange([...data]);
-      setIsDefaultExpandedTreeNodesExecute(true);
-    } else {
-      setDataSource([...data]);
-    }
+    updateExpandOnDataChange([...data]);
   }
 
   function getTreeNodeStyle(level: number) {

--- a/packages/components/table/hooks/useTreeDataExpand.ts
+++ b/packages/components/table/hooks/useTreeDataExpand.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import TableTreeStore, { diffExpandedTreeNode, getUniqueRowValue } from '@tdesign/common-js/table/tree-store';
-import usePrevious from '../../hooks/usePrevious';
-import { TdEnhancedTableProps, TableRowData } from '../type';
 import useControlled from '../../hooks/useControlled';
-import { TableTreeExpandType } from '../interface';
+import usePrevious from '../../hooks/usePrevious';
+import type { TableTreeExpandType } from '../interface';
+import type { TableRowData, TdEnhancedTableProps } from '../type';
 
 export function useTreeDataExpand(
   props: TdEnhancedTableProps,
@@ -140,8 +140,6 @@ export function useTreeDataExpand(
   };
 
   return {
-    tExpandedTreeNode,
-    isDefaultExpandAllExecute,
     expandAll,
     foldAll,
     onExpandFoldIconClick,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/3566

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

`resetData` 中引入了一堆复杂的条件判断，在 `useEffect` 中产生状态顺序冲突，意外把 expend 的状态错误 reset 了。实际上，`useTreeDataExpand` 的 `updateExpandOnDataChange` 内部本身就有 `isDefaultExpandAllExecute` 和 `setDataSource` 的相关处理逻辑了，完全交给它就可以 🤔？

```tsx
const updateExpandOnDataChange = (data: TableRowData[]) => {
  if (tree?.defaultExpandAll && !isDefaultExpandAllExecute) {
    expandAll('default-expand-all', [...data]);
    setIsDefaultExpandAllExecute(true);
  } else if (tExpandedTreeNode?.length) {
    const newData = updateExpandState([...data], tExpandedTreeNode, []);
    setDataSource([...newData]);
  }
};
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): `tree.defaultExpandAll` 在一些场景下无法生效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
