### PR TITLE
fix(Popup): enhance arrow modifier support for popper.js

### DIFF
--- a/packages/components/guide/__tests__/__snapshots__/vitest-guide.test.jsx.snap
+++ b/packages/components/guide/__tests__/__snapshots__/vitest-guide.test.jsx.snap
@@ -169,8 +169,7 @@ exports[`Guide Component > GuideStep.body works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          data-popper-arrow="true"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          style=""
         />
       </div>
     </div>
@@ -624,8 +623,7 @@ exports[`Guide Component > GuideStep.highlightContent works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          data-popper-arrow="true"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          style=""
         />
       </div>
     </div>
@@ -994,8 +992,7 @@ exports[`Guide Component > GuideStep.placement is equal to bottom-left 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          data-popper-arrow="true"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          style=""
         />
       </div>
     </div>
@@ -1168,8 +1165,7 @@ exports[`Guide Component > GuideStep.stepOverlayClass is equal to t-test-guide-s
         </div>
         <div
           class="t-popup__arrow"
-          data-popper-arrow="true"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          style=""
         />
       </div>
     </div>
@@ -1346,8 +1342,7 @@ exports[`Guide Component > GuideStep.title works fine 1`] = `
         </div>
         <div
           class="t-popup__arrow"
-          data-popper-arrow="true"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          style=""
         />
       </div>
     </div>

--- a/packages/components/popup/Popup.tsx
+++ b/packages/components/popup/Popup.tsx
@@ -1,5 +1,4 @@
-import type { Options } from '@popperjs/core';
-import { Placement } from '@popperjs/core';
+import { Placement, type Options } from '@popperjs/core';
 import classNames from 'classnames';
 import { debounce, isFunction } from 'lodash-es';
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';

--- a/packages/components/popup/PopupPlugin.tsx
+++ b/packages/components/popup/PopupPlugin.tsx
@@ -1,5 +1,4 @@
-import type { Options } from '@popperjs/core';
-import { createPopper, Instance, Placement } from '@popperjs/core';
+import { createPopper, Instance, Placement, type Options } from '@popperjs/core';
 import classNames from 'classnames';
 import { isString } from 'lodash-es';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';

--- a/packages/components/popup/PopupPlugin.tsx
+++ b/packages/components/popup/PopupPlugin.tsx
@@ -1,17 +1,18 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { Options } from '@popperjs/core';
 import { createPopper, Instance, Placement } from '@popperjs/core';
-import { isString } from 'lodash-es';
 import classNames from 'classnames';
+import { isString } from 'lodash-es';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { render, unmount } from '../_util/react-render';
 import { getAttach } from '../_util/dom';
-import { TNode } from '../common';
-import { TdPopupProps } from './type';
-import useDefaultProps from '../hooks/useDefaultProps';
-import { popupDefaultProps } from './defaultProps';
 import { off, on } from '../_util/listener';
+import { render, unmount } from '../_util/react-render';
+import type { TNode } from '../common';
 import PluginContainer from '../common/PluginContainer';
 import ConfigProvider from '../config-provider';
+import useDefaultProps from '../hooks/useDefaultProps';
+import { popupDefaultProps } from './defaultProps';
+import type { TdPopupProps } from './type';
 
 export interface PopupPluginApi {
   config: TdPopupProps;
@@ -68,7 +69,7 @@ const Overlay: React.FC<OverlayProps> = (originalProps) => {
 
   const hidePopup = hideEmptyPopup && isString(content) && ['', undefined, null].includes(content);
 
-  const stylePoper = (): React.CSSProperties => {
+  const stylePopper = (): React.CSSProperties => {
     let style = {};
     if (hidePopup) {
       style = { visibility: 'hidden', pointerEvents: 'none' };
@@ -131,6 +132,8 @@ const Overlay: React.FC<OverlayProps> = (originalProps) => {
     onMouseMove: handleMouseEnter,
   };
 
+  const hasArrowModifier = (props.popperOptions as Options)?.modifiers?.some((modifier) => modifier.name === 'arrow');
+
   // render node
   const renderNode = (
     <div
@@ -139,13 +142,14 @@ const Overlay: React.FC<OverlayProps> = (originalProps) => {
         renderCallback(ref);
       }}
       className={classNames([componentName, overlayClassName])}
-      style={stylePoper()}
+      style={stylePopper()}
       {...eventProps}
     >
       <div ref={overlayRef} className={classNames(overlayClasses)} style={overlayInnerStyleMerge()}>
         {content}
-        {/* popper.js 修饰符(modifiers)的高级功能 arrow 会自动根据属性 data-popper-arrow 来识别箭头元素，从而支持调整箭头位置(padding) */}
-        {showArrow && <div className={`${componentName}__arrow`} data-popper-arrow></div>}
+        {showArrow && (
+          <div className={`${componentName}__arrow`} {...(hasArrowModifier && { 'data-popper-arrow': '' })} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/pull/3437

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

箭头位置在左右两侧时，无法居中（[官网 Plugin](http://localhost:15000/react/components/popup?tab=demo#%E9%80%9A%E8%BF%87%E6%8F%92%E4%BB%B6%E6%96%B9%E5%BC%8F%E8%B0%83%E7%94%A8popup) 可复现）：
![image](https://github.com/user-attachments/assets/a921a12a-f4e3-4a1e-90bd-e46d41e4b2fc)

- 当用户启用 `popperOptions.modifiers`，且 `name = "arrow"`  时，再给 div 赋予 `data-popper-arrow` 属性，否则会和 styles 冲突（根据 [popper.js 文档](https://popper.js.org/docs/v2/modifiers/)，modifiers 有多种，但实际上只有当启用 `arrow` 时，需要额外设置这种[特殊属性](https://popper.js.org/docs/v2/modifiers/arrow/#element)）

```tsx
import React from 'react';
import { Button, Popup } from 'tdesign-react';

export default function BasicUsage() {
  return (
    <Popup
      showArrow
      trigger="hover"
      content="这是一个弹出框"
      placement="right"
      popperOptions={{
        modifiers: [
          {
            name: 'arrow',
            options: {
              // padding: 5, // 箭头偏上
              // padding: 15, // 差不多居中
              padding: 20, // 箭头偏下
            },
          },
        ],
      }}
    >
      <Button>Hover me</Button>
    </Popup>
  );
}
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 修复 `1.11.2` 引入 popper.js 的 `arrow` 修饰符导致箭头位置偏移

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
