### PR TITLE
Docs/input

### DIFF
--- a/packages/components/date-picker/hooks/useRange.tsx
+++ b/packages/components/date-picker/hooks/useRange.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { CalendarIcon as TdCalendarIcon } from 'tdesign-icons-react';
 import classNames from 'classnames';
-import { isValidDate, formatDate, getDefaultFormat, parseToDayjs } from '@tdesign/common-js/date-picker/format';
+import React, { useEffect, useRef, useState } from 'react';
+import { CalendarIcon as TdCalendarIcon } from 'tdesign-icons-react';
+import { formatDate, getDefaultFormat, isValidDate, parseToDayjs } from '@tdesign/common-js/date-picker/format';
 import useConfig from '../../hooks/useConfig';
 import useGlobalIcon from '../../hooks/useGlobalIcon';
-import { RangeInputRefInterface } from '../../range-input';
-import { TdDateRangePickerProps, DateValue } from '../type';
-import useRangeValue from './useRangeValue';
 import type { TdPopupProps } from '../../popup/type';
+import type { RangeInputRef } from '../../range-input';
+import type { DateValue, TdDateRangePickerProps } from '../type';
+import useRangeValue from './useRangeValue';
 
 export const PARTIAL_MAP = { first: 'start', second: 'end' };
 
@@ -17,7 +17,7 @@ export default function useRange(props: TdDateRangePickerProps) {
   const name = `${classPrefix}-date-range-picker`;
 
   const isMountedRef = useRef(false);
-  const inputRef = useRef<RangeInputRefInterface>(null);
+  const inputRef = useRef<RangeInputRef>(null);
 
   const {
     value,

--- a/packages/components/input-number/index.ts
+++ b/packages/components/input-number/index.ts
@@ -2,7 +2,7 @@ import _InputNumber from './InputNumber';
 
 import './style/index.js';
 
-export type { InputNumberProps } from './InputNumber';
+export type { InputNumberProps, InputNumberRef } from './InputNumber';
 export * from './type';
 
 export const InputNumber = _InputNumber;

--- a/packages/components/input/Input.tsx
+++ b/packages/components/input/Input.tsx
@@ -1,28 +1,34 @@
-import React, { useState, useRef, useImperativeHandle, useEffect } from 'react';
 import classNames from 'classnames';
+import { isFunction } from 'lodash-es';
+import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import {
   BrowseIcon as TdBrowseIcon,
   BrowseOffIcon as TdBrowseOffIcon,
   CloseCircleFilledIcon as TdCloseCircleFilledIcon,
 } from 'tdesign-icons-react';
-import { isFunction } from 'lodash-es';
-import useLayoutEffect from '../hooks/useLayoutEffect';
 import forwardRefWithStatics from '../_util/forwardRefWithStatics';
+import parseTNode from '../_util/parseTNode';
+import { StyledProps, type TElement, type TNode } from '../common';
 import useConfig from '../hooks/useConfig';
-import useGlobalIcon from '../hooks/useGlobalIcon';
-import { TdInputProps } from './type';
-import { StyledProps, TNode, TElement } from '../common';
-import InputGroup from './InputGroup';
 import useControlled from '../hooks/useControlled';
+import useDefaultProps from '../hooks/useDefaultProps';
+import useGlobalIcon from '../hooks/useGlobalIcon';
+import useLayoutEffect from '../hooks/useLayoutEffect';
 import { useLocaleReceiver } from '../locale/LocalReceiver';
 import { inputDefaultProps } from './defaultProps';
-import parseTNode from '../_util/parseTNode';
+import InputGroup from './InputGroup';
+import type { TdInputProps } from './type';
 import useLengthLimit from './useLengthLimit';
-import useDefaultProps from '../hooks/useDefaultProps';
 
-export interface InputProps extends TdInputProps, StyledProps {
-  showInput?: boolean; // 控制透传readonly同时是否展示input 默认保留 因为正常Input需要撑开宽度
-  keepWrapperWidth?: boolean; // 控制透传autoWidth之后是否容器宽度也自适应 多选等组件需要用到自适应但也需要保留宽度
+export interface InputProps
+  extends Omit<
+      React.TextareaHTMLAttributes<HTMLInputElement>,
+      'value' | 'defaultValue' | 'spellCheck' | 'onBlur' | 'onChange' | 'onClick' | 'onFocus' | 'onPaste' | 'onWheel'
+    >,
+    TdInputProps,
+    StyledProps {
+  showInput?: boolean; // 控制透传 readonly 同时是否展示 input；默认保留，因为正常 Input 需要撑开宽度
+  keepWrapperWidth?: boolean; // 控制透传 autoWidth 之后是否容器宽度也自适应；多选等组件需要用到自适应，但也需要保留宽度
 }
 
 export interface InputRef extends React.RefObject<unknown> {
@@ -103,6 +109,22 @@ const Input = forwardRefWithStatics(
       ...restProps
     } = props;
 
+    const inputPropsNames = Object.keys(restProps).filter((key) => !/^on[A-Z]/.test(key));
+    const inputProps = inputPropsNames.reduce(
+      (textareaProps, key) => Object.assign(textareaProps, { [key]: props[key] }),
+      {},
+    );
+    const eventPropsNames = Object.keys(restProps).filter((key) => /^on[A-Z]/.test(key));
+    const eventProps = eventPropsNames.reduce((eventProps, key) => {
+      Object.assign(eventProps, {
+        [key]: (e: React.SyntheticEvent<HTMLInputElement>) => {
+          if (disabled) return;
+          props[key](e);
+        },
+      });
+      return eventProps;
+    }, {});
+
     const [value, onChange] = useControlled(props, 'value', onChangeFromProps);
     const { limitNumber, getValueByLimitNumber, tStatus } = useLengthLimit({
       value: value === undefined ? undefined : String(value),
@@ -119,10 +141,10 @@ const Input = forwardRefWithStatics(
     // inputPreRef 用于预存输入框宽度，应用在 auto width 模式中
     const inputPreRef: React.RefObject<HTMLInputElement> = useRef(null);
     const wrapperRef: React.RefObject<HTMLDivElement> = useRef(null);
+
     const [isHover, toggleIsHover] = useState(false);
     const [isFocused, toggleIsFocused] = useState(false);
     const [renderType, setRenderType] = useState(type);
-
     const [composingValue, setComposingValue] = useState<string>('');
 
     // 组件内部 input 原生控件是否处于 readonly 状态，当整个组件 readonly 时，或者处于不可输入时
@@ -221,7 +243,10 @@ const Input = forwardRefWithStatics(
 
     const renderInput = (
       <input
+        {...inputProps}
+        {...eventProps}
         ref={inputRef}
+        name={name}
         placeholder={placeholder}
         type={renderType}
         className={classNames(`${classPrefix}-input__inner`, {
@@ -241,7 +266,6 @@ const Input = forwardRefWithStatics(
         onFocus={handleFocus}
         onBlur={handleBlur}
         onPaste={handlePaste}
-        name={name}
       />
     );
 
@@ -406,7 +430,6 @@ const Input = forwardRefWithStatics(
         className={classNames(`${classPrefix}-input__wrap`, className, {
           [`${classPrefix}-input--auto-width`]: autoWidth && !keepWrapperWidth,
         })}
-        {...restProps}
       >
         {renderInputNode}
         {tips && (

--- a/packages/components/input/_example/native-element.tsx
+++ b/packages/components/input/_example/native-element.tsx
@@ -1,0 +1,22 @@
+import React, { useRef } from 'react';
+import { Button, Input, Space, type InputRef } from 'tdesign-react';
+
+export default function InputNativeElementDemo() {
+  const inputRef = useRef<InputRef>(null);
+
+  const handleSelectAll = () => {
+    const inputElement = inputRef.current?.inputElement;
+    if (!inputElement) return;
+    inputElement.focus();
+    inputElement.setSelectionRange(0, inputElement.value.length);
+  };
+
+  return (
+    <Space direction="vertical">
+      <Space align="center">
+        <Button onClick={handleSelectAll}>点击全选文本</Button>
+      </Space>
+      <Input ref={inputRef} defaultValue="Hello World" />
+    </Space>
+  );
+}

--- a/packages/components/input/_example/native-event.tsx
+++ b/packages/components/input/_example/native-event.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Divider, Input, Space } from 'tdesign-react';
+
+export default function InputNativeEventDemo() {
+  const [cursorPosition, setCursorPosition] = useState<number>(0);
+  const [selectedText, setSelectedText] = useState<string>('');
+
+  /* 文档上明确有写的事件，遵循其回调格式 */
+  const handleBlur = (value: string, context: { e: React.FocusEvent<HTMLInputElement> }) => {
+    console.log(value, context);
+    setCursorPosition(0);
+    setSelectedText('');
+  };
+
+  /* 文档上没写的事件，遵循原生的回调格式 */
+  const handleSelect = (e: React.FocusEvent<HTMLInputElement>) => {
+    const { value, selectionStart, selectionEnd } = e.target;
+    const selectedText = value.substring(selectionStart, selectionEnd);
+    setCursorPosition(selectionStart);
+    setSelectedText(selectedText);
+  };
+
+  return (
+    <Space size="100px">
+      <Space direction="vertical">
+        {/* 设置 Tab 键切换焦点的顺序，如果不设置，默认按 DOM 顺序，否则根据 tabIndex 的大小
+          https://developer.mozilla.org/docs/Web/HTML/Reference/Global_attributes/tabindex */}
+        <Input tabIndex={2} placeholder="我会被聚焦" />
+        <Input placeholder="先聚焦我，然后按 Tab 键切换焦点" tabIndex={1} style={{ width: 300 }} />
+        {/* <input tabIndex={2} placeholder="我会被聚焦" />
+        <input tabIndex={1} placeholder="先聚焦我，然后按 Tab 键切换焦点"/> */}
+      </Space>
+      <Divider layout="vertical" style={{ height: '100%' }} />
+      <Space direction="vertical">
+        <Input defaultValue="Helle World" onBlur={handleBlur} onSelect={handleSelect} />
+        <Space direction="vertical">
+          <p>光标位置: {cursorPosition}</p>
+          <p>选中文本: {selectedText || '未选中'}</p>
+        </Space>
+      </Space>
+    </Space>
+  );
+}

--- a/packages/components/input/input.md
+++ b/packages/components/input/input.md
@@ -1,5 +1,19 @@
 :: BASE_DOC ::
 
+## FAQ
+
+### 如何获取组件内部原生的 `<input />` 元素并进行自定义操作？
+
+使用 `ref` 获取组件实例，并调用 `inputRef.current.inputElement`，从而获取原生的 HTML 元素，例子如下：
+
+{{ native-element }}
+
+### 部分原生属性与事件在 API 文档中没有提及？
+
+全部支持穿透。但如果文档上明确标明了某个事件的回调，请遵循其写法；否则统一返回 React 的合成事件，例子如下：
+
+{{ native-event }}
+
 ## API
 
 ### Input Props

--- a/packages/components/range-input/RangeInput.tsx
+++ b/packages/components/range-input/RangeInput.tsx
@@ -1,20 +1,20 @@
-import React, { useState, useRef, useImperativeHandle } from 'react';
 import classNames from 'classnames';
 import { isFunction } from 'lodash-es';
+import React, { useImperativeHandle, useRef, useState } from 'react';
 import { CloseCircleFilledIcon as TdCloseCircleFilledIcon } from 'tdesign-icons-react';
-import Input, { InputRef } from '../input';
-import useConfig from '../hooks/useConfig';
-import useGlobalIcon from '../hooks/useGlobalIcon';
-import useControlled from '../hooks/useControlled';
-import type { StyledProps, TNode } from '../common';
 import parseTNode from '../_util/parseTNode';
-import type { TdRangeInputProps, RangeInputValue, RangeInputInstanceFunctions } from './type';
-import { rangeInputDefaultProps } from './defaultProps';
+import type { StyledProps, TNode } from '../common';
+import useConfig from '../hooks/useConfig';
+import useControlled from '../hooks/useControlled';
 import useDefaultProps from '../hooks/useDefaultProps';
+import useGlobalIcon from '../hooks/useGlobalIcon';
+import Input, { type InputRef } from '../input';
+import { rangeInputDefaultProps } from './defaultProps';
+import type { RangeInputInstanceFunctions, RangeInputValue, TdRangeInputProps } from './type';
 
 export interface RangeInputProps extends TdRangeInputProps, StyledProps {}
 
-export interface RangeInputRefInterface extends React.RefObject<unknown>, RangeInputInstanceFunctions {
+export interface RangeInputRef extends React.RefObject<unknown>, RangeInputInstanceFunctions {
   currentElement: HTMLFormElement;
 }
 

--- a/packages/components/range-input/index.ts
+++ b/packages/components/range-input/index.ts
@@ -3,7 +3,7 @@ import _RangeInputPopup from './RangeInputPopup';
 
 import './style/index.js';
 
-export type { RangeInputProps, RangeInputRefInterface } from './RangeInput';
+export type { RangeInputProps, RangeInputRef } from './RangeInput';
 export type { RangeInputPopupProps } from './RangeInputPopup';
 export * from './type';
 

--- a/packages/components/select-input/SelectInput.tsx
+++ b/packages/components/select-input/SelectInput.tsx
@@ -1,24 +1,26 @@
-import React, { useRef, useImperativeHandle } from 'react';
 import classNames from 'classnames';
+import React, { useImperativeHandle, useRef } from 'react';
+import { StyledProps } from '../common';
 import useConfig from '../hooks/useConfig';
-import Popup, { PopupRef, PopupVisibleChangeContext } from '../popup';
-import useSingle from './useSingle';
+import useDefaultProps from '../hooks/useDefaultProps';
+import type { InputRef } from '../input';
+import Popup, { type PopupRef, type PopupVisibleChangeContext } from '../popup';
+import { selectInputDefaultProps } from './defaultProps';
+import type { TdSelectInputProps } from './type';
 import useMultiple from './useMultiple';
 import useOverlayInnerStyle from './useOverlayInnerStyle';
-import { TdSelectInputProps } from './type';
-import { StyledProps } from '../common';
-import { selectInputDefaultProps } from './defaultProps';
-import useDefaultProps from '../hooks/useDefaultProps';
-import { InputRef } from '../input';
+import useSingle from './useSingle';
 
 export interface SelectInputProps extends TdSelectInputProps, StyledProps {
   updateScrollTop?: (content: HTMLDivElement) => void;
   options?: any[]; // 参数穿透options, 给SelectInput/SelectInput 自定义选中项呈现的内容和多选状态下设置折叠项内容
 }
 
-const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputProps>((originalProps, ref) => {
+export interface SelectInputRef extends PopupRef, InputRef {}
+
+const SelectInput = React.forwardRef<Partial<SelectInputRef>, SelectInputProps>((originalProps, ref) => {
   const props = useDefaultProps<SelectInputProps>(originalProps, selectInputDefaultProps);
-  const selectInputRef = useRef<PopupRef>(null);
+  const popupRef = useRef<PopupRef>(null);
   const selectInputWrapRef = useRef<HTMLDivElement>(null);
   const { classPrefix: prefix } = useConfig();
   const { multiple, value, popupVisible, popupProps, borderless, disabled } = props;
@@ -41,7 +43,7 @@ const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputPr
   ]);
 
   useImperativeHandle(ref, () => ({
-    ...(selectInputRef.current || {}),
+    ...(popupRef.current || {}),
     ...(inputRef.current || {}),
     ...(tagInputRef.current || {}),
   }));
@@ -61,7 +63,7 @@ const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputPr
   const mainContent = (
     <div className={popupClasses} style={props.style}>
       <Popup
-        ref={selectInputRef}
+        ref={popupRef}
         trigger={popupProps?.trigger || 'click'}
         placement="bottom-left"
         content={props.panel}

--- a/packages/components/select-input/index.ts
+++ b/packages/components/select-input/index.ts
@@ -2,7 +2,7 @@ import _SelectInput from './SelectInput';
 
 import './style/index.js';
 
-export type { SelectInputProps } from './SelectInput';
+export type { SelectInputProps, SelectInputRef } from './SelectInput';
 export * from './type';
 
 export const SelectInput = _SelectInput;

--- a/packages/components/textarea/_example/native-element.tsx
+++ b/packages/components/textarea/_example/native-element.tsx
@@ -1,0 +1,22 @@
+import React, { useRef } from 'react';
+import { Button, Space, Textarea, type TextareaRef } from 'tdesign-react';
+
+export default function TextareaNativeElementDemo() {
+  const textareaRef = useRef<TextareaRef>(null);
+
+  const handleSelectAll = () => {
+    const inputElement = textareaRef.current?.textareaElement;
+    if (!inputElement) return;
+    inputElement.focus();
+    inputElement.setSelectionRange(0, inputElement.value.length);
+  };
+
+  return (
+    <Space direction="vertical">
+      <Space align="center">
+        <Button onClick={handleSelectAll}>点击全选文本</Button>
+      </Space>
+      <Textarea ref={textareaRef} defaultValue="Hello World" />
+    </Space>
+  );
+}

--- a/packages/components/textarea/_example/native-event.tsx
+++ b/packages/components/textarea/_example/native-event.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { Divider, Space, Textarea } from 'tdesign-react';
+
+export default function TextareaNativeEventDemo() {
+  const [cursorPosition, setCursorPosition] = useState<number>(0);
+  const [selectedText, setSelectedText] = useState<string>('');
+
+  /* 文档上明确有写的事件，遵循其回调格式 */
+  const handleBlur = (value: string, context: { e: React.FocusEvent<HTMLTextAreaElement> }) => {
+    console.log(value, context);
+    setCursorPosition(0);
+    setSelectedText('');
+  };
+
+  /* 文档上没写的事件，遵循原生的回调格式 */
+  const handleSelect = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const { value, selectionStart, selectionEnd } = e.target;
+    const selectedText = value.substring(selectionStart, selectionEnd);
+    setCursorPosition(selectionStart);
+    setSelectedText(selectedText);
+  };
+
+  return (
+    <Space size="100px">
+      <Space direction="vertical">
+        {/* 设置 Tab 键切换焦点的顺序，如果不设置，默认按 DOM 顺序，否则根据 tabIndex 的大小
+          https://developer.mozilla.org/docs/Web/HTML/Reference/Global_attributes/tabindex */}
+        <Textarea tabIndex={2} placeholder="我会被聚焦" />
+        <Textarea placeholder="先聚焦我，然后按 Tab 键切换焦点" tabIndex={1} style={{ width: 300 }} />
+      </Space>
+      <Divider layout="vertical" style={{ height: '100%' }} />
+      <Space direction="vertical">
+        <Textarea defaultValue="Helle World" onBlur={handleBlur} onSelect={handleSelect} />
+        <Space direction="vertical">
+          <p>光标位置: {cursorPosition}</p>
+          <p>选中文本: {selectedText || '未选中'}</p>
+        </Space>
+      </Space>
+    </Space>
+  );
+}

--- a/packages/components/textarea/index.tsx
+++ b/packages/components/textarea/index.tsx
@@ -2,7 +2,7 @@ import _Textarea from './Textarea';
 
 import './style/index.js';
 
-export type { TextareaProps } from './Textarea';
+export type { TextareaProps, TextareaRef } from './Textarea';
 export * from './type';
 
 export const Textarea = _Textarea;

--- a/packages/components/textarea/textarea.md
+++ b/packages/components/textarea/textarea.md
@@ -1,5 +1,19 @@
 :: BASE_DOC ::
 
+## FAQ
+
+### 如何获取组件内部原生的 `<textarea />` 元素并进行自定义操作？
+
+使用 `ref` 获取组件实例，并调用 `textareaRef.current.textareaElement`，从而获取原生的 HTML 元素，例子如下：
+
+{{ native-element }}
+
+### 部分原生属性与事件在 API 文档中没有提及？
+
+全部支持穿透。但如果文档上明确标明了某个事件的回调，请遵循其写法；否则按照原生的回调格式，统一返回 React 的合成事件，例子如下：
+
+{{ native-event }}
+
 ## API
 ### Textarea Props
 

--- a/packages/tdesign-react/site/plugins/plugin-tdoc/index.js
+++ b/packages/tdesign-react/site/plugins/plugin-tdoc/index.js
@@ -1,25 +1,32 @@
 import vitePluginTdoc from 'vite-plugin-tdoc';
 
-import transforms from './transforms';
 import renderDemo from './demo';
+import transforms from './transforms';
 
-export default () => vitePluginTdoc({
-  transforms, // 解析 markdown 数据
-  markdown: {
-    anchor: {
-      tabIndex: false,
-      config: (anchor) => ({
-        permalink: anchor.permalink.linkInsideHeader({ symbol: '' }),
-      }),
+export default () =>
+  vitePluginTdoc({
+    transforms, // 解析 markdown 数据
+    markdown: {
+      anchor: {
+        tabIndex: false,
+        config: (anchor) => ({
+          permalink: anchor.permalink.linkInsideHeader({ symbol: '' }),
+        }),
+      },
+      toc: {
+        listClass: 'tdesign-toc_list',
+        itemClass: 'tdesign-toc_list_item',
+        linkClass: 'tdesign-toc_list_item_a',
+        containerClass: 'tdesign-toc_container',
+        format: parseHeader,
+      },
+      container(md, container) {
+        renderDemo(md, container);
+      },
     },
-    toc: {
-      listClass: 'tdesign-toc_list',
-      itemClass: 'tdesign-toc_list_item',
-      linkClass: 'tdesign-toc_list_item_a',
-      containerClass: 'tdesign-toc_container',
-    },
-    container(md, container) {
-      renderDemo(md, container);
-    },
-  },
-});
+  });
+
+function parseHeader(header) {
+  // 转义 HTML 标签
+  return header.replace(/</g, '&lt;').replace(/>/g, '&gt;').trim();
+}

--- a/packages/tdesign-react/site/plugins/plugin-tdoc/md-to-react.js
+++ b/packages/tdesign-react/site/plugins/plugin-tdoc/md-to-react.js
@@ -12,7 +12,6 @@ import { fileURLToPath } from 'url';
 import { compileUsage, getGitTimestamp } from '@tdesign/common-docs/compile';
 import testCoverage from '../../test-coverage';
 
-// eslint-disable-next-line no-underscore-dangle
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default async function mdToReact(options) {
@@ -181,7 +180,6 @@ const DEFAULT_EN_TABS = [
 async function customRender({ source, file, md }) {
   let { content, data } = matter(source);
   const lastUpdated = (await getGitTimestamp(file)) || Math.round(fs.statSync(file).mtimeMs);
-  // console.log('data', data);
   const isEn = file.endsWith('en-US.md');
   // md top data
   const pageData = {
@@ -207,9 +205,15 @@ async function customRender({ source, file, md }) {
   let [demoMd = '', apiMd = ''] = content.split(pageData.apiFlag);
 
   // fix table | render error
-  demoMd = demoMd.replace(/`([^`\r\n]+)`/g, (str, codeStr) => {
-    codeStr = codeStr.replace(/"/g, "'");
-    return `<td-code text="${codeStr}"></td-code>`;
+  demoMd = demoMd.replace(/^(.*?)$/gm, (line) => {
+    if (/^#+\s/.test(line)) {
+      return line;
+    }
+    // 非标题行才替换为行内代码，避免目录解析不完整
+    return line.replace(/`([^`\r\n]+)`/g, (_, codeStr) => {
+      codeStr = codeStr.replace(/"/g, "'");
+      return `<td-code text="${codeStr}"></td-code>`;
+    });
   });
 
   const mdSegment = {

--- a/packages/tdesign-react/site/plugins/plugin-tdoc/transforms.js
+++ b/packages/tdesign-react/site/plugins/plugin-tdoc/transforms.js
@@ -1,11 +1,9 @@
-/* eslint-disable indent */
-/* eslint-disable no-param-reassign */
+/* eslint-disable */
 import fs from 'fs';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import mdToReact from './md-to-react';
 
-// eslint-disable-next-line no-underscore-dangle
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 let demoImports = {};


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-react/issues/2708
- https://github.com/Tencent/tdesign-react/issues/2790 
- https://github.com/Tencent/tdesign-react/issues/3654
- https://github.com/Tencent/tdesign-react/issues/3662

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<details>
<summary><strong>🐛 问题1：文档目录解析异常</strong></summary>

- 如果大标题存在行内 code，会被替换为 `td-code`，导致目录标题无法提取到原始的字符串

<img width="2526" height="892" src="https://github.com/user-attachments/assets/af26be6a-3a10-4e94-8c76-0bb630c7f50b" />
</details>

<details>
<summary><strong>🔧 问题2：大部分基于 <code>Input</code> 的组件无法通过 <code>ref</code> 获取内部的原生组件</strong></summary>

- 其实部分组件有 <code>export</code> 出来过，只不过文档上没有标，主打一个某天意外被用户挖掘到，所以暂时放在 FAQ

- AntDesign 它们有一个[工具](https://ant.design/components/_util-cn?locale=zh-CN)，也许未来可以引进优化一下
<img width="500" src="https://github.com/user-attachments/assets/38015dda-f785-4f08-8acc-23caa1223246" />
</details>

<details>
<summary><strong>🚨 问题3：<code>Textarea</code> 支持所有原生属性和事件穿透，但 <code>Input</code> 不支持</strong></summary>

```tsx
有点 Breaking Change 了，需要讨论一下，我会在下面 Code Review 进行引用并评论解释
```
</details>

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Input): 支持所有原生属性和事件穿透

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
