### PR TITLE
refactor(Statistic): change color attribute type to string and update  docs description

### DIFF
--- a/packages/components/statistic/Statistic.tsx
+++ b/packages/components/statistic/Statistic.tsx
@@ -6,7 +6,7 @@ import {
   ArrowTriangleUpFilledIcon as TDArrowTriangleUpFilledIcon,
 } from 'tdesign-icons-react';
 import Tween from '@tdesign/common-js/statistic/tween';
-import { COLOR_MAP, getFormatValue } from '@tdesign/common-js/statistic/utils';
+import { getFormatValue } from '@tdesign/common-js/statistic/utils';
 import { TdStatisticProps } from './type';
 import { statisticDefaultProps } from './defaultProps';
 import { StyledProps } from '../common';
@@ -93,7 +93,7 @@ const Statistic = forwardRef<StatisticRef, StatisticProps>((props, ref) => {
 
   const valueStyle = useMemo(
     () => ({
-      color: COLOR_MAP[color] || color,
+      color,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [color],

--- a/packages/components/statistic/Statistic.tsx
+++ b/packages/components/statistic/Statistic.tsx
@@ -6,7 +6,7 @@ import {
   ArrowTriangleUpFilledIcon as TDArrowTriangleUpFilledIcon,
 } from 'tdesign-icons-react';
 import Tween from '@tdesign/common-js/statistic/tween';
-import { getFormatValue } from '@tdesign/common-js/statistic/utils';
+import { getFormatValue, COLOR_MAP } from '@tdesign/common-js/statistic/utils';
 import { TdStatisticProps } from './type';
 import { statisticDefaultProps } from './defaultProps';
 import { StyledProps } from '../common';
@@ -93,7 +93,7 @@ const Statistic = forwardRef<StatisticRef, StatisticProps>((props, ref) => {
 
   const valueStyle = useMemo(
     () => ({
-      color,
+      color: COLOR_MAP[color as keyof typeof COLOR_MAP] || color,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [color],

--- a/packages/components/statistic/__tests__/statistic.test.tsx
+++ b/packages/components/statistic/__tests__/statistic.test.tsx
@@ -17,23 +17,21 @@ describe('Statistic 组件测试', () => {
   });
 
   /**
-   * color
+   * props
    */
 
-  const COLOR_MAP = {
-    black: 'var(--td-text-color-primary)',
-    blue: 'var(--td-brand-color)',
-    red: 'var(--td-error-color)',
-    orange: 'var(--td-warning-color)',
-    green: 'var(--td-success-color)',
-  };
-  const colors = ['black', 'blue', 'red', 'orange', 'green'] as const;
-  colors.forEach((color) => {
-    test('color', () => {
-      render(<Statistic title="Total Assets" value={82.76} unit="%" trend="increase" color={color} />);
+  it('color="green"', () => {
+    const { container } = render(<Statistic title="Total Sales" value={1000} color="green" />);
 
-      expect(document.querySelector('.t-statistic-content')).toHaveStyle(`color: ${COLOR_MAP[color]}`);
-    });
+    const contentElement = container.querySelector('.t-statistic-content');
+    expect(contentElement).toHaveStyle('color: green');
+  });
+
+  it('color="#fff123"', () => {
+    const { container } = render(<Statistic title="Total Sales" value={1000} color="#fff123" />);
+
+    const contentElement = container.querySelector('.t-statistic-content');
+    expect(contentElement).toHaveStyle('color: #fff123');
   });
 
   /**

--- a/packages/components/statistic/__tests__/statistic.test.tsx
+++ b/packages/components/statistic/__tests__/statistic.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, mockDelay } from '@test/utils';
 import { ArrowTriangleDownFilledIcon, ArrowTriangleUpFilledIcon } from 'tdesign-icons-react';
+import { COLOR_MAP } from '@tdesign/common-js/statistic/utils';
 import Statistic from '../index';
 
 describe('Statistic 组件测试', () => {
@@ -24,7 +25,7 @@ describe('Statistic 组件测试', () => {
     const { container } = render(<Statistic title="Total Sales" value={1000} color="green" />);
 
     const contentElement = container.querySelector('.t-statistic-content');
-    expect(contentElement).toHaveStyle('color: green');
+    expect(contentElement).toHaveStyle('color: var(--td-success-color)');
   });
 
   it('color="#fff123"', () => {
@@ -32,6 +33,17 @@ describe('Statistic 组件测试', () => {
 
     const contentElement = container.querySelector('.t-statistic-content');
     expect(contentElement).toHaveStyle('color: #fff123');
+  });
+
+  it('colors: colorKeys', () => {
+    Object.keys(COLOR_MAP).forEach((color) => {
+      const { container } = render(<Statistic title="Total Sales" value={1000} color={color} />);
+
+      const contentElement = container.querySelector('.t-statistic-content');
+      expect(contentElement).toBeTruthy();
+      const expectedColor = COLOR_MAP[color as keyof typeof COLOR_MAP];
+      expect(contentElement).toHaveStyle(`color: ${expectedColor}`);
+    });
   });
 
   /**

--- a/packages/components/statistic/__tests__/statistic.test.tsx
+++ b/packages/components/statistic/__tests__/statistic.test.tsx
@@ -21,11 +21,11 @@ describe('Statistic 组件测试', () => {
    * props
    */
 
-  it('color="green"', () => {
-    const { container } = render(<Statistic title="Total Sales" value={1000} color="green" />);
+  it('color="yellow"', () => {
+    const { container } = render(<Statistic title="Total Sales" value={1000} color="yellow" />);
 
     const contentElement = container.querySelector('.t-statistic-content');
-    expect(contentElement).toHaveStyle('color: var(--td-success-color)');
+    expect(contentElement).toHaveStyle('color: yellow');
   });
 
   it('color="#fff123"', () => {

--- a/packages/components/statistic/statistic.en-US.md
+++ b/packages/components/statistic/statistic.en-US.md
@@ -1,21 +1,22 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Statistic Props
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
 animation | Object | - | Animation effect control, `duration` refers to the transition time of the animation `unit: millisecond`, `valueFrom` refers to the initial value of the animation. `{ duration, valueFrom }`。Typescript：`animation` `interface animation { duration: number; valueFrom: number;  }`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/statistic/type.ts) | N
 animationStart | Boolean | false | Whether to start animation | N
-color | String | - | Color style, followed by TDesign style black, blue, red, orange, green.Can also be any RGB equivalent supported by [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)。options: black/blue/red/orange/green | N
+color | String | - | The color style can support TDesign's light and dark modes with the following options: black, blue, red, orange, and green. Alternatively, it can be any [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) value, but in this case, TDesign's light and dark modes will not be supported. | N
 decimalPlaces | Number | - |  Decimal places | N
 extra | TNode | - |  Additional display content。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 format | Function | - | Format numeric display value。Typescript：`(value: number) => number` | N
 loading | Boolean | false | Loading | N
 prefix | TNode | - | Prefix content, display priority is higher than trend。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-separator | String | , | The carry separator is displayed by default, and can be customized to other content. When `separator = ''` is set to an empty string/null/undefined, the separator is hidden | N
+separator | String | , | Thousands separator is displayed by default, and can be customized to other content, and the default separator is displayed when `separator = ''` is set to an empty string/null/undefined | N
 suffix | TNode | - |  Suffix content, display priority is higher than trend。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 title | TNode | - | The title of Statistic。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 trend | String | - | trend。options: increase/decrease | N
@@ -27,6 +28,6 @@ value | Number | - | The value of Statistic | N
 
 name | params | return | description
 -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
-start | `(from: number, to: number)` | \- | required。Digital scrolling change, from one number to another number
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
+start | \- | \- | required。start animation

--- a/packages/components/statistic/statistic.md
+++ b/packages/components/statistic/statistic.md
@@ -10,7 +10,7 @@ className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
 animation | Object | - | 动画效果控制，`duration` 指动画的过渡时间`单位：毫秒`，`valueFrom` 指动画的起始数值。`{ duration, valueFrom }`。TS 类型：`animation` `interface animation { duration: number; valueFrom: number;  }`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/statistic/type.ts) | N
 animationStart | Boolean | false | 是否开始动画 | N
-color | String | - | 颜色风格可以为支持 TDesign 的浅色和深色模式的黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，但不支持 TDesign 的浅色和深色模式。 | N
+color | String | - | 颜色风格，预设五个 TDesign 颜色风格：黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）支持深浅色模式切换。也可以自定义任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，深浅色模式切换需自行适配 | N
 decimalPlaces | Number | - | 小数保留位数 | N
 extra | TNode | - | 额外的显示内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 format | Function | - | 格式化数值显示值。TS 类型：`(value: number) => number` | N

--- a/packages/components/statistic/statistic.md
+++ b/packages/components/statistic/statistic.md
@@ -1,21 +1,22 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Statistic Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
 animation | Object | - | 动画效果控制，`duration` 指动画的过渡时间`单位：毫秒`，`valueFrom` 指动画的起始数值。`{ duration, valueFrom }`。TS 类型：`animation` `interface animation { duration: number; valueFrom: number;  }`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/statistic/type.ts) | N
 animationStart | Boolean | false | 是否开始动画 | N
-color | String | - | 颜色风格，依次为 TDesign 风格的黑色、蓝色、红色、橙色、绿色。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的 RGB 等值。可选项：black/blue/red/orange/green | N
+color | String | - | 颜色风格可以为支持 TDesign 的浅色和深色模式的黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，但不支持 TDesign 的浅色和深色模式。 | N
 decimalPlaces | Number | - | 小数保留位数 | N
 extra | TNode | - | 额外的显示内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 format | Function | - | 格式化数值显示值。TS 类型：`(value: number) => number` | N
 loading | Boolean | false | 是否加载中 | N
 prefix | TNode | - | 前缀内容，展示优先级高于 trend。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-separator | String | , | 默认展示进位分隔符，可以自定义为其他内容，`separator = ''` 设置为空字符串/null/undefined 时隐藏分隔符 | N
+separator | String | , | 默认展示千位分隔符，可以自定义为其他内容，`separator = ''` 设置为空字符串/null/undefined 时展示默认分隔符 | N
 suffix | TNode | - | 后缀内容，展示优先级高于 trend。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 title | TNode | - | 数值显示的标题。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 trend | String | - | 趋势。可选项：increase/decrease | N
@@ -29,4 +30,4 @@ value | Number | - | 数值显示的值 | N
 -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
-start | `(from: number, to: number)` | \- | 必需。设置数字滚动变化效果，从一个数字到另一个数字
+start | \- | \- | 必需。开始动画

--- a/packages/components/statistic/type.ts
+++ b/packages/components/statistic/type.ts
@@ -17,7 +17,7 @@ export interface TdStatisticProps {
    */
   animationStart?: boolean;
   /**
-   * 颜色风格可以为支持 TDesign 的浅色和深色模式的黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，但不支持 TDesign 的浅色和深色模式。
+   * 颜色风格，预设五个 TDesign 颜色风格：黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）支持深浅色模式切换。也可以自定义任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，深浅色模式切换需自行适配
    * @default ''
    */
   color?: string;

--- a/packages/components/statistic/type.ts
+++ b/packages/components/statistic/type.ts
@@ -17,9 +17,10 @@ export interface TdStatisticProps {
    */
   animationStart?: boolean;
   /**
-   * 颜色风格，依次为 TDesign 风格的黑色、蓝色、红色、橙色、绿色。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的 RGB 等值
+   * 可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的颜色值。
+   * @default ''
    */
-  color?: 'black' | 'blue' | 'red' | 'orange' | 'green';
+  color?: string;
   /**
    * 小数保留位数
    */
@@ -42,7 +43,7 @@ export interface TdStatisticProps {
    */
   prefix?: TNode;
   /**
-   * 默认展示进位分隔符，可以自定义为其他内容，`separator = ''` 设置为空字符串/null/undefined 时隐藏分隔符
+   * 默认展示千位分隔符，可以自定义为其他内容，`separator = ''` 设置为空字符串/null/undefined 时展示默认分隔符
    * @default ,
    */
   separator?: string;
@@ -76,9 +77,9 @@ export interface TdStatisticProps {
 /** 组件实例方法 */
 export interface StatisticInstanceFunctions {
   /**
-   * 设置数字滚动变化效果，从一个数字到另一个数字
+   * 开始动画
    */
-  start: (from: number, to: number) => void;
+  start: () => void;
 }
 
 export interface animation {

--- a/packages/components/statistic/type.ts
+++ b/packages/components/statistic/type.ts
@@ -17,7 +17,7 @@ export interface TdStatisticProps {
    */
   animationStart?: boolean;
   /**
-   * 可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的颜色值。
+   * 颜色风格可以为支持 TDesign 的浅色和深色模式的黑色（black）、蓝色（blue）、红色（red）、橙色（orange）、绿色（green）。也可以为任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持颜色值，但不支持 TDesign 的浅色和深色模式。
    * @default ''
    */
   color?: string;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/TDesignOteam/tdesign-api/pull/688

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(Statistic): 修改 color 属性类型为字符串，以支持任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的颜色值

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
