### PR TITLE
fix(FormList): remove unnecessary `data` in `fields`

### DIFF
--- a/packages/components/form/FormList.tsx
+++ b/packages/components/form/FormList.tsx
@@ -23,8 +23,7 @@ const FormList: React.FC<TdFormListProps> = (props) => {
 
   const [formListValue, setFormListValue] = useState(initialData);
   const [fields, setFields] = useState<Array<FormListField>>(() =>
-    initialData.map((data, index) => ({
-      data: { ...data },
+    initialData.map((_, index) => ({
       key: (key += 1),
       name: index,
       isListField: true,
@@ -235,8 +234,7 @@ const FormList: React.FC<TdFormListProps> = (props) => {
         if (resetType === 'initial') {
           setFormListValue(initialData);
 
-          const newFields = initialData.map((data, index) => ({
-            data: { ...data },
+          const newFields = initialData.map((_, index) => ({
             key: (key += 1),
             name: index,
             isListField: true,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 用户想要通过实时更新值，渲染不同组件，减少先 `setFields` 再 `getFieldsValue` 的流程
- 但是在初始化的时候打印发现 `fields` 里面有 `data`，后期手动新增生成的没有...误以为是有 Bug
- 该业务场景理论上可以通过 [`shoudUpdate`](https://tdesign.tencent.com/react/components/form?tab=demo#%E5%AD%97%E6%AE%B5%E8%81%94%E5%8A%A8%E7%9A%84%E8%A1%A8%E5%8D%95) 实现

<img width="70%" src="https://github.com/user-attachments/assets/e9b2ea17-d9bc-468c-b962-67da45010408" />

<img width="100%" src="https://github.com/user-attachments/assets/1d343c8f-5881-4fca-9da9-d916d2b521aa" />

(`isListField` 这个字段其实也从来没有在代码中应用过，理论上也可以移除？）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(FormList): 移除初始和重置时 `fields` 里面的 `data`，避免产生歧义

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
