### PR TITLE
fix(Input): preserve cursor position when toggling password visibility

### DIFF
--- a/packages/components/input/Input.tsx
+++ b/packages/components/input/Input.tsx
@@ -288,8 +288,16 @@ const Input = forwardRefWithStatics(
 
     function togglePasswordVisible() {
       if (disabled) return;
+      // 保存光标位置
+      const inputEl = inputRef.current;
+      const cursorPosition = inputRef.current?.selectionStart || 0;
+
       const toggleType = renderType === 'password' ? 'text' : 'password';
       setRenderType(toggleType);
+
+      requestAnimationFrame(() => {
+        inputEl?.setSelectionRange(cursorPosition, cursorPosition);
+      });
     }
 
     function handleChange(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 切换 `type` 的时候，相当于重渲染了一个新元素，只回填了 `value`，但没有恢复光标位置

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复密码输入框点击图标切换内容可见性时，光标位置没能被保留

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
