### PR TITLE
feat(Tree): add dragNode and dropPosition params for onDragOver API

### DIFF
--- a/packages/components/tree/_example/draggable.tsx
+++ b/packages/components/tree/_example/draggable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tree, Space } from 'tdesign-react';
+import { Space, Tree } from 'tdesign-react';
 
 import type { TreeProps } from 'tdesign-react';
 
@@ -46,15 +46,18 @@ const items = [
   },
   {
     value: '2',
-    label: '2',
+    label: '2（不允许拖放该节点及其子节点）',
+    disabled: true,
     children: [
       {
         value: '2.1',
         label: '2.1',
+        disabled: true,
       },
       {
         value: '2.2',
-        label: '2.2 不允许拖放为 2.2 的子节点',
+        label: '2.2',
+        disabled: true,
       },
     ],
   },
@@ -73,15 +76,18 @@ export default () => {
   const handleDragLeave = () => {
     console.log('dragLeave');
   };
-  const handleDrop: TreeProps['onDrop'] = ({ dragNode, dropPosition, e }) => {
-    console.log(dragNode, dropPosition, e);
-  };
-
   const handleAllowDrop: TreeProps['allowDrop'] = (ctx) => {
-    const { dropNode, dropPosition } = ctx;
-    if (dropNode.value === '2.2' && dropPosition === 0) {
+    // 放置位置：-1 上方，0 内部，1 下方
+    // 适合在这做简单的权限检查
+    const { dragNode, dropNode, dropPosition } = ctx;
+    console.log('allowDrop', dragNode, dropNode, dropPosition);
+    if ((dragNode.value as string).startsWith('2') || (dropNode.value as string).startsWith('2')) {
       return false;
     }
+  };
+  const handleDrop: TreeProps['onDrop'] = (ctx) => {
+    // 与 allowDrop 的回调类型一致，但适合在这处理复杂的业务操作
+    console.log(ctx);
   };
 
   return (
@@ -93,12 +99,12 @@ export default () => {
         transition
         expandAll
         draggable
+        allowDrop={handleAllowDrop}
         onDrop={handleDrop}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}
-        allowDrop={handleAllowDrop}
       />
     </Space>
   );

--- a/packages/components/tree/hooks/TreeDraggableContext.tsx
+++ b/packages/components/tree/hooks/TreeDraggableContext.tsx
@@ -32,10 +32,13 @@ export const TreeDraggableContext = createHookContext((value: Value) => {
     });
   };
 
-  const onDragOver = (context: { node: TreeNode; e: DragEvent<HTMLDivElement> }) => {
+  const onDragOver = (context: { node: TreeNode; dropPosition: number; e: DragEvent<HTMLDivElement> }) => {
+    const { node, dropPosition } = context;
     props.onDragOver?.({
       ...context,
-      node: context.node.model,
+      dragNode: dragNode.current?.model,
+      dropPosition,
+      node: node.model,
     });
   };
 

--- a/packages/components/tree/hooks/TreeDraggableContext.tsx
+++ b/packages/components/tree/hooks/TreeDraggableContext.tsx
@@ -49,7 +49,7 @@ export const TreeDraggableContext = createHookContext((value: Value) => {
     props.onDragOver?.({
       ...context,
       node: context.node.getModel(),
-      dragNode: dragNode.current.getModel(),
+      dragNode: dragNode.current?.getModel(),
     });
   };
 
@@ -57,7 +57,7 @@ export const TreeDraggableContext = createHookContext((value: Value) => {
     props.onDragLeave?.({
       ...context,
       node: context.node.getModel(),
-      dragNode: dragNode.current.getModel(),
+      dragNode: dragNode.current?.getModel(),
     });
   };
 

--- a/packages/components/tree/hooks/TreeDraggableContext.tsx
+++ b/packages/components/tree/hooks/TreeDraggableContext.tsx
@@ -1,9 +1,8 @@
-import { useRef, DragEvent } from 'react';
-import TreeStore from '@tdesign/common-js/tree-v1/tree-store';
+import { useRef } from 'react';
 import TreeNode from '@tdesign/common-js/tree-v1/tree-node';
-import { TreeProps } from '../Tree';
+import TreeStore from '@tdesign/common-js/tree-v1/tree-store';
 import { createHookContext } from '../../_util/createHookContext';
-
+import type { TreeProps } from '../Tree';
 import type { TdTreeProps } from '../type';
 
 interface Value {
@@ -11,50 +10,58 @@ interface Value {
   store: TreeStore;
 }
 
+export type BaseDragContextType = {
+  node: TreeNode;
+  e: React.DragEvent<HTMLDivElement>;
+};
+
+export type DragContextType = BaseDragContextType & {
+  dropPosition: number;
+};
+
+export type DropContextType = BaseDragContextType & {
+  dropPosition: number;
+  allowDrop?: TdTreeProps['allowDrop'];
+};
+
 export const TreeDraggableContext = createHookContext((value: Value) => {
   const { props, store } = value;
 
   const dragNode = useRef<TreeNode | null>(null);
 
-  const onDragStart = (context: { node: TreeNode; e: DragEvent<HTMLDivElement> }) => {
+  const onDragStart = (context: BaseDragContextType) => {
     dragNode.current = context.node;
     props.onDragStart?.({
       ...context,
-      node: context.node.model,
+      node: context.node.getModel(),
     });
   };
 
-  const onDragEnd = (context: { node: TreeNode; e: DragEvent<HTMLDivElement> }) => {
+  const onDragEnd = (context: BaseDragContextType) => {
     dragNode.current = context.node;
     props.onDragEnd?.({
       ...context,
-      node: context.node.model,
+      node: context.node.getModel(),
     });
   };
 
-  const onDragOver = (context: { node: TreeNode; dropPosition: number; e: DragEvent<HTMLDivElement> }) => {
-    const { node, dropPosition } = context;
+  const onDragOver = (context: DragContextType) => {
     props.onDragOver?.({
       ...context,
-      dragNode: dragNode.current?.model,
-      dropPosition,
-      node: node.model,
+      node: context.node.getModel(),
+      dragNode: dragNode.current.getModel(),
     });
   };
 
-  const onDragLeave = (context: { node: TreeNode; e: DragEvent<HTMLDivElement> }) => {
+  const onDragLeave = (context: DragContextType) => {
     props.onDragLeave?.({
       ...context,
-      node: context.node.model,
+      node: context.node.getModel(),
+      dragNode: dragNode.current.getModel(),
     });
   };
 
-  const onDrop = (context: {
-    node: TreeNode;
-    dropPosition: number;
-    e: DragEvent<HTMLDivElement>;
-    allowDrop?: TdTreeProps['allowDrop'];
-  }) => {
+  const onDrop = (context: DropContextType) => {
     const { node, dropPosition } = context;
     if (
       node.value === dragNode.current?.value ||
@@ -87,8 +94,8 @@ export const TreeDraggableContext = createHookContext((value: Value) => {
     });
     props.onDrop?.({
       ...context,
-      dragNode: dragNode.current?.model,
-      dropNode: node.model,
+      dragNode: dragNode.current?.getModel(),
+      dropNode: node.getModel(),
     });
   };
 

--- a/packages/components/tree/hooks/useDraggable.tsx
+++ b/packages/components/tree/hooks/useDraggable.tsx
@@ -43,11 +43,11 @@ export default function useDraggable(props: {
       const diff = pageY - offsetY;
 
       if (diff < gapHeight) {
-        setPartialState({ dropPosition: -1 }); // 放置在节点之前
+        setPartialState({ dropPosition: -1 });
       } else if (diff < rect.height - gapHeight) {
-        setPartialState({ dropPosition: 0 }); // 放置在节点内部
+        setPartialState({ dropPosition: 0 });
       } else {
-        setPartialState({ dropPosition: 1 }); // 放置在节点之后
+        setPartialState({ dropPosition: 1 });
       }
     }),
   ).current;

--- a/packages/components/tree/hooks/useDraggable.tsx
+++ b/packages/components/tree/hooks/useDraggable.tsx
@@ -78,7 +78,7 @@ export default function useDraggable(props: {
           isDragOver: true,
         });
         updateDropPosition(e);
-        onDragOver?.({ node, e });
+        onDragOver?.({ node, dropPosition: state.dropPosition, e });
         break;
       case 'dragLeave':
         setPartialState({

--- a/packages/components/tree/hooks/useDraggable.tsx
+++ b/packages/components/tree/hooks/useDraggable.tsx
@@ -43,11 +43,11 @@ export default function useDraggable(props: {
       const diff = pageY - offsetY;
 
       if (diff < gapHeight) {
-        setPartialState({ dropPosition: -1 });
+        setPartialState({ dropPosition: -1 }); // 放置在节点之前
       } else if (diff < rect.height - gapHeight) {
-        setPartialState({ dropPosition: 0 });
+        setPartialState({ dropPosition: 0 }); // 放置在节点内部
       } else {
-        setPartialState({ dropPosition: 1 });
+        setPartialState({ dropPosition: 1 }); // 放置在节点之后
       }
     }),
   ).current;
@@ -83,10 +83,9 @@ export default function useDraggable(props: {
       case 'dragLeave':
         setPartialState({
           isDragOver: false,
-          dropPosition: 0,
         });
         updateDropPosition.cancel();
-        onDragLeave?.({ node, e });
+        onDragLeave?.({ node, dropPosition: state.dropPosition, e });
         break;
       case 'drop':
         onDrop?.({ node, dropPosition: state.dropPosition, e, allowDrop });

--- a/packages/components/tree/tree.en-US.md
+++ b/packages/components/tree/tree.en-US.md
@@ -1,13 +1,14 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Tree Props
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
-activable | Boolean | false | \- | N
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
+activable | Boolean | false | make nodes can be highlight | N
 activeMultiple | Boolean | false | \- | N
 actived | Array | - | Typescript：`Array<TreeNodeValue>` | N
 allowDrop | Function | - | Determine whether the node can execute the drop operation。Typescript：`(context: { e: DragEvent; dragNode: TreeNodeModel<T>; dropNode: TreeNodeModel<T>; dropPosition: number; }) => boolean` | N
@@ -29,7 +30,7 @@ expanded | Array | [] | Typescript：`Array<TreeNodeValue>` | N
 filter | Function | - | Typescript：`(node: TreeNodeModel<T>) => boolean` | N
 hover | Boolean | - | \- | N
 icon | TNode | true | Typescript：`boolean \| TNode<TreeNodeModel<T>>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-keys | Object | - | Typescript：`TreeKeysType` `interface TreeKeysType { value?: string; label?: string; children?: string }`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
+keys | Object | - | alias field name in data。Typescript：`TreeKeysType`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 label | TNode | true | Typescript：`string \| boolean \| TNode<TreeNodeModel<T>>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 lazy | Boolean | true | \- | N
 line | TNode | false | Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
@@ -44,8 +45,8 @@ onActive | Function |  | Typescript：`(value: Array<TreeNodeValue>, context: { 
 onChange | Function |  | Typescript：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: any; trigger: 'node-click' \| 'setItem' }) => void`<br/> | N
 onClick | Function |  | Typescript：`(context: { node: TreeNodeModel<T>; e: MouseEvent }) => void`<br/> | N
 onDragEnd | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/> | N
-onDragLeave | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/> | N
-onDragOver | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/> | N
+onDragLeave | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number; }) => void`<br/> | N
+onDragOver | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number; }) => void`<br/> | N
 onDragStart | Function |  | Typescript：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/> | N
 onDrop | Function |  | Typescript：`(context: {     e: DragEvent;     dragNode: TreeNodeModel<T>;     dropNode: TreeNodeModel<T>;     dropPosition: number;   }) => void`<br/> | N
 onExpand | Function |  | Typescript：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: MouseEvent; trigger: 'node-click' \| 'icon-click' \| 'setItem' }) => void`<br/> | N
@@ -56,8 +57,8 @@ onScroll | Function |  | Typescript：`(params: { e: WheelEvent }) => void`<br/>
 
 name | params | return | description
 -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
 appendTo | `(value: TreeNodeValue, newData: T \| Array<T>)` | \- | required
 getIndex | `(value: TreeNodeValue)` | `number` | required
 getItem | `(value: TreeNodeValue)` | `TreeNodeModel<T>` | required
@@ -65,10 +66,12 @@ getItems | `(value?: TreeNodeValue)` | `Array<TreeNodeModel<T>>` | required
 getParent | `(value: TreeNodeValue)` | `TreeNodeModel<T>` | required
 getParents | `(value: TreeNodeValue)` | `TreeNodeModel<T>[]` | required
 getPath | `(value: TreeNodeValue)` | `TreeNodeModel<T>[]` | required
+getTreeData | `(value?: TreeNodeValue)` | `Array<T>` | required。get tree struct data
 insertAfter | `(value: TreeNodeValue, newData: T)` | \- | required
 insertBefore | `(value: TreeNodeValue, newData: T)` | \- | required
+refresh | \- | \- | required。refresh tree state, used in tree search
 remove | `(value: TreeNodeValue)` | \- | required
-scrollTo | `(scrollToParams: ComponentScrollToElementParams)` | \- | support scrolling to a specific node when virtual scrolling 
+scrollTo | `(scrollToParams: ScrollToElementParams)` | \- | support scrolling to a specific node when virtual scrolling 
 setItem | `(value: TreeNodeValue, options: TreeNodeState)` | \- | required
 
 ### TreeNodeState
@@ -96,12 +99,12 @@ name | type | default | description | required
 actived | Boolean | - | required | Y
 checked | Boolean | - | required | Y
 data | Object | - | required。node data, extends `TreeOptionData`。Typescript：`T` | Y
+disabled | Boolean | - | required。node disabled state | Y
 expanded | Boolean | - | required | Y
 indeterminate | Boolean | - | required | Y
 loading | Boolean | - | required | Y
 `TreeNodeState` | \- | - | extends `TreeNodeState` | N
-
-### TreeNodeModelFunctions
+### TreeNodeModel
 
 name | params | return | description
 -- | -- | -- | --

--- a/packages/components/tree/tree.en-US.md
+++ b/packages/components/tree/tree.en-US.md
@@ -66,12 +66,10 @@ getItems | `(value?: TreeNodeValue)` | `Array<TreeNodeModel<T>>` | required
 getParent | `(value: TreeNodeValue)` | `TreeNodeModel<T>` | required
 getParents | `(value: TreeNodeValue)` | `TreeNodeModel<T>[]` | required
 getPath | `(value: TreeNodeValue)` | `TreeNodeModel<T>[]` | required
-getTreeData | `(value?: TreeNodeValue)` | `Array<T>` | required。get tree struct data
 insertAfter | `(value: TreeNodeValue, newData: T)` | \- | required
 insertBefore | `(value: TreeNodeValue, newData: T)` | \- | required
-refresh | \- | \- | required。refresh tree state, used in tree search
 remove | `(value: TreeNodeValue)` | \- | required
-scrollTo | `(scrollToParams: ScrollToElementParams)` | \- | support scrolling to a specific node when virtual scrolling 
+scrollTo | `(scrollToParams: ComponentScrollToElementParams)` | \- | support scrolling to a specific node when virtual scrolling 
 setItem | `(value: TreeNodeValue, options: TreeNodeState)` | \- | required
 
 ### TreeNodeState
@@ -99,7 +97,6 @@ name | type | default | description | required
 actived | Boolean | - | required | Y
 checked | Boolean | - | required | Y
 data | Object | - | required。node data, extends `TreeOptionData`。Typescript：`T` | Y
-disabled | Boolean | - | required。node disabled state | Y
 expanded | Boolean | - | required | Y
 indeterminate | Boolean | - | required | Y
 loading | Boolean | - | required | Y

--- a/packages/components/tree/tree.md
+++ b/packages/components/tree/tree.md
@@ -45,7 +45,7 @@ onChange | Function |  | TS 类型：`(value: Array<TreeNodeValue>, context: { n
 onClick | Function |  | TS 类型：`(context: { node: TreeNodeModel<T>; e: MouseEvent }) => void`<br/>节点点击时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDragEnd | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点结束拖拽时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDragLeave | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点拖拽时离开目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
-onDragOver | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
+onDragOver | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number }) => void`<br/>节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDragStart | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点开始拖拽时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDrop | Function |  | TS 类型：`(context: {     e: DragEvent;     dragNode: TreeNodeModel<T>;     dropNode: TreeNodeModel<T>;     dropPosition: number;   }) => void`<br/>节点在目标元素上释放时触发，泛型 `T` 表示树节点 TS 类型 | N
 onExpand | Function |  | TS 类型：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: MouseEvent; trigger: 'node-click' \| 'icon-click' \| 'setItem' }) => void`<br/>节点展开或收起时触发，泛型 `T` 表示树节点 TS 类型 | N

--- a/packages/components/tree/tree.md
+++ b/packages/components/tree/tree.md
@@ -97,7 +97,6 @@ visible | Boolean | false | 节点是否可视 | N
 actived | Boolean | - | 必需。当前节点是否处于高亮激活态 | Y
 checked | Boolean | - | 必需。当前节点是否被选中 | Y
 data | Object | - | 必需。节点数据，泛型 `T` 表示树节点 TS 类型，继承 `TreeOptionData`。TS 类型：`T` | Y
-disabled | Boolean | - | 必需。禁用状态 | Y
 expanded | Boolean | - | 必需。当前节点是否展开 | Y
 indeterminate | Boolean | - | 必需。当前节点是否处于半选状态 | Y
 loading | Boolean | - | 必需。当前节点是否处于加载中状态 | Y

--- a/packages/components/tree/tree.md
+++ b/packages/components/tree/tree.md
@@ -1,9 +1,10 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Tree Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
@@ -29,7 +30,7 @@ expanded | Array | [] | 展开的节点值。TS 类型：`Array<TreeNodeValue>` 
 filter | Function | - | 节点过滤方法，只呈现返回值为 true 的节点，泛型 `T` 表示树节点 TS 类型。TS 类型：`(node: TreeNodeModel<T>) => boolean` | N
 hover | Boolean | - | 节点是否有悬浮状态 | N
 icon | TNode | true | 节点图标，可自定义。TS 类型：`boolean \| TNode<TreeNodeModel<T>>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-keys | Object | - | 用来定义 `value / label / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`。TS 类型：`TreeKeysType` `interface TreeKeysType { value?: string; label?: string; children?: string }`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
+keys | Object | - | 用来定义 `value / label / disabled / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`。其中，disabled 待开发。TS 类型：`TreeKeysType`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 label | TNode | true | 自定义节点内容，值为 `false` 不显示，值为 `true` 显示默认 label，值为字符串直接输出该字符串。泛型 `T` 表示树节点 TS 类型。<br/>如果期望只有点击复选框才选中，而点击节点不选中，可以使用 `label` 自定义节点，然后加上点击事件 `e.preventDefault()`，通过调整自定义节点的宽度和高度决定禁止点击选中的范围。TS 类型：`string \| boolean \| TNode<TreeNodeModel<T>>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 lazy | Boolean | true | 延迟加载 children 为 true 的节点的子节点数据，即使 expandAll 被设置为 true，也同样延迟加载 | N
 line | TNode | false | 连接线。值为 false 不显示连接线；值为 true 显示默认连接线；值类型为 Function 表示自定义连接线。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
@@ -37,15 +38,15 @@ load | Function | - | 加载子数据的方法，在展开节点时调用（仅�
 operations | TElement | - | 自定义节点操作项，泛型 `T` 表示树节点 TS 类型。TS 类型：`TNode<TreeNodeModel<T>>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 scroll | Object | - | 懒加载和虚拟滚动。为保证组件收益最大化，当数据量小于阈值 `scroll.threshold` 时，无论虚拟滚动的配置是否存在，组件内部都不会开启虚拟滚动，`scroll.threshold` 默认为 `100`。TS 类型：`TScroll`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 transition | Boolean | true | 节点展开折叠时是否使用过渡动画 | N
-value | Array | [] | 选中值（组件为可选状态时）。TS 类型：`Array<TreeNodeValue>` `type TreeNodeValue = string \| number`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
-defaultValue | Array | [] | 选中值（组件为可选状态时）。非受控属性。TS 类型：`Array<TreeNodeValue>` `type TreeNodeValue = string \| number`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
-valueMode | String | onlyLeaf | 选中值模式。all 表示父节点和子节点全部会出现在选中值里面；parentFirst 表示当子节点全部选中时，仅父节点在选中值里面；onlyLeaft 表示无论什么情况，选中值仅呈现叶子节点。可选项：onlyLeaf/parentFirst/all | N
+value | Array | [] | 选中值，组件为可选状态时有效。TS 类型：`Array<TreeNodeValue>` `type TreeNodeValue = string \| number`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
+defaultValue | Array | [] | 选中值，组件为可选状态时有效。非受控属性。TS 类型：`Array<TreeNodeValue>` `type TreeNodeValue = string \| number`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tree/type.ts) | N
+valueMode | String | onlyLeaf | 选中值模式。all 表示父节点和子节点全部会出现在选中值里面；parentFirst 表示当子节点全部选中时，仅父节点在选中值里面；onlyLeaf 表示无论什么情况，选中值仅呈现叶子节点。可选项：onlyLeaf/parentFirst/all | N
 onActive | Function |  | TS 类型：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: MouseEvent; trigger: 'node-click' \| 'setItem' }) => void`<br/>节点激活时触发，泛型 `T` 表示树节点 TS 类型 | N
 onChange | Function |  | TS 类型：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: any; trigger: 'node-click' \| 'setItem' }) => void`<br/>节点选中状态变化时触发，context.node 表示当前变化的选项，泛型 `T` 表示树节点 TS 类型 | N
 onClick | Function |  | TS 类型：`(context: { node: TreeNodeModel<T>; e: MouseEvent }) => void`<br/>节点点击时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDragEnd | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点结束拖拽时触发，泛型 `T` 表示树节点 TS 类型 | N
-onDragLeave | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点拖拽时离开目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
-onDragOver | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number }) => void`<br/>节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
+onDragLeave | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number; }) => void`<br/>节点拖拽时离开目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
+onDragOver | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T>; dragNode: TreeNodeModel<T>; dropPosition: number; }) => void`<br/>节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDragStart | Function |  | TS 类型：`(context: { e: DragEvent; node: TreeNodeModel<T> }) => void`<br/>节点开始拖拽时触发，泛型 `T` 表示树节点 TS 类型 | N
 onDrop | Function |  | TS 类型：`(context: {     e: DragEvent;     dragNode: TreeNodeModel<T>;     dropNode: TreeNodeModel<T>;     dropPosition: number;   }) => void`<br/>节点在目标元素上释放时触发，泛型 `T` 表示树节点 TS 类型 | N
 onExpand | Function |  | TS 类型：`(value: Array<TreeNodeValue>, context: { node: TreeNodeModel<T>; e?: MouseEvent; trigger: 'node-click' \| 'icon-click' \| 'setItem' }) => void`<br/>节点展开或收起时触发，泛型 `T` 表示树节点 TS 类型 | N
@@ -73,7 +74,7 @@ setItem | `(value: TreeNodeValue, options: TreeNodeState)` | \- | 必需。设�
 
 ### TreeNodeState
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 activable | Boolean | false | 节点是否允许被激活 | N
 actived | Boolean | false | 节点是否被激活 | N
@@ -91,17 +92,17 @@ visible | Boolean | false | 节点是否可视 | N
 
 ### TreeNodeModel
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 actived | Boolean | - | 必需。当前节点是否处于高亮激活态 | Y
 checked | Boolean | - | 必需。当前节点是否被选中 | Y
 data | Object | - | 必需。节点数据，泛型 `T` 表示树节点 TS 类型，继承 `TreeOptionData`。TS 类型：`T` | Y
+disabled | Boolean | - | 必需。禁用状态 | Y
 expanded | Boolean | - | 必需。当前节点是否展开 | Y
 indeterminate | Boolean | - | 必需。当前节点是否处于半选状态 | Y
 loading | Boolean | - | 必需。当前节点是否处于加载中状态 | Y
 `TreeNodeState` | \- | - | 继承 `TreeNodeState` 中的全部属性 | N
-
-### TreeNodeModelFunctions
+### TreeNodeModel
 
 名称 | 参数 | 返回值 | 描述
 -- | -- | -- | --
@@ -124,7 +125,7 @@ setData | `(data: T)` | \- | 必需。设置节点数据，数据变化可自动
 
 ### TScroll
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 bufferSize | Number | 20 | 表示除可视区域外，额外渲染的行数，避免快速滚动过程中，新出现的内容来不及渲染从而出现空白 | N
 isFixedRowHeight | Boolean | false | 表示每行内容是否同一个固定高度，仅在 `scroll.type` 为 `virtual` 时有效，该属性设置为 `true` 时，可用于简化虚拟滚动内部计算逻辑，提升性能，此时则需要明确指定 `scroll.rowHeight` 属性的值 | N

--- a/packages/components/tree/type.ts
+++ b/packages/components/tree/type.ts
@@ -206,7 +206,12 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
    * 节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型
    */
-  onDragOver?: (context: { e: DragEvent<HTMLDivElement>; node: TreeNodeModel<T> }) => void;
+  onDragOver?: (context: {
+    e: DragEvent<HTMLDivElement>;
+    node: TreeNodeModel<T>;
+    dragNode: TreeNodeModel<T>;
+    dropPosition: number;
+  }) => void;
   /**
    * 节点开始拖拽时触发，泛型 `T` 表示树节点 TS 类型
    */

--- a/packages/components/tree/type.ts
+++ b/packages/components/tree/type.ts
@@ -5,8 +5,8 @@
  * */
 
 import { CheckboxProps } from '../checkbox';
-import { TNode, TreeOptionData, TScroll, ComponentScrollToElementParams } from '../common';
-import { MouseEvent, DragEvent } from 'react';
+import { TNode, TreeOptionData, TreeKeysType, TScroll, ComponentScrollToElementParams } from '../common';
+import { MouseEvent, WheelEvent, DragEvent } from 'react';
 
 export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
@@ -70,7 +70,7 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
    */
   disabled?: boolean;
   /**
-   * [开发中]节点是否可拖拽
+   * 节点是否可拖拽
    */
   draggable?: boolean;
   /**
@@ -127,7 +127,7 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
    */
   icon?: boolean | TNode<TreeNodeModel<T>>;
   /**
-   * 用来定义 `value / label / disabled / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`。其中，disabled 待开发。
+   * 用来定义 `value / label / disabled / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`。其中，disabled 待开发
    */
   keys?: TreeKeysType;
   /**
@@ -163,17 +163,17 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
    */
   transition?: boolean;
   /**
-   * 选中值（组件为可选状态时）
+   * 选中值，组件为可选状态时有效
    * @default []
    */
   value?: Array<TreeNodeValue>;
   /**
-   * 选中值（组件为可选状态时），非受控属性
+   * 选中值，组件为可选状态时有效，非受控属性
    * @default []
    */
   defaultValue?: Array<TreeNodeValue>;
   /**
-   * 选中值模式。all 表示父节点和子节点全部会出现在选中值里面；parentFirst 表示当子节点全部选中时，仅父节点在选中值里面；onlyLeaft 表示无论什么情况，选中值仅呈现叶子节点
+   * 选中值模式。all 表示父节点和子节点全部会出现在选中值里面；parentFirst 表示当子节点全部选中时，仅父节点在选中值里面；onlyLeaf 表示无论什么情况，选中值仅呈现叶子节点
    * @default onlyLeaf
    */
   valueMode?: 'onlyLeaf' | 'parentFirst' | 'all';
@@ -202,7 +202,12 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
    * 节点拖拽时离开目标元素时触发，泛型 `T` 表示树节点 TS 类型
    */
-  onDragLeave?: (context: { e: DragEvent<HTMLDivElement>; node: TreeNodeModel<T> }) => void;
+  onDragLeave?: (context: {
+    e: DragEvent<HTMLDivElement>;
+    node: TreeNodeModel<T>;
+    dragNode: TreeNodeModel<T>;
+    dropPosition: number;
+  }) => void;
   /**
    * 节点拖拽到目标元素时触发，泛型 `T` 表示树节点 TS 类型
    */
@@ -243,7 +248,7 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
    * 滚动事件
    */
-  onScroll?: (params: { e: WheelEvent }) => void;
+  onScroll?: (params: { e: WheelEvent<HTMLDivElement> }) => void;
 }
 
 /** 组件实例方法 */
@@ -454,12 +459,6 @@ export interface TreeNodeModel<T extends TreeOptionData = TreeOptionData> extend
    * 设置节点数据，数据变化可自动刷新页面，泛型 `T` 表示树节点 TS 类型，继承 `TreeOptionData`
    */
   setData: (data: T) => void;
-}
-
-export interface TreeKeysType {
-  value?: string;
-  label?: string;
-  children?: string;
 }
 
 export type TreeNodeValue = string | number;

--- a/packages/components/tree/type.ts
+++ b/packages/components/tree/type.ts
@@ -5,8 +5,8 @@
  * */
 
 import { CheckboxProps } from '../checkbox';
-import { TNode, TreeOptionData, TreeKeysType, TScroll, ComponentScrollToElementParams } from '../common';
-import { MouseEvent, WheelEvent, DragEvent } from 'react';
+import { TNode, TreeOptionData, TScroll, ComponentScrollToElementParams } from '../common';
+import { MouseEvent, DragEvent } from 'react';
 
 export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
@@ -248,7 +248,7 @@ export interface TdTreeProps<T extends TreeOptionData = TreeOptionData> {
   /**
    * 滚动事件
    */
-  onScroll?: (params: { e: WheelEvent<HTMLDivElement> }) => void;
+  onScroll?: (params: { e: WheelEvent }) => void;
 }
 
 /** 组件实例方法 */
@@ -459,6 +459,12 @@ export interface TreeNodeModel<T extends TreeOptionData = TreeOptionData> extend
    * 设置节点数据，数据变化可自动刷新页面，泛型 `T` 表示树节点 TS 类型，继承 `TreeOptionData`
    */
   setData: (data: T) => void;
+}
+
+export interface TreeKeysType {
+  value?: string;
+  label?: string;
+  children?: string;
 }
 
 export type TreeNodeValue = string | number;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- Tree 组件拖拽过程中，需要展开 dropPosition 为0的树，不中断用户操作，再往拖拽下层移动。该场景下使用 onDragOver 属性无法获取 dragNode、dropPosition 等信息，外层无法实现此交互
- 直接读取 `node.model` 会遇见 `null` 的情况...改用 `node.getModel()` 比较稳定，详见 https://github.com/Tencent/tdesign-common/blob/develop/js/tree-v1/tree-node.ts#L1393 逻辑

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Tree): `onDragLeave` 与 `onDragOver` 增加 `dragNode`、`dropPosition` 参数
- fix(Tree): 修复 Drag 相关事件的回调中 `node` 为 null 的异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
