### PR TITLE
feat: add style and class for internal dom

### DIFF
--- a/packages/components/card/Card.tsx
+++ b/packages/components/card/Card.tsx
@@ -31,6 +31,12 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     theme,
     status,
     loadingProps,
+    bodyClassName,
+    bodyStyle,
+    footerClassName,
+    footerStyle,
+    headerClassName,
+    headerStyle,
   } = useDefaultProps<CardProps>(props, cardDefaultProps);
 
   const children = props.children ?? props.content;
@@ -50,7 +56,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   const showHeader =
     header || title || subtitle || description || avatar || (actions && !isPoster2) || (status && isPoster2);
 
-  const headerClass = classNames({
+  const headerClass = classNames(headerClassName, {
     [`${classPrefix}-card__header`]: showHeader,
     [`${classPrefix}-card__title--bordered`]: headerBordered,
   });
@@ -67,7 +73,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     [`${classPrefix}-card__actions`]: actions,
   });
 
-  const footerClass = classNames({
+  const footerClass = classNames(footerClassName, {
     [`${classPrefix}-card__footer`]: footer,
   });
 
@@ -79,7 +85,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     [`${classPrefix}-card__avatar`]: avatar,
   });
 
-  const bodyClass = classNames({
+  const bodyClass = classNames(bodyClassName, {
     [`${classPrefix}-card__body`]: children,
   });
 
@@ -102,10 +108,14 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
   const renderHeader = () => {
     if (header) {
-      return <div className={headerClass}>{header}</div>;
+      return (
+        <div className={headerClass} style={headerStyle}>
+          {header}
+        </div>
+      );
     }
     return (
-      <div className={headerClass}>
+      <div className={headerClass} style={headerStyle}>
         <div className={`${classPrefix}-card__header-wrapper`}>
           {renderAvatar}
           <div>
@@ -124,10 +134,14 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     <div className={coverClass}>{typeof cover === 'string' ? <img src={cover} alt=""></img> : cover}</div>
   ) : null;
 
-  const renderChildren = children && <div className={bodyClass}>{children}</div>;
+  const renderChildren = children && (
+    <div className={bodyClass} style={bodyStyle}>
+      {children}
+    </div>
+  );
 
   const renderFooter = footer && (
-    <div className={footerClass}>
+    <div className={footerClass} style={footerStyle}>
       <div className={`${classPrefix}-card__footer-wrapper`}>{footer}</div>
       {renderFooterActions}
     </div>

--- a/packages/components/card/__tests__/card.test.tsx
+++ b/packages/components/card/__tests__/card.test.tsx
@@ -42,10 +42,40 @@ describe('Card', () => {
     expect(container.querySelector('.t-card__header')).toBeInTheDocument();
   });
 
+  test('headerClassName and headerStyle', () => {
+    const { container } = render(
+      <Card header headerClassName="test-header-class-name" headerStyle={{ height: '100px' }}></Card>,
+    );
+    const headerEle = container.querySelector('.t-card__header');
+    expect(headerEle).toHaveClass('test-header-class-name');
+    console.log(window.getComputedStyle(headerEle), window.getComputedStyle(headerEle).height);
+    expect(window.getComputedStyle(headerEle).height).toBe(`100px`);
+  });
+
   test('footer', () => {
     const { container } = render(<Card footer={<div>底部</div>}></Card>);
     expect(container.querySelector('.t-card__footer')).toBeInTheDocument();
     expect(container.querySelector('.t-card__footer').textContent).toBe('底部');
+  });
+
+  test('footerClassName and footerStyle', () => {
+    const { container } = render(
+      <Card footerClassName="test-footer-class-name" footerStyle={{ height: '100px' }} footer={<div>底部</div>}></Card>,
+    );
+    const footerEle = container.querySelector('.t-card__footer');
+    expect(footerEle).toHaveClass('test-footer-class-name');
+    expect(window.getComputedStyle(footerEle).height).toBe(`100px`);
+  });
+
+  test('bodyClassName and bodyStyle', () => {
+    const { container } = render(
+      <Card bodyClassName="test-body-class-name" bodyStyle={{ height: '100px' }}>
+        <div>body</div>
+      </Card>,
+    );
+    const bodyEle = container.querySelector('.test-body-class-name');
+    expect(bodyEle).not.toBeNull();
+    expect(window.getComputedStyle(bodyEle).height).toBe(`100px`);
   });
 
   test('actions', () => {

--- a/packages/components/card/__tests__/card.test.tsx
+++ b/packages/components/card/__tests__/card.test.tsx
@@ -48,7 +48,6 @@ describe('Card', () => {
     );
     const headerEle = container.querySelector('.t-card__header');
     expect(headerEle).toHaveClass('test-header-class-name');
-    console.log(window.getComputedStyle(headerEle), window.getComputedStyle(headerEle).height);
     expect(window.getComputedStyle(headerEle).height).toBe(`100px`);
   });
 

--- a/packages/components/card/card.en-US.md
+++ b/packages/components/card/card.en-US.md
@@ -10,14 +10,20 @@ className | String | - | className of component | N
 style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
 actions | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 avatar | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+bodyClassName | String | - | \- | N
+bodyStyle | Object | - | Styles that apply to the card body content。Typescript：`Styles`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 bordered | Boolean | true | \- | N
 children | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 content | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 cover | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 description | TNode | - | card description。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 footer | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+footerClassName | String | - | \- | N
+footerStyle | Object | - | Styles that apply to the card footer content。Typescript：`Styles`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 header | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 headerBordered | Boolean | false | \- | N
+headerClassName | String | - | \- | N
+headerStyle | Object | - | Styles that apply to the card header content。Typescript：`Styles`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 hoverShadow | Boolean | false | \- | N
 loading | TNode | false | Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 loadingProps | Object | - | Loading Component Props。Typescript：`LoadingProps`，[Loading API Documents](./loading?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/card/type.ts) | N

--- a/packages/components/card/card.md
+++ b/packages/components/card/card.md
@@ -4,20 +4,26 @@
 
 ### Card Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
 actions | TNode | - | 卡片操作区。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 avatar | TNode | - | 卡片中的用户头像，仅在海报风格的卡片中有效。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+bodyClassName | String | - | 卡片内容的类名，示例：'t-class-body' | N
+bodyStyle | Object | - | 作用于卡片内容的样式。TS 类型：`Styles`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 bordered | Boolean | true | 是否有边框 | N
 children | TNode | - | 卡片内容，同 content。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 content | TNode | - | 卡片内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 cover | TNode | - | 卡片封面图。值类型为字符串，会自动使用 `img` 标签输出封面图；也可以完全自定义封面图。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 description | TNode | - | 卡片描述文案。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 footer | TNode | - | 卡片底部内容，可完全自定义。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+footerClassName | String | - | 卡片底部的类名，示例：'t-class-footer' | N
+footerStyle | Object | - | 作用于卡片底部的样式。TS 类型：`Styles`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 header | TNode | - | 卡片顶部内容，优先级高于其他所有元素。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 headerBordered | Boolean | false | 头部是否带分割线，仅在有header时有效 | N
+headerClassName | String | - | 卡片头部的类名，示例：'t-class-header' | N
+headerStyle | Object | - | 作用于卡片头部的样式。TS 类型：`Styles`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 hoverShadow | Boolean | false | hover时是否有阴影 | N
 loading | TNode | false | 加载状态，值为 true 会根据不同的布局显示不同的加载状态，值为 false 则表示非加载状态。也可以使用 Skeleton 组件完全自定义加载态呈现内容。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 loadingProps | Object | - | 透传加载组件(Loading)全部属性。TS 类型：`LoadingProps`，[Loading API Documents](./loading?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/card/type.ts) | N

--- a/packages/components/card/type.ts
+++ b/packages/components/card/type.ts
@@ -5,7 +5,7 @@
  * */
 
 import { LoadingProps } from '../loading';
-import { TNode } from '../common';
+import { TNode, Styles } from '../common';
 
 export interface TdCardProps {
   /**
@@ -16,6 +16,15 @@ export interface TdCardProps {
    * 卡片中的用户头像，仅在海报风格的卡片中有效
    */
   avatar?: TNode;
+  /**
+   * 卡片内容的类名，示例：'t-class-body'
+   * @default ''
+   */
+  bodyClassName?: string;
+  /**
+   * 作用于卡片内容的样式
+   */
+  bodyStyle?: Styles;
   /**
    * 是否有边框
    * @default true
@@ -30,7 +39,7 @@ export interface TdCardProps {
    */
   content?: TNode;
   /**
-   * 卡片封面图。值类型为字符串，会自动使用 `img` 标签输出封面图；也可以完全最定义封面图
+   * 卡片封面图。值类型为字符串，会自动使用 `img` 标签输出封面图；也可以完全自定义封面图
    */
   cover?: TNode;
   /**
@@ -42,6 +51,15 @@ export interface TdCardProps {
    */
   footer?: TNode;
   /**
+   * 卡片底部的类名，示例：'t-class-footer'
+   * @default ''
+   */
+  footerClassName?: string;
+  /**
+   * 作用于卡片底部的样式
+   */
+  footerStyle?: Styles;
+  /**
    * 卡片顶部内容，优先级高于其他所有元素
    */
   header?: TNode;
@@ -50,6 +68,15 @@ export interface TdCardProps {
    * @default false
    */
   headerBordered?: boolean;
+  /**
+   * 卡片头部的类名，示例：'t-class-header'
+   * @default ''
+   */
+  headerClassName?: string;
+  /**
+   * 作用于卡片头部的样式
+   */
+  headerStyle?: Styles;
   /**
    * hover时是否有阴影
    * @default false

--- a/packages/components/tooltip/_example/lite.tsx
+++ b/packages/components/tooltip/_example/lite.tsx
@@ -6,20 +6,20 @@ export default function BasicUsage() {
     <Space direction="vertical">
       <Space>
         <TooltipLite
-          content="文字提示仅展示文本内容"
+          content="下方文字提示"
           placement="bottom"
           triggerElement={<Button variant="outline">下方文字提示</Button>}
         ></TooltipLite>
-        <TooltipLite content="提示" placement="top">
+        <TooltipLite content="上方文字提示" placement="top">
           <Button variant="outline">上方文字提示</Button>
         </TooltipLite>
-        <TooltipLite content="提示" placement="mouse">
+        <TooltipLite content="鼠标位置显示提示" placement="mouse">
           <Button variant="outline">鼠标位置显示提示</Button>
         </TooltipLite>
-        <TooltipLite content="提示" showArrow={false}>
+        <TooltipLite content="无箭头文字提示" showArrow={false}>
           <Button variant="outline">无箭头文字提示</Button>
         </TooltipLite>
-        <TooltipLite content="提示" showShadow={false}>
+        <TooltipLite content="无投影文字提示" showShadow={false}>
           <Button variant="outline">无投影文字提示</Button>
         </TooltipLite>
       </Space>
@@ -27,7 +27,7 @@ export default function BasicUsage() {
         <TooltipLite content="浅色提示" theme="light">
           <Button variant="outline">浅色模式</Button>
         </TooltipLite>
-        <TooltipLite content="浅色提示" theme="light" showArrow={false} showShadow={true}>
+        <TooltipLite content="无箭头浅色提示" theme="light" showArrow={false} showShadow={true}>
           <Button variant="outline">无箭头浅色模式</Button>
         </TooltipLite>
         <TooltipLite content="不可用提示">


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [X] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Card): 新增 `headerClassName`、`headerStyle`、`bodyClassName`、`bodyStyle`、`footerClassName`、`footerStyle`，方便用于定制卡片组件的各部分样式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
