### PR TITLE
fix(Pagination): ellipsis icon should be restored after changing page

### DIFF
--- a/packages/components/pagination/hooks/usePageNumber.tsx
+++ b/packages/components/pagination/hooks/usePageNumber.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import classNames from 'classnames';
 import {
   EllipsisIcon as TdEllipsisIcon,
@@ -64,6 +64,15 @@ export default function usePageNumber(props) {
 
   const isFolded = pageCount > maxPageBtn; // 判断是否为需要折叠
 
+  const showPrevMore = (2 + pivot < current); // 显示左侧往前翻页的省略图标
+  const showNextMore = (pageCount - 1 - pivot > current); // 显示右侧往后翻页的省略图标
+
+  // 当省略图标消失时，需要还原hover标记
+  useEffect(() => {
+    if (!showPrevMore) toggleHoverPreMore(false);
+    if (!showNextMore) toggleHoverNextMore(false);
+  }, [showNextMore, showPrevMore]);
+
   const pageNumberControl = showPageNumber && (
     <ul className={`${name}__pager`}>
       {isFolded && isMidEllipsis && (
@@ -78,7 +87,7 @@ export default function usePageNumber(props) {
           >
             1
           </li>
-          {2 + pivot < current && (
+          {showPrevMore && (
             <li
               className={classNames(`${name}__number`, `${name}__number--more`, {
                 [`${classPrefix}-is-disabled`]: disabled,
@@ -106,7 +115,7 @@ export default function usePageNumber(props) {
       ))}
       {isFolded && isMidEllipsis && (
         <>
-          {pageCount - 1 - pivot > current && (
+          {showNextMore && (
             <li
               className={classNames(`${name}__number`, `${name}__number--more`, {
                 [`${classPrefix}-is-disabled`]: disabled,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当用户进入分页省略的icon（点击 >>），点击到icon消失后，往前回退页数，省略的icon还错误的维持在跳页图标
<img width="1656" height="258" alt="Clipboard_Screenshot_1756109376" src="https://github.com/user-attachments/assets/ca44a8c9-8326-4474-b56c-8143d75f658d" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

跳页图标的展示修复

- fix(Pagination): 修复跳转图标没有重置回正确状态的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
