### PR TITLE
feat(DatePicker): improve preset handling and popup visibility

### DIFF
--- a/packages/components/date-picker/DatePicker.tsx
+++ b/packages/components/date-picker/DatePicker.tsx
@@ -1,20 +1,24 @@
 import React, { forwardRef, useCallback, useEffect } from 'react';
+
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import { isDate } from 'lodash-es';
+
 import { formatDate, formatTime, getDefaultFormat, parseToDayjs } from '@tdesign/common-js/date-picker/format';
 import { addMonth, covertToDate, extractTimeObj, isSame, subtractMonth } from '@tdesign/common-js/date-picker/utils';
-import type { StyledProps } from '../common';
+
 import useConfig from '../hooks/useConfig';
 import useDefaultProps from '../hooks/useDefaultProps';
 import useLatest from '../hooks/useLatest';
 import useUpdateEffect from '../hooks/useUpdateEffect';
 import { useLocaleReceiver } from '../locale/LocalReceiver';
 import SelectInput from '../select-input';
-import type { TagInputRemoveContext } from '../tag-input';
 import { datePickerDefaultProps } from './defaultProps';
 import useSingle from './hooks/useSingle';
 import SinglePanel from './panel/SinglePanel';
+
+import type { StyledProps } from '../common';
+import type { TagInputRemoveContext } from '../tag-input';
 import type { DateMultipleValue, DateValue, PresetDate, TdDatePickerProps } from './type';
 
 export interface DatePickerProps extends TdDatePickerProps, StyledProps {}
@@ -149,11 +153,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     if (enableTimePicker) {
       setCacheValue(formatDate(date, { format }));
       if (props.needConfirm) return;
+      handlePopupInvisible();
       onChange(formatDate(date, { format, targetFormat: valueType }), {
         dayjsValue: parseToDayjs(date, format),
         trigger: 'pick',
       });
-      handlePopupInvisible();
     } else {
       if (multiple) {
         const newDate = processDate(date);
@@ -163,11 +167,11 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
         });
         return;
       }
+      handlePopupInvisible();
       onChange(formatDate(date, { format, targetFormat: valueType }), {
         dayjsValue: parseToDayjs(date, format),
         trigger: 'pick',
       });
-      handlePopupInvisible();
     }
   }
   // 头部快速切换
@@ -218,7 +222,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
   function onConfirmClick({ e }) {
     const nextValue = formatDate(inputValue, { format });
     props?.onConfirm?.({ e, date: nextValue });
-
+    handlePopupInvisible();
     if (nextValue) {
       onChange(formatDate(inputValue, { format, targetFormat: valueType }), {
         dayjsValue: parseToDayjs(inputValue, format),
@@ -227,7 +231,6 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     } else {
       setInputValue(formatDate(value, { format }));
     }
-    handlePopupInvisible();
   }
 
   // 预设
@@ -236,19 +239,24 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>((originalProps, r
     if (typeof preset === 'function') {
       presetValue = preset();
     }
-    const formattedPresetValue = formatDate(presetValue, { format, targetFormat: valueType });
-    const formattedInputValue = formatDate(presetValue, { format });
+    const formattedPreset = formatDate(presetValue, { format, targetFormat: valueType });
+    const formattedInput = formatDate(presetValue, { format });
 
-    // preset 不需要 confirm 就同步
-    setInputValue(formattedInputValue);
-    setCacheValue(formattedInputValue);
+    setInputValue(formattedInput);
+    setCacheValue(formattedInput);
 
-    onChange(formattedPresetValue, {
+    setTime(formatTime(presetValue, format, timeFormat, props.defaultTime));
+    setYear(parseToDayjs(presetValue, format).year());
+    setMonth(parseToDayjs(presetValue, format).month());
+
+    // 先回调 onVisibleChange
+    handlePopupInvisible();
+    // 再回调 onChange（方便用户覆盖弹窗开闭状态）
+    onChange(formattedPreset, {
       dayjsValue: parseToDayjs(presetValue, format),
       trigger: 'preset',
     });
     props.onPresetClick?.(context);
-    handlePopupInvisible();
   }
 
   const onYearChange = useCallback((year: number) => {

--- a/packages/components/date-picker/DateRangePicker.tsx
+++ b/packages/components/date-picker/DateRangePicker.tsx
@@ -1,25 +1,29 @@
 import React, { forwardRef, useEffect, useState } from 'react';
+
 import classNames from 'classnames';
 import dayjs from 'dayjs';
+
 import {
-  parseToDayjs,
-  formatTime,
   formatDate,
-  isValidDate,
+  formatTime,
   getDefaultFormat,
   initYearMonthTime,
+  isValidDate,
+  parseToDayjs,
 } from '@tdesign/common-js/date-picker/format';
-import { subtractMonth, addMonth, extractTimeObj } from '@tdesign/common-js/date-picker/utils';
+import { addMonth, extractTimeObj, subtractMonth } from '@tdesign/common-js/date-picker/utils';
 import log from '@tdesign/common-js/log/index';
+
 import useConfig from '../hooks/useConfig';
-import { StyledProps } from '../common';
-import { TdDateRangePickerProps, PresetDate } from './type';
-import { RangeInputPopup } from '../range-input';
-import RangePanel from './panel/RangePanel';
-import useRange from './hooks/useRange';
-import { dateRangePickerDefaultProps } from './defaultProps';
 import useDefaultProps from '../hooks/useDefaultProps';
+import { RangeInputPopup } from '../range-input';
+import { dateRangePickerDefaultProps } from './defaultProps';
+import useRange from './hooks/useRange';
+import RangePanel from './panel/RangePanel';
 import { dateCorrection } from './utils';
+
+import type { StyledProps } from '../common';
+import type { DateRangeValue, PresetDate, TdDateRangePickerProps } from './type';
 
 export interface DateRangePickerProps extends TdDateRangePickerProps, StyledProps {}
 
@@ -274,7 +278,10 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
   }
 
   // 预设
-  function onPresetClick(preset, context: { preset: PresetDate; e: React.MouseEvent<HTMLDivElement> }) {
+  function onPresetClick(
+    preset: DateRangeValue | (() => DateRangeValue),
+    context: { preset: PresetDate; e: React.MouseEvent<HTMLDivElement> },
+  ) {
     let presetValue = preset;
     if (typeof preset === 'function') {
       presetValue = preset();
@@ -282,12 +289,21 @@ const DateRangePicker = forwardRef<HTMLDivElement, DateRangePickerProps>((origin
     if (!Array.isArray(presetValue)) {
       log.error('DateRangePicker', `preset: ${preset} must be Array!`);
     } else {
-      onChange(formatDate(presetValue, { format, targetFormat: valueType, autoSwap: true }), {
-        dayjsValue: presetValue.map((p) => parseToDayjs(p, format)),
-        trigger: 'preset',
-      });
-      props.onPresetClick?.(context);
+      const formattedPreset = formatDate(presetValue, { format });
+      setInputValue(formattedPreset);
+      setCacheValue(formattedPreset);
+      setTime(formatTime(formattedPreset, format, timeFormat, props.defaultTime));
+      const newYear = formattedPreset.map((v) => parseToDayjs(v, format).year());
+      const newMonth = formattedPreset.map((v) => parseToDayjs(v, format).month());
+
+      setYear(newYear);
+      setMonth(newMonth);
+      setIsSelected(true);
+      setIsFirstValueSelected(true);
+
       handlePopupInvisible();
+      onChange(value, { dayjsValue: formattedPreset.map((p) => parseToDayjs(p, format)), trigger: 'preset' });
+      props.onPresetClick?.(context);
     }
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-react/issues/3793

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 点击 Preset 后直接同步 `value`，而不是等弹窗开启后再同步
- 先 `onVisibleChange` 再 `onChange` 回调，避免被状态被覆盖

<details>

<summary>Hacking Example</summary>

```tsx
import React, { useState } from 'react';
import dayjs from 'dayjs';
import { DateRangePicker } from 'tdesign-react';
import type { DateRangePickerProps, DateRangeValue } from 'tdesign-react';

export default function YearDatePicker() {
  const DATE_RANGE_PRESETS = {
    最近7天: [dayjs().subtract(6, 'day').toDate(), dayjs().toDate()],
    最近3天: [dayjs().subtract(2, 'day').toDate(), dayjs().toDate()],
  } as DateRangePickerProps['presets'];

  const [popupVisible, setPopupVisible] = useState(false);
  const [range, setRange] = useState<DateRangeValue>(['2025-01-01', '2025-08-08']);

  return (
    <DateRangePicker
      enableTimePicker
      value={range}
      presets={DATE_RANGE_PRESETS}
      popupProps={{
        visible: popupVisible,
        onVisibleChange: (v, context) => {
          // 外部手动关闭的情况，trigger 类型未定，之前被定义为 {}
          // 算是一个 Hacking 方案
          if (context && Object.keys(context).length === 0 && !v) {
            return;
          }
          setPopupVisible(v);
        },
      }}
      onChange={(val, context) => {
        setRange(val);
        if (context.trigger === 'preset') {
          return;
        }
        setPopupVisible(false);
      }}
    />
  );
}
```

</details>

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 支持通过覆盖popupVi，使电机preset时不关闭弹窗

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
