### PR TITLE
fix(Dialog/Drawer): add useDeepEffect hook

### DIFF
--- a/packages/components/dialog/Dialog.tsx
+++ b/packages/components/dialog/Dialog.tsx
@@ -1,12 +1,15 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
+
 import classNames from 'classnames';
 import { isUndefined } from 'lodash-es';
+
 import log from '@tdesign/common-js/log/index';
-import type { StyledProps } from '../common';
+
 import Portal from '../common/Portal';
 import useAttach from '../hooks/useAttach';
 import useConfig from '../hooks/useConfig';
+import useDeepEffect from '../hooks/useDeepEffect';
 import useDefaultProps from '../hooks/useDefaultProps';
 import useSetState from '../hooks/useSetState';
 import { useLocaleReceiver } from '../locale/LocalReceiver';
@@ -16,8 +19,10 @@ import useDialogDrag from './hooks/useDialogDrag';
 import useDialogEsc from './hooks/useDialogEsc';
 import useDialogPosition from './hooks/useDialogPosition';
 import useLockStyle from './hooks/useLockStyle';
-import type { DialogInstance, TdDialogProps } from './type';
 import { parseValueToPx } from './utils';
+
+import type { StyledProps } from '../common';
+import type { DialogInstance, TdDialogProps } from './type';
 
 export interface DialogProps extends TdDialogProps, StyledProps {
   isPlugin?: boolean; // 是否以插件形式调用
@@ -81,13 +86,11 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
     canDraggable: draggable && mode === 'modeless',
   });
 
-  useEffect(() => {
-    if (isPlugin) {
-      return;
-    }
+  useDeepEffect(() => {
+    if (isPlugin) return;
     // 插件式调用不会更新props, 只有组件式调用才会更新props
     setState((prevState) => ({ ...prevState, ...props }));
-  }, [props, setState, isPlugin]);
+  }, [props, setState]);
 
   useImperativeHandle(ref, () => ({
     show() {

--- a/packages/components/dialog/Dialog.tsx
+++ b/packages/components/dialog/Dialog.tsx
@@ -1,11 +1,8 @@
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
-
 import classNames from 'classnames';
 import { isUndefined } from 'lodash-es';
-
 import log from '@tdesign/common-js/log/index';
-
 import Portal from '../common/Portal';
 import useAttach from '../hooks/useAttach';
 import useConfig from '../hooks/useConfig';
@@ -20,7 +17,6 @@ import useDialogEsc from './hooks/useDialogEsc';
 import useDialogPosition from './hooks/useDialogPosition';
 import useLockStyle from './hooks/useLockStyle';
 import { parseValueToPx } from './utils';
-
 import type { StyledProps } from '../common';
 import type { DialogInstance, TdDialogProps } from './type';
 

--- a/packages/components/drawer/Drawer.tsx
+++ b/packages/components/drawer/Drawer.tsx
@@ -1,13 +1,10 @@
-import classnames from 'classnames';
-import { isFunction, isObject, isString, isUndefined } from 'lodash-es';
 import React, { forwardRef, isValidElement, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-
 import { CSSTransition } from 'react-transition-group';
 import { CloseIcon as TdCloseIcon } from 'tdesign-icons-react';
-
+import classnames from 'classnames';
+import { isFunction, isObject, isString, isUndefined } from 'lodash-es';
 import parseTNode from '../_util/parseTNode';
 import Button, { type ButtonProps } from '../button';
-
 import Portal from '../common/Portal';
 import useAttach from '../hooks/useAttach';
 import useConfig from '../hooks/useConfig';

--- a/packages/components/drawer/Drawer.tsx
+++ b/packages/components/drawer/Drawer.tsx
@@ -1,24 +1,27 @@
-import React, { forwardRef, useState, useEffect, useImperativeHandle, useRef, useMemo, isValidElement } from 'react';
 import classnames from 'classnames';
-import { isString, isObject, isFunction, isUndefined } from 'lodash-es';
+import { isFunction, isObject, isString, isUndefined } from 'lodash-es';
+import React, { forwardRef, isValidElement, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 
 import { CSSTransition } from 'react-transition-group';
 import { CloseIcon as TdCloseIcon } from 'tdesign-icons-react';
 
-import { useLocaleReceiver } from '../locale/LocalReceiver';
-import type { TdDrawerProps, DrawerEventSource, DrawerInstance } from './type';
-import { StyledProps } from '../common';
-import Button, { ButtonProps } from '../button';
+import parseTNode from '../_util/parseTNode';
+import Button, { type ButtonProps } from '../button';
+
+import Portal from '../common/Portal';
+import useAttach from '../hooks/useAttach';
 import useConfig from '../hooks/useConfig';
+import useDeepEffect from '../hooks/useDeepEffect';
+import useDefaultProps from '../hooks/useDefaultProps';
 import useGlobalIcon from '../hooks/useGlobalIcon';
+import useSetState from '../hooks/useSetState';
+import { useLocaleReceiver } from '../locale/LocalReceiver';
 import { drawerDefaultProps } from './defaultProps';
 import useDrag from './hooks/useDrag';
-import Portal from '../common/Portal';
 import useLockStyle from './hooks/useLockStyle';
-import useDefaultProps from '../hooks/useDefaultProps';
-import parseTNode from '../_util/parseTNode';
-import useAttach from '../hooks/useAttach';
-import useSetState from '../hooks/useSetState';
+
+import type { StyledProps } from '../common';
+import type { DrawerEventSource, DrawerInstance, TdDrawerProps } from './type';
 
 export const CloseTriggerType: { [key: string]: DrawerEventSource } = {
   CLICK_OVERLAY: 'overlay',
@@ -112,12 +115,11 @@ const Drawer = forwardRef<DrawerInstance, DrawerProps>((originalProps, ref) => {
     }
   }, [visible]);
 
-  useEffect(() => {
+  useDeepEffect(() => {
     // 非插件式调用 更新props
-    if (!isPlugin) {
-      setState((prevState) => ({ ...prevState, ...props }));
-    }
-  }, [isPlugin, props, setState]);
+    if (isPlugin) return;
+    setState((prevState) => ({ ...prevState, ...props }));
+  }, [props, setState]);
 
   function onMaskClick(e: React.MouseEvent<HTMLDivElement>) {
     onOverlayClick?.({ e });

--- a/packages/components/hooks/useDeepEffect.ts
+++ b/packages/components/hooks/useDeepEffect.ts
@@ -1,0 +1,25 @@
+import { isEqual } from 'lodash-es';
+import { useEffect, useRef } from 'react';
+
+/**
+ * 与 useEffect 用法一致，但对依赖数组进行深比较
+ * - 只在依赖项真正变化时才会触发副作用函数
+ * - 适用于依赖为复杂对象的场景
+ */
+function useDeepEffect(effect, deps) {
+  const isInitial = useRef(true);
+  const prevDeps = useRef(deps);
+
+  useEffect(() => {
+    const isSame = isEqual(prevDeps.current, deps);
+
+    if (isInitial.current || !isSame) {
+      effect();
+    }
+
+    isInitial.current = false;
+    prevDeps.current = deps;
+  }, [effect, deps]);
+}
+
+export default useDeepEffect;

--- a/packages/components/hooks/useDeepEffect.ts
+++ b/packages/components/hooks/useDeepEffect.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef } from 'react';
  * - 只在依赖项真正变化时才会触发副作用函数
  * - 适用于依赖为复杂对象的场景
  */
-function useDeepEffect(effect, deps) {
+function useDeepEffect(effect: React.EffectCallback, deps: any[]) {
   const isInitial = useRef(true);
   const prevDeps = useRef(deps);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/3796

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

React 19 中，`ref` 被改为一个普通的 `props`：https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复在 React 19 环境下，由于使用 `ref` 引发的死循环问题
- fix(Drawer): 修复在 React 19 环境下，由于使用 `ref` 引发的死循环问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
