### PR TITLE
fix(TagInput): optimize value display rendering with useMemo

### DIFF
--- a/packages/components/select/base/Select.tsx
+++ b/packages/components/select/base/Select.tsx
@@ -451,7 +451,23 @@ const Select = forwardRefWithStatics(
       }
       return parseContentTNode(valueDisplay, { value: selectedLabel, onClose: noop });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [valueDisplay, selectedOptions]);
+    }, [
+      valueDisplay,
+      multiple,
+      selectedLabel,
+      minCollapsedNum,
+      options,
+      disabled,
+      readonly,
+      size,
+      tagProps,
+      value,
+      valueType,
+      keys,
+      valueToOption,
+      onRemove,
+      selectedOptions,
+    ]);
 
     // 将第一个选中的 option 置于列表可见范围的最后一位
     const updateScrollTop = (content: HTMLDivElement) => {

--- a/packages/components/select/base/Select.tsx
+++ b/packages/components/select/base/Select.tsx
@@ -1,39 +1,40 @@
 import React, {
-  useEffect,
-  useMemo,
+  Children,
   KeyboardEvent,
   WheelEvent,
-  useRef,
-  useCallback,
-  Children,
   cloneElement,
   isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
   useState,
 } from 'react';
 import classNames from 'classnames';
-import { isFunction, get, debounce } from 'lodash-es';
-import { getOffsetTopToContainer } from '../../_util/helper';
-import useControlled from '../../hooks/useControlled';
-import { useLocaleReceiver } from '../../locale/LocalReceiver';
-import useConfig from '../../hooks/useConfig';
+import { debounce, get, isFunction } from 'lodash-es';
+import composeRefs from '../../_util/composeRefs';
 import forwardRefWithStatics from '../../_util/forwardRefWithStatics';
-import { getSelectValueArr, getSelectedOptions } from '../util/helper';
+import { getOffsetTopToContainer } from '../../_util/helper';
 import noop from '../../_util/noop';
+import { parseContentTNode } from '../../_util/parseTNode';
 import FakeArrow from '../../common/FakeArrow';
+import useConfig from '../../hooks/useConfig';
+import useControlled from '../../hooks/useControlled';
+import useDefaultProps from '../../hooks/useDefaultProps';
 import Loading from '../../loading';
-import SelectInput, { SelectInputValue, SelectInputValueChangeContext } from '../../select-input';
+import { useLocaleReceiver } from '../../locale/LocalReceiver';
+import SelectInput, { type SelectInputValue, type SelectInputValueChangeContext } from '../../select-input';
+import Tag from '../../tag';
+import { selectDefaultProps } from '../defaultProps';
+import useOptions, { isSelectOptionGroup } from '../hooks/useOptions';
+import { getSelectValueArr, getSelectedOptions } from '../util/helper';
 import Option from './Option';
 import OptionGroup from './OptionGroup';
 import PopupContent from './PopupContent';
-import Tag from '../../tag';
-import { TdSelectProps, TdOptionProps, SelectOption, SelectValueChangeTrigger, SelectValue } from '../type';
-import { StyledProps } from '../../common';
-import { selectDefaultProps } from '../defaultProps';
-import { PopupVisibleChangeContext } from '../../popup';
-import useOptions, { isSelectOptionGroup } from '../hooks/useOptions';
-import composeRefs from '../../_util/composeRefs';
-import { parseContentTNode } from '../../_util/parseTNode';
-import useDefaultProps from '../../hooks/useDefaultProps';
+
+import type { StyledProps } from '../../common';
+import type { PopupVisibleChangeContext } from '../../popup';
+import type { SelectOption, SelectValue, SelectValueChangeTrigger, TdOptionProps, TdSelectProps } from '../type';
 
 export interface SelectProps<T = SelectOption> extends TdSelectProps<T>, StyledProps {
   // 子节点
@@ -393,7 +394,7 @@ const Select = forwardRefWithStatics(
       return <PopupContent {...popupContentProps}>{childrenWithProps}</PopupContent>;
     };
 
-    const renderValueDisplay = () => {
+    const renderValueDisplay = useMemo(() => {
       if (!valueDisplay) {
         if (!multiple) {
           if (typeof selectedLabel !== 'string') {
@@ -449,7 +450,8 @@ const Select = forwardRefWithStatics(
         return ({ onClose }) => parseContentTNode(valueDisplay, { value: selectedOptions, onClose });
       }
       return parseContentTNode(valueDisplay, { value: selectedLabel, onClose: noop });
-    };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [valueDisplay, selectedOptions]);
 
     // 将第一个选中的 option 置于列表可见范围的最后一位
     const updateScrollTop = (content: HTMLDivElement) => {
@@ -512,7 +514,7 @@ const Select = forwardRefWithStatics(
           multiple={multiple}
           value={selectedLabel}
           options={selectedOptions}
-          valueDisplay={renderValueDisplay()}
+          valueDisplay={renderValueDisplay}
           clearable={clearable}
           disabled={disabled}
           status={props.status}

--- a/packages/components/tag-input/TagInput.tsx
+++ b/packages/components/tag-input/TagInput.tsx
@@ -1,19 +1,28 @@
-import React, { CompositionEvent, KeyboardEvent, useRef, useImperativeHandle, forwardRef, MouseEvent } from 'react';
+import React, {
+  CompositionEvent,
+  forwardRef,
+  KeyboardEvent,
+  MouseEvent,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
 import { CloseCircleFilledIcon as TdCloseCircleFilledIcon } from 'tdesign-icons-react';
-import { isFunction } from 'lodash-es';
 import classnames from 'classnames';
+import { isFunction } from 'lodash-es';
 import useConfig from '../hooks/useConfig';
-import useGlobalIcon from '../hooks/useGlobalIcon';
-import useDragSorter from '../hooks/useDragSorter';
-import TInput, { InputValue, InputRef } from '../input';
-import { TdTagInputProps } from './type';
-import useTagScroll from './useTagScroll';
-import useTagList from './useTagList';
-import useHover from './useHover';
 import useControlled from '../hooks/useControlled';
-import { StyledProps } from '../common';
-import { tagInputDefaultProps } from './defaultProps';
 import useDefaultProps from '../hooks/useDefaultProps';
+import useDragSorter from '../hooks/useDragSorter';
+import useGlobalIcon from '../hooks/useGlobalIcon';
+import TInput, { type InputRef, type InputValue } from '../input';
+import { tagInputDefaultProps } from './defaultProps';
+import useHover from './useHover';
+import useTagList from './useTagList';
+import useTagScroll from './useTagScroll';
+
+import type { TdTagInputProps } from './type';
+import type { StyledProps } from '../common';
 
 export interface TagInputProps extends TdTagInputProps, StyledProps {
   options?: any[]; // 参数穿透options, 给SelectInput/SelectInput 自定义选中项呈现的内容和多选状态下设置折叠项内容
@@ -117,13 +126,19 @@ const TagInput = forwardRef<InputRef, TagInputProps>((originalProps, ref) => {
   ) : (
     suffixIcon
   );
+
   // 自定义 Tag 节点
-  const displayNode = isFunction(valueDisplay)
-    ? valueDisplay({
-        value: tagValue,
-        onClose: (index) => onClose({ index }),
-      })
-    : valueDisplay;
+  const displayNode = useMemo(
+    () =>
+      isFunction(valueDisplay)
+        ? valueDisplay({
+            value: tagValue,
+            onClose: (index) => onClose({ index }),
+          })
+        : valueDisplay,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [valueDisplay],
+  );
 
   const isEmpty = !(Array.isArray(tagValue) && tagValue.length);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<details>

<summary><strong><em>复现代码</strong></em></summary>

```tsx
import React, { useCallback, useState } from 'react';
import { Select, SelectOption, Space, Tag } from 'tdesign-react';

const options = [
  { label: '选项一', value: '1' },
  { label: '选项二', value: '2' },
  { label: '选项三', value: '3' },
  { label: '选项四', value: '4' },
  { label: '选项五', value: '5' },
  { label: '选项六', value: '6' },
  { label: '选项七', value: '7' },
  { label: '选项八', value: '8' },
  { label: '选项九', value: '9' },
];

const CustomSelected = () => {
  const [value, setValue] = useState(['1', '2', '3']);
  const onChange = (value: string[]) => {
    setValue(value);
  };

  const singleSelect = ({ value }) => {
    console.log('singleSelect');
    return value ? `${value} 👼 ` : null;
  };

  const multipleSelect = useCallback(({ value, onClose }) => {
    console.log('multipleSelect');
    return Array.isArray(value) && value.length > 0
      ? value.map((v: SelectOption, idx: number) => (
          <Tag
            key={idx}
            onClose={(context) => {
              context.e && context.e.stopPropagation();
              onClose(idx);
            }}
            closable
          >{`${v.label} 😈`}</Tag>
        ))
      : null;
  }, []);

  return (
    <Space>
      <Select
        clearable
        defaultValue={'1'}
        style={{ width: '300px', marginRight: '20px' }}
        valueDisplay={singleSelect}
        options={options}
      ></Select>
      <Select
        clearable
        multiple
        value={value}
        onChange={onChange}
        style={{ width: '300px', marginRight: '20px' }}
        options={[
          { label: '选项一', value: '1' },
          { label: '选项二', value: '2' },
          { label: '选项三', value: '3' },
          { label: '选项四', value: '4' },
          { label: '选项五', value: '5' },
          { label: '选项六', value: '6' },
          { label: '选项七', value: '7' },
          { label: '选项八', value: '8' },
          { label: '选项九', value: '9' },
        ]}
        valueDisplay={multipleSelect}
      />
    </Space>
  );
};

export default CustomSelected;
```

</details>

https://github.com/user-attachments/assets/6d4efd90-a4c9-477c-ab1a-13aa3586fa1f

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 避免下拉框的打开与关闭时，频繁重复触发 `valueDisplay` 的渲染
- fix(TagInput): 避免下拉框的打开与关闭时，频繁重复触发 `valueDisplay` 的渲染

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
