### PR TITLE
feat(Watermark): support layout API

### DIFF
--- a/packages/components/watermark/Watermark.tsx
+++ b/packages/components/watermark/Watermark.tsx
@@ -81,7 +81,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
         layout,
       },
       (url, { width }) => {
-        backgroundSize.current = `${width}px`;
+        backgroundSize.current = width ? `${width}px` : null;
         setBase64Url(url);
       },
     );
@@ -112,14 +112,14 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
       bottom: 0,
       width: movable ? `${width}px` : '100%',
       height: movable ? `${height}px` : '100%',
-      backgroundSize: backgroundSize.current,
+      backgroundSize: backgroundSize.current || `${gapX + width}px`,
       pointerEvents: 'none',
       backgroundRepeat: movable ? 'no-repeat' : isRepeat ? 'repeat' : 'no-repeat',
       backgroundImage: `url('${base64Url}')`,
       animation: movable ? `watermark infinite ${(moveInterval * 4) / 60}s` : 'none',
       ...style,
     });
-  }, [zIndex, gapX, width, movable, isRepeat, base64Url, moveInterval, style, height]);
+  }, [zIndex, gapX, width, movable, isRepeat, base64Url, moveInterval, style, height, backgroundSize]);
 
   // 水印节点 - 渲染
   const renderWatermark = useCallback(() => {

--- a/packages/components/watermark/Watermark.tsx
+++ b/packages/components/watermark/Watermark.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-import generateBase64Url from '@tdesign/common-js/watermark/generateBase64Url';
+import generateWatermark from '@tdesign/common-js/watermark/generateWatermark';
 import randomMovingStyle from '@tdesign/common-js/watermark/randomMovingStyle';
 import injectStyle from '@tdesign/common-js/utils/injectStyle';
 import { StyledProps } from '../common';
@@ -34,6 +34,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
     content,
     children,
     watermarkContent,
+    layout,
     className,
     style = {},
   } = props;
@@ -56,6 +57,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
   const stopObservation = useRef(false);
   const offsetLeft = offset[0] || gapX / 2;
   const offsetTop = offset[1] || gapY / 2;
+  const backgroundSize = useRef(`${gapX + width}px`);
 
   const { fontColor } = useVariables({
     fontColor: '--td-text-color-watermark',
@@ -63,7 +65,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
 
   // 水印节点 - 背景base64
   useEffect(() => {
-    generateBase64Url(
+    generateWatermark(
       {
         width,
         height,
@@ -76,12 +78,28 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
         offsetLeft,
         offsetTop,
         fontColor,
+        layout,
       },
-      (url) => {
+      (url, { width }) => {
+        backgroundSize.current = `${width}px`;
         setBase64Url(url);
       },
     );
-  }, [width, height, rotate, zIndex, lineSpace, alpha, offsetLeft, offsetTop, gapX, gapY, watermarkContent, fontColor]);
+  }, [
+    width,
+    height,
+    rotate,
+    zIndex,
+    lineSpace,
+    alpha,
+    offsetLeft,
+    offsetTop,
+    gapX,
+    gapY,
+    watermarkContent,
+    fontColor,
+    layout,
+  ]);
 
   // 水印节点 - styleStr
   useEffect(() => {
@@ -94,7 +112,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
       bottom: 0,
       width: movable ? `${width}px` : '100%',
       height: movable ? `${height}px` : '100%',
-      backgroundSize: `${gapX + width}px`,
+      backgroundSize: backgroundSize.current,
       pointerEvents: 'none',
       backgroundRepeat: movable ? 'no-repeat' : isRepeat ? 'repeat' : 'no-repeat',
       backgroundImage: `url('${base64Url}')`,

--- a/packages/components/watermark/Watermark.tsx
+++ b/packages/components/watermark/Watermark.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-import generateWatermark from '@tdesign/common-js/watermark/generateWatermark';
+import generateBase64Url from '@tdesign/common-js/watermark/generateBase64Url';
 import randomMovingStyle from '@tdesign/common-js/watermark/randomMovingStyle';
 import injectStyle from '@tdesign/common-js/utils/injectStyle';
 import { StyledProps } from '../common';
@@ -65,7 +65,7 @@ const Watermark: React.FC<WatermarkProps> = (originalProps) => {
 
   // 水印节点 - 背景base64
   useEffect(() => {
-    generateWatermark(
+    generateBase64Url(
       {
         width,
         height,

--- a/packages/components/watermark/__tests__/watermark.test.tsx
+++ b/packages/components/watermark/__tests__/watermark.test.tsx
@@ -51,7 +51,7 @@ describe('Watermark 组件测试', () => {
 
   test('mutationObserver', async () => {
     const wrapper = render(
-      <Watermark watermarkContent={{ text: '@水印' }} className="test-observer" y={100}>
+      <Watermark watermarkContent={{ text: '@水印' }} className="test-observer" y={100} removable={false}>
         <div data-testid={childTestID} style={{ height: 300 }}></div>
       </Watermark>,
     );

--- a/packages/components/watermark/_example/layout.tsx
+++ b/packages/components/watermark/_example/layout.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Watermark } from 'tdesign-react';
+
+export default function LayoutWatermark() {
+  return (
+    <>
+      <h3>横平竖直的水印</h3>
+      <Watermark
+        watermarkContent={{ text: '文字水印' }}
+        width={120}
+        height={60}
+        y={120}
+        x={80}
+      >
+        <div style={{ height: 300 }}></div>
+      </Watermark>
+
+      <h3>错位的水印</h3>
+      <Watermark
+        watermarkContent={{ text: '文字水印' }}
+        width={120}
+        height={60}
+        y={120}
+        x={80}
+        layout="hexagonal"
+      >
+        <div style={{ height: 300 }}></div>
+      </Watermark>
+
+      <h3>Watermark Test</h3>
+      <Watermark
+        watermarkContent={[
+          { text: '文字水印', fontColor: '#0052D9' },
+          { text: '水印水印水印水印', fontColor: '#0052D9' },
+        ]}
+        width={120}
+        height={60}
+        y={120}
+        x={80}
+        layout="hexagonal"
+      >
+        <div style={{ height: 300 }}></div>
+      </Watermark>
+
+      <h3>多行水印</h3>
+      <Watermark
+        watermarkContent={[
+          { text: '水印文本', fontColor: '#0052D9' },
+          { text: '水印水印水印水印', fontColor: '#0052D9' },
+          { text: '文本文本文本文本文本文本', fontColor: '#0052D9' },
+          { url: 'https://tdesign.gtimg.com/starter/brand-logo-light.png' },
+        ]}
+        lineSpace={24}
+        x={100}
+        y={120}
+        width={158}
+        height={22}
+        layout="hexagonal"
+      >
+        <div style={{ height: 300 }}></div>
+      </Watermark>
+
+      <h3>多行灰度水印</h3>
+      <Watermark
+        watermarkContent={[
+          { text: '水印文本', fontColor: '#0052D9' },
+          { url: 'https://tdesign.gtimg.com/starter/brand-logo-light.png', isGrayscale: true },
+        ]}
+        lineSpace={24}
+        x={100}
+        y={120}
+        width={158}
+        height={22}
+        layout="hexagonal"
+      >
+        <div style={{ height: 300 }}></div>
+      </Watermark>
+    </>
+  );
+}

--- a/packages/components/watermark/_example/layout.tsx
+++ b/packages/components/watermark/_example/layout.tsx
@@ -5,74 +5,12 @@ export default function LayoutWatermark() {
   return (
     <>
       <h3>横平竖直的水印</h3>
-      <Watermark
-        watermarkContent={{ text: '文字水印' }}
-        width={120}
-        height={60}
-        y={120}
-        x={80}
-      >
+      <Watermark watermarkContent={{ text: '文字水印' }} width={120} height={60} y={120} x={80}>
         <div style={{ height: 300 }}></div>
       </Watermark>
 
       <h3>错位的水印</h3>
-      <Watermark
-        watermarkContent={{ text: '文字水印' }}
-        width={120}
-        height={60}
-        y={120}
-        x={80}
-        layout="hexagonal"
-      >
-        <div style={{ height: 300 }}></div>
-      </Watermark>
-
-      <h3>Watermark Test</h3>
-      <Watermark
-        watermarkContent={[
-          { text: '文字水印', fontColor: '#0052D9' },
-          { text: '水印水印水印水印', fontColor: '#0052D9' },
-        ]}
-        width={120}
-        height={60}
-        y={120}
-        x={80}
-        layout="hexagonal"
-      >
-        <div style={{ height: 300 }}></div>
-      </Watermark>
-
-      <h3>多行水印</h3>
-      <Watermark
-        watermarkContent={[
-          { text: '水印文本', fontColor: '#0052D9' },
-          { text: '水印水印水印水印', fontColor: '#0052D9' },
-          { text: '文本文本文本文本文本文本', fontColor: '#0052D9' },
-          { url: 'https://tdesign.gtimg.com/starter/brand-logo-light.png' },
-        ]}
-        lineSpace={24}
-        x={100}
-        y={120}
-        width={158}
-        height={22}
-        layout="hexagonal"
-      >
-        <div style={{ height: 300 }}></div>
-      </Watermark>
-
-      <h3>多行灰度水印</h3>
-      <Watermark
-        watermarkContent={[
-          { text: '水印文本', fontColor: '#0052D9' },
-          { url: 'https://tdesign.gtimg.com/starter/brand-logo-light.png', isGrayscale: true },
-        ]}
-        lineSpace={24}
-        x={100}
-        y={120}
-        width={158}
-        height={22}
-        layout="hexagonal"
-      >
+      <Watermark watermarkContent={{ text: '文字水印' }} width={120} height={60} y={120} x={80} layout="hexagonal">
         <div style={{ height: 300 }}></div>
       </Watermark>
     </>

--- a/packages/components/watermark/_usage/index.jsx
+++ b/packages/components/watermark/_usage/index.jsx
@@ -1,0 +1,58 @@
+/**
+ *  该脚本为自动生成，如有需要请在 /script/generate-usage.js 中调整
+ */
+
+// @ts-nocheck
+import React, { useState, useEffect, useMemo } from "react";
+import BaseUsage, {
+  useConfigChange,
+  usePanelChange,
+} from "@tdesign/react-site/src/components/BaseUsage";
+import jsxToString from "react-element-to-jsx-string";
+
+import configProps from "./props.json";
+
+import { Watermark } from "tdesign-react";
+
+export default function Usage() {
+  const [configList, setConfigList] = useState(configProps);
+
+  const { changedProps, onConfigChange } = useConfigChange(configList);
+
+  const panelList = [{ label: "Watermark", value: "Watermark" }];
+
+  const { panel, onPanelChange } = usePanelChange(panelList);
+
+  const [renderComp, setRenderComp] = useState();
+
+  const defaultProps = {
+    watermarkContent: { text: "文字水印" },
+    y: 120,
+    x: 80,
+  };
+
+  useEffect(() => {
+    setRenderComp(
+      <Watermark {...defaultProps} {...changedProps}>
+        <div style={{ height: 300, width: 400 }}></div>
+      </Watermark>
+    );
+  }, [changedProps]);
+
+  const jsxStr = useMemo(() => {
+    if (!renderComp) return "";
+    return jsxToString(renderComp);
+  }, [renderComp]);
+
+  return (
+    <BaseUsage
+      code={jsxStr}
+      panelList={panelList}
+      configList={configList}
+      onPanelChange={onPanelChange}
+      onConfigChange={onConfigChange}
+    >
+      {renderComp}
+    </BaseUsage>
+  );
+}

--- a/packages/components/watermark/_usage/props.json
+++ b/packages/components/watermark/_usage/props.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "movable",
+    "type": "Boolean",
+    "defaultValue": false,
+    "options": []
+  },
+  {
+    "name": "isRepeat",
+    "type": "Boolean",
+    "defaultValue": true,
+    "options": []
+  },
+  {
+    "name": "removable",
+    "type": "Boolean",
+    "defaultValue": true,
+    "options": []
+  },
+  {
+    "name": "layout",
+    "type": "enum",
+    "defaultValue": "rectangular",
+    "options": [
+      {
+        "label": "rectangular",
+        "value": "rectangular"
+      },
+      {
+        "label": "hexagonal",
+        "value": "hexagonal"
+      }
+    ]
+  }
+]

--- a/packages/components/watermark/defaultProps.ts
+++ b/packages/components/watermark/defaultProps.ts
@@ -11,6 +11,6 @@ export const watermarkDefaultProps: TdWatermarkProps = {
   lineSpace: 16,
   movable: false,
   moveInterval: 3000,
-  removable: true,
+  removable: false,
   rotate: -22,
 };

--- a/packages/components/watermark/defaultProps.ts
+++ b/packages/components/watermark/defaultProps.ts
@@ -7,9 +7,10 @@ import { TdWatermarkProps } from './type';
 export const watermarkDefaultProps: TdWatermarkProps = {
   alpha: 1,
   isRepeat: true,
+  layout: 'rectangular',
   lineSpace: 16,
   movable: false,
   moveInterval: 3000,
-  removable: false,
+  removable: true,
   rotate: -22,
 };

--- a/packages/components/watermark/type.ts
+++ b/packages/components/watermark/type.ts
@@ -55,7 +55,7 @@ export interface TdWatermarkProps {
   offset?: Array<number>;
   /**
    * 水印是否可被删除
-   * @default true
+   * @default false
    */
   removable?: boolean;
   /**

--- a/packages/components/watermark/type.ts
+++ b/packages/components/watermark/type.ts
@@ -30,6 +30,11 @@ export interface TdWatermarkProps {
    */
   isRepeat?: boolean;
   /**
+   * 水印的布局方式，rectangular：矩形，即横平竖直的水印；hexagonal：六边形，即错位的水印
+   * @default rectangular
+   */
+  layout?: 'rectangular' | 'hexagonal';
+  /**
    * 行间距，只作用在多行（`content` 配置为数组）情况下
    * @default 16
    */
@@ -49,7 +54,7 @@ export interface TdWatermarkProps {
    */
   offset?: Array<number>;
   /**
-   * 水印是否可被删除，默认会开启水印节点防删
+   * 水印是否可被删除
    * @default true
    */
   removable?: boolean;
@@ -86,6 +91,11 @@ export interface WatermarkText {
    * @default rgba(0,0,0,0.1)
    */
   fontColor?: string;
+  /**
+   * 水印文本文字字体
+   * @default ''
+   */
+  fontFamily?: string;
   /**
    * 水印文本文字大小
    * @default 16

--- a/packages/components/watermark/watermark.en-US.md
+++ b/packages/components/watermark/watermark.en-US.md
@@ -6,18 +6,19 @@
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-className | String | - | 类名 | N
-style | Object | - | 样式，Typescript：`React.CSSProperties` | N
+className | String | - | className of component | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
 alpha | Number | 1 | \- | N
 children | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 content | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 height | Number | - | \- | N
 isRepeat | Boolean | true | \- | N
+layout | String | rectangular | options: rectangular/hexagonal | N
 lineSpace | Number | 16 | \- | N
 movable | Boolean | false | \- | N
 moveInterval | Number | 3000 | \- | N
 offset | Array | - | Typescript：`Array<number>` | N
-removable | Boolean | false | \- | N
+removable | Boolean | true | \- | N
 rotate | Number | -22 | \- | N
 watermarkContent | Object / Array | - | Typescript：`WatermarkText\|WatermarkImage\|Array<WatermarkText\|WatermarkImage>` | N
 width | Number | - | \- | N
@@ -30,8 +31,9 @@ zIndex | Number | - | \- | N
 name | type | default | description | required
 -- | -- | -- | -- | --
 fontColor | String | rgba(0,0,0,0.1) | \- | N
+fontFamily | String | - | font-family configuration for watermark text | N
 fontSize | Number | 16 | \- | N
-fontWeight | String | normal | options：normal/lighter/bold/bolder | N
+fontWeight | String | normal | options: normal/lighter/bold/bolder | N
 text | String | - | \- | N
 
 ### WatermarkImage

--- a/packages/components/watermark/watermark.en-US.md
+++ b/packages/components/watermark/watermark.en-US.md
@@ -18,7 +18,7 @@ lineSpace | Number | 16 | \- | N
 movable | Boolean | false | \- | N
 moveInterval | Number | 3000 | \- | N
 offset | Array | - | Typescript：`Array<number>` | N
-removable | Boolean | true | \- | N
+removable | Boolean | false | \- | N
 rotate | Number | -22 | \- | N
 watermarkContent | Object / Array | - | Typescript：`WatermarkText\|WatermarkImage\|Array<WatermarkText\|WatermarkImage>` | N
 width | Number | - | \- | N

--- a/packages/components/watermark/watermark.md
+++ b/packages/components/watermark/watermark.md
@@ -18,7 +18,7 @@ lineSpace | Number | 16 | 行间距，只作用在多行（`content` 配置为�
 movable | Boolean | false | 水印是否可移动 | N
 moveInterval | Number | 3000 | 水印发生运动位移的间隙，单位：毫秒 | N
 offset | Array | - | 水印在画布上绘制的水平和垂直偏移量，正常情况下水印绘制在中间位置，即 `offset = [gapX / 2, gapY / 2]`。TS 类型：`Array<number>` | N
-removable | Boolean | true | 水印是否可被删除 | N
+removable | Boolean | false | 水印是否可被删除，默认会开启水印节点防删 | N
 rotate | Number | -22 | 水印旋转的角度，单位 ° | N
 watermarkContent | Object / Array | - | 水印内容，需要显示多行情况下可配置为数组。TS 类型：`WatermarkText\|WatermarkImage\|Array<WatermarkText\|WatermarkImage>` | N
 width | Number | - | 水印宽度 | N

--- a/packages/components/watermark/watermark.md
+++ b/packages/components/watermark/watermark.md
@@ -1,9 +1,10 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Watermark Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
@@ -12,11 +13,12 @@ children | TNode | - | 水印所覆盖的内容节点，同 `content`。TS 类�
 content | TNode | - | 水印所覆盖的内容节点。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 height | Number | - | 水印高度 | N
 isRepeat | Boolean | true | 水印是否重复出现 | N
+layout | String | rectangular | 水印的布局方式，rectangular：矩形，即横平竖直的水印；hexagonal：六边形，即错位的水印。可选项：rectangular/hexagonal | N
 lineSpace | Number | 16 | 行间距，只作用在多行（`content` 配置为数组）情况下 | N
 movable | Boolean | false | 水印是否可移动 | N
 moveInterval | Number | 3000 | 水印发生运动位移的间隙，单位：毫秒 | N
 offset | Array | - | 水印在画布上绘制的水平和垂直偏移量，正常情况下水印绘制在中间位置，即 `offset = [gapX / 2, gapY / 2]`。TS 类型：`Array<number>` | N
-removable | Boolean | false | 水印是否可被删除，默认会开启水印节点防删 | N
+removable | Boolean | true | 水印是否可被删除 | N
 rotate | Number | -22 | 水印旋转的角度，单位 ° | N
 watermarkContent | Object / Array | - | 水印内容，需要显示多行情况下可配置为数组。TS 类型：`WatermarkText\|WatermarkImage\|Array<WatermarkText\|WatermarkImage>` | N
 width | Number | - | 水印宽度 | N
@@ -26,16 +28,17 @@ zIndex | Number | - | 水印元素的 `z-index`，默认值写在 CSS 中 | N
 
 ### WatermarkText
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 fontColor | String | rgba(0,0,0,0.1) | 水印文本文字颜色 | N
+fontFamily | String | - | 水印文本文字字体 | N
 fontSize | Number | 16 | 水印文本文字大小 | N
 fontWeight | String | normal | 水印文本文字粗细。可选项：normal/lighter/bold/bolder | N
 text | String | - | 水印文本内容 | N
 
 ### WatermarkImage
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
 isGrayscale | Boolean | false | 水印图片是否需要灰阶显示 | N
 url | String | - | 水印图片源地址，为了显示清楚，建议导出 2 倍或 3 倍图 | N

--- a/script/generate-usage/config.js
+++ b/script/generate-usage/config.js
@@ -1169,4 +1169,21 @@ module.exports = {
       }, [changedProps]);
     `,
   },
+  watermark: {
+    importStr: `
+      import configProps from './props.json';\n
+      import { Watermark } from 'tdesign-react';\n`,
+    configStr: `
+      const [configList, setConfigList] = useState(configProps);
+    `,
+    panelStr: `
+      const panelList = [{ label: 'Watermark', value: 'Watermark' }];
+    `,
+    usageStr: `
+      const defaultProps =  { watermarkContent: { text: '文字水印' }, y: 120, x: 80 };\n
+      useEffect(() => {
+        setRenderComp(<Watermark {...defaultProps} {...changedProps}><div style={{ height: 300, width: 400 }}></div></Watermark>);
+      }, [changedProps]);
+    `,
+  },
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Watermark): 新增 `layout` API，支持生成不同布局的水印，`watermarkText` 支持配置字体
- fix(Watermark): 修复多行图文水印图片配置了灰度时，整个画布内容也会灰度的问题
- docs(Watermark): 新增 live demo 展示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
