### PR TITLE
fix(Table): optimize cell value retrieval for `EditableCell`

### DIFF
--- a/packages/components/table/EditableCell.tsx
+++ b/packages/components/table/EditableCell.tsx
@@ -75,10 +75,8 @@ const EditableCell = (props: EditableCellProps) => {
     [col, row, colIndex, rowIndex],
   );
 
-  const cellValue = useMemo(() => get(row, col.colKey), [row, col.colKey]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const currentRow = useMemo(() => getCurrentRow(row, col.colKey, editValue), [col.colKey, editValue, row]);
+  const cellValue = get(row, col.colKey);
+  const currentRow = getCurrentRow(row, col.colKey, editValue);
 
   const updateEditedCellValue = (val: any) => {
     setEditValue(val);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/2676

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

面对复杂对象 `row`（由 `data` 计算得到），`useMemo` 只比较引用地址，无法检测到值的具体变化

用户更新方式：
```tsx
const newData = data.map((e) => {
  e.firstName = '???';
  return e; // 返回的还是同一个对象引用
});
setData(newData);
```

如果用户使用下面方法进行更新，就会触发了 UI 更新了
```tsx
const newData = data.map((e) => ({
  ...e,
  firstName: '???',
}));
setData(newData);  
```

所以感觉直接移除 `useMemo` 是最优解 🤔，毕竟 `get` 方法的性能开销应该不会带来很大的影响

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复修改 `data` 时，可编辑单元格的内容没有同步的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
