### PR TITLE
fix(list): correct virtual scroll item props injection on virtual scroll

### DIFF
--- a/packages/components/list/List.tsx
+++ b/packages/components/list/List.tsx
@@ -106,7 +106,7 @@ const List = forwardRefWithStatics(
             <div style={cursorStyle}></div>
             <ul className={`${COMPONENT_NAME}__inner`} style={listStyle}>
               {virtualConfig.visibleData.map((item, index) => (
-                <ListItem key={index} {...item}/>
+                <ListItem key={index} {...item} />
               ))}
             </ul>
           </>


### PR DESCRIPTION
fix #3834

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#3834](https://github.com/Tencent/tdesign-react/issues/3834)

### 💡 需求背景和解决方案


### 📝 更新日志

* fix(List): 修复开启虚拟滚动后，`ListItem` 的部分 API 无法生效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
