### PR TITLE
fix(SelectInput): ensure `onBlur` can trigger when set `popupVisible`

### DIFF
--- a/packages/components/cascader/Cascader.tsx
+++ b/packages/components/cascader/Cascader.tsx
@@ -206,6 +206,7 @@ const Cascader: React.FC<CascaderProps> = (originalProps) => {
           value: cascaderContext.value,
           e: context.e,
           inputValue: inputVal,
+          ...(props.multiple ? { tagInputValue: context.tagInputValue } : {}),
         });
         props?.selectInputProps?.onBlur?.(val, context);
       }}

--- a/packages/components/select-input/SelectInput.tsx
+++ b/packages/components/select-input/SelectInput.tsx
@@ -31,9 +31,12 @@ const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputPr
   const { commonInputProps, inputRef, singleInputValue, onInnerClear, renderSelectSingle } = useSingle(props);
   const { tagInputRef, tags, multipleInputValue, renderSelectMultiple } = useMultiple(props);
 
-  const { tOverlayInnerStyle, innerPopupVisible, onInnerPopupVisibleChange } = useOverlayInnerStyle(props, {
-    afterHidePopup: onInnerBlur,
-  });
+  const { tOverlayInnerStyle, innerPopupVisible, onInnerPopupVisibleChange, skipNextBlur } = useOverlayInnerStyle(
+    props,
+    {
+      afterHidePopup: onInnerBlur,
+    },
+  );
 
   const popupClasses = classNames([
     props.className,
@@ -55,12 +58,10 @@ const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputPr
   // 浮层显示的受控与非受控
   const visibleProps = { visible: popupVisible ?? innerPopupVisible };
 
-  // 有 panel 时且用户控制 popupVisible 为 false，需要直接处理 blur 事件
-  const shouldBlurDirectly = props.panel && popupVisible === false;
-
   /* SelectInput 与普通 Input 的 blur 事件触发时机不同
     该组件的 blur 事件在 popup 隐藏时才触发，避免点击浮层内容时触发 blur 事件 */
   function onInnerBlur(ctx: PopupVisibleChangeContext) {
+    if (skipNextBlur.current) return;
     const inputValue = props.multiple ? multipleInputValue : singleInputValue;
     const params: Parameters<TdSelectInputProps['onBlur']>[1] = {
       e: ctx.e,
@@ -92,9 +93,9 @@ const SelectInput = React.forwardRef<Partial<PopupRef & InputRef>, SelectInputPr
               popupVisible: visibleProps.visible,
               allowInput: props.allowInput,
               onInnerClear,
-              onDirectBlur: shouldBlurDirectly ? onInnerBlur : undefined,
+              onInnerBlur,
             })
-          : renderSelectSingle(visibleProps.visible, shouldBlurDirectly ? onInnerBlur : undefined)}
+          : renderSelectSingle(visibleProps.visible, onInnerBlur)}
       </Popup>
     </div>
   );

--- a/packages/components/select-input/useMultiple.tsx
+++ b/packages/components/select-input/useMultiple.tsx
@@ -64,7 +64,7 @@ export default function useMultiple(props: SelectInputProps) {
       if (blurTimeoutRef.current) {
         clearTimeout(blurTimeoutRef.current);
       }
-      // 强制把 popupVisible 设置为 false 时，会出现 blur -> focus 的情况，因此忽略前面短暂的 blur 事件
+      // 强制把 popupVisible 设置为 false 时，点击 input，会出现 blur -> focus 的情况，因此忽略前面短暂的 blur 事件
       blurTimeoutRef.current = setTimeout(() => {
         if (blurTimeoutRef.current) {
           if (!p.popupVisible) {

--- a/packages/components/select-input/useMultiple.tsx
+++ b/packages/components/select-input/useMultiple.tsx
@@ -59,8 +59,7 @@ export default function useMultiple(props: SelectInputProps) {
     const handleBlur = (value: SelectInputValue, context: { e: React.FocusEvent<HTMLInputElement> }) => {
       if (p.onDirectBlur) {
         p.onDirectBlur(context);
-      } else {
-        // 处理没有 panel 时的场景
+      } else if (!props.panel) {
         props.onBlur?.(value, { e: context.e, inputValue: tInputValue, tagInputValue: tags });
       }
     };

--- a/packages/components/select-input/useSingle.tsx
+++ b/packages/components/select-input/useSingle.tsx
@@ -81,7 +81,7 @@ export default function useSingle(props: TdSelectInputProps) {
       if (blurTimeoutRef.current) {
         clearTimeout(blurTimeoutRef.current);
       }
-      // 强制把 popupVisible 设置为 false 时，会出现 blur -> focus 的情况，因此忽略前面短暂的 blur 事件
+      // 强制把 popupVisible 设置为 false 时，点击 input，会出现 blur -> focus 的情况，因此忽略前面短暂的 blur 事件
       blurTimeoutRef.current = setTimeout(() => {
         if (blurTimeoutRef.current) {
           if (!popupVisible) {

--- a/packages/components/select-input/useSingle.tsx
+++ b/packages/components/select-input/useSingle.tsx
@@ -77,8 +77,7 @@ export default function useSingle(props: TdSelectInputProps) {
     const handleBlur = (value, ctx) => {
       if (onDirectBlur) {
         onDirectBlur(ctx);
-      } else {
-        // 处理没有 panel 时的场景
+      } else if (!props.panel) {
         props.onBlur?.(value, { e: ctx.e, inputValue: value });
       }
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/3837

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

涉及 `Select`、`TreeSelect` 、`Cascader` 等基于 `SelectInput` 二次封装的组件

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(SelectInput): 修复自定义 `popupVisible={false}` 时，`onBlur` 不生效的问题
- fix(SelectInput): 修复开启 `multiple` 时， `onBlur` 缺少 `tagInputValue` 参数的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
