### PR TITLE
fix(TagInput): pass `inputValue` to `onBlur` callback

### DIFF
--- a/packages/components/tag-input/TagInput.tsx
+++ b/packages/components/tag-input/TagInput.tsx
@@ -209,7 +209,7 @@ const TagInput = forwardRef<InputRef, TagInputProps>((originalProps, ref) => {
         if (tInputValue) {
           setTInputValue('', { e: context.e, trigger: 'blur' });
         }
-        onBlur?.(tagValue, { e: context.e, inputValue: '' });
+        onBlur?.(tagValue, { e: context.e, inputValue });
       }}
       onCompositionstart={onInputCompositionstart}
       onCompositionend={onInputCompositionend}

--- a/packages/components/tag-input/__tests__/vitest-tag-input.test.jsx
+++ b/packages/components/tag-input/__tests__/vitest-tag-input.test.jsx
@@ -318,8 +318,10 @@ describe('TagInput Component', () => {
     expect(onBlurFn2).toHaveBeenCalled();
     expect(onBlurFn2.mock.calls[0][0]).toEqual([]);
     expect(onBlurFn2.mock.calls[0][1].e.type).toBe('blur');
-    expect(onBlurFn2.mock.calls[0][1].inputValue).toBe('');
+    // blur 回调中 inputValue 保留用户输入值
+    expect(onBlurFn2.mock.calls[0][1].inputValue).toBe('tag1');
     expect(onInputChangeFn2).toHaveBeenCalled();
+    // 但 input 本身立刻被清空
     expect(onInputChangeFn2.mock.calls[1][0]).toBe('');
     expect(onInputChangeFn2.mock.calls[1][1].e.type).toBe('blur');
     expect(onInputChangeFn2.mock.calls[1][1].trigger).toBe('blur');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/3324

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

虽然 blur 的一瞬间，输入被清空，但依旧应该提供给用户之前的输入（对齐以下交互）
- Vue Next 的 `TagInput` 目前是保留输入
- React 的 `Cascader` 等组件的 blur 也是保留输入

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TagInput): 修复 `onBlur` 中的 `inputValue` 始终为空的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
