### PR TITLE
fix(textarea): add hide scrollbar when autosize is true

### DIFF
--- a/packages/components/textarea/Textarea.tsx
+++ b/packages/components/textarea/Textarea.tsx
@@ -88,6 +88,7 @@ const Textarea = forwardRef<TextareaRefInterface, TextareaProps>((originalProps,
     [`${classPrefix}-is-disabled`]: disabled,
     [`${classPrefix}-is-focused`]: isFocused,
     [`${classPrefix}-resize-none`]: typeof autosize === 'object',
+    [`${classPrefix}-hide-scrollbar`]: autosize === true,
   });
 
   const adjustTextareaHeight = useEventCallback(() => {


### PR DESCRIPTION
fix#5567

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5567

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

autosize=true，textarea 内部实现的隐藏滚动轴有缺陷；

复现条件：
1. textarea 初始的文本很长
2. 业务设置的 scrollbarWidth > 6px

表现：
1. 线上版本的 Textarea ，滚动轴宽度被调整为 6px，视觉上看起来没问题：

详情见：
https://github.com/Tencent/tdesign-vue-next/pull/6019

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
