### PR TITLE
fix(Radio): add null check for inputNode in keyboard event handler

### DIFF
--- a/packages/components/radio/useKeyboard.ts
+++ b/packages/components/radio/useKeyboard.ts
@@ -11,7 +11,7 @@ export default function useKeyboard(
     if (CHECKED_CODE_REG.test(e.key) || CHECKED_CODE_REG.test(e.code)) {
       const inputNode = (e.target as HTMLElement).querySelector('input');
       if (!inputNode) return;
-      const data = inputNode?.dataset || {};
+      const data = inputNode.dataset || {};
       if (inputNode.checked && data.allowUncheck) {
         setInnerValue(undefined, { e });
       } else {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

复现步骤：
- 选中某个 Radio 后（焦点落在组件内部的 `<span>`，而不是 `<input>` 本身）
- 按下 Enter 键
- 报错

（原先的 Enter 应该是为了配合 Tab 键盘操作的...手动选中也不需要）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(RadioGroup): 修复键盘操作时读取到 `null` 产生的报错 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
