### PR TITLE
fix(Popup): set default attach property to `'body'`

### DIFF
--- a/packages/components/popup/defaultProps.ts
+++ b/packages/components/popup/defaultProps.ts
@@ -5,6 +5,7 @@
 import { TdPopupProps } from './type';
 
 export const popupDefaultProps: TdPopupProps = {
+  attach: 'body',
   destroyOnClose: false,
   hideEmptyPopup: false,
   placement: 'top',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<img width="1549" height="1029" alt="image" src="https://github.com/user-attachments/assets/389569eb-d0ce-4734-ae09-b1c076b7f370" />

因 `useAttach` 最后兜底的默认值为`const defaultAttach = 'body';` 所以不会对 `popup` 的使用产生影响

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
