### PR TITLE
fix(Title): implement a fallback for `level` API errors

### DIFF
--- a/packages/components/typography/Title.tsx
+++ b/packages/components/typography/Title.tsx
@@ -1,29 +1,37 @@
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
-import Ellipsis from './ellipsis/Ellipsis';
-
-import { TdTitleProps } from './type';
-import { titleDefaultProps } from './defaultProps';
 
 import useConfig from '../hooks/useConfig';
-import useEllipsis from './ellipsis/useEllipsis';
 import useDefaultProps from '../hooks/useDefaultProps';
+import { titleDefaultProps } from './defaultProps';
+import Ellipsis from './ellipsis/Ellipsis';
+import useEllipsis from './ellipsis/useEllipsis';
 
 import type { StyledProps } from '../common';
+import type { TdTitleProps } from './type';
 
 export type TypographyTitleProps = TdTitleProps &
   StyledProps & {
     children: React.ReactNode;
   };
 
+const VALID_LEVELS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+
 export const Title = forwardRef<HTMLHeadingElement, TypographyTitleProps>((originalProps, ref) => {
   const { classPrefix } = useConfig();
-  const props = useDefaultProps<TypographyTitleProps>(originalProps, titleDefaultProps);
-
-  const { level: Component = 'h1', children, className, content, ellipsis, ...rest } = props;
   const prefixCls = `${classPrefix}-typography`;
 
+  const props = useDefaultProps<TypographyTitleProps>(originalProps, titleDefaultProps);
+  const { level, children, className, content, ellipsis, ...rest } = props;
+
   const { ellipsisProps } = useEllipsis(ellipsis);
+
+  const formatLevel = (level: string | number) => {
+    const normalizedLevel = typeof level === 'number' ? `h${level}` : level;
+    const levelProp = VALID_LEVELS.includes(normalizedLevel) ? normalizedLevel : 'h1';
+    return levelProp as TypographyTitleProps['level'];
+  };
+  const Component = formatLevel(level);
 
   if (!ellipsis) {
     return (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Title): 添加兜底机制，避免错误使用 `level` 导致页面直接白屏的问题 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
