### PR TITLE
fix(Popup): nested content can not closed

### DIFF
--- a/packages/components/popup/Popup.tsx
+++ b/packages/components/popup/Popup.tsx
@@ -100,7 +100,7 @@ const Popup = forwardRef<PopupInstanceFunctions, PopupProps>((originalProps, ref
     [placement],
   );
 
-  const { triggerElementIsString, handleMouseLeave, getTriggerElement, getTriggerNode } = useTrigger({
+  const { triggerElementIsString, getTriggerElement, getTriggerNode, getPopupProps } = useTrigger({
     triggerElement,
     content,
     disabled,
@@ -232,7 +232,7 @@ const Popup = forwardRef<PopupInstanceFunctions, PopupProps>((originalProps, ref
             className={classNames(`${classPrefix}-popup`, overlayClassName)}
             {...attributes.popper}
             onClick={(e) => props.onOverlayClick?.({ e })}
-            onMouseLeave={handleMouseLeave}
+            {...getPopupProps()}
           >
             <div
               ref={contentRef}

--- a/packages/components/popup/hooks/useTrigger.tsx
+++ b/packages/components/popup/hooks/useTrigger.tsx
@@ -11,6 +11,7 @@ export default function useTrigger({ triggerElement, content, disabled, trigger,
   const triggerElementIsString = typeof triggerElement === 'string';
 
   const triggerRef = useRef<HTMLElement>(null);
+  const hasPopupMouseDown = useRef(false);
   const visibleTimer = useRef(null);
 
   // 禁用和无内容时不展示
@@ -54,6 +55,13 @@ export default function useTrigger({ triggerElement, content, disabled, trigger,
         callback: () => onVisibleChange(false, { e, trigger: 'trigger-element-hover' }),
       });
     }
+  };
+
+  const handlePopupMouseDown = () => {
+    hasPopupMouseDown.current = true;
+    requestAnimationFrame(() => {
+      hasPopupMouseDown.current = false;
+    });
   };
 
   useEffect(() => clearTimeout(visibleTimer.current), []);
@@ -164,16 +172,18 @@ export default function useTrigger({ triggerElement, content, disabled, trigger,
     if (!shouldToggle) return;
 
     const handleDocumentClick = (e: any) => {
-      const element = getTriggerElement();
-      if (element?.contains?.(e.target) || e.target?.closest?.(`.${classPrefix}-popup`)) return;
-      visible && onVisibleChange(false, { e, trigger: 'document' });
+      if (!visible || getTriggerElement()?.contains?.(e.target) || hasPopupMouseDown.current) return;
+      onVisibleChange(false, { e, trigger: 'document' });
     };
 
     on(document, 'mousedown', handleDocumentClick);
     on(document, 'touchend', handleDocumentClick, { passive: true });
+
     return () => {
-      off(document, 'mousedown', handleDocumentClick);
-      off(document, 'touchend', handleDocumentClick, { passive: true });
+      requestAnimationFrame(() => {
+        off(document, 'mousedown', handleDocumentClick);
+        off(document, 'touchend', handleDocumentClick, { passive: true });
+      });
     };
   }, [classPrefix, shouldToggle, visible, onVisibleChange, getTriggerElement]);
 
@@ -205,10 +215,18 @@ export default function useTrigger({ triggerElement, content, disabled, trigger,
     );
   }
 
+  function getPopupProps() {
+    return {
+      onMouseLeave: handleMouseLeave,
+      onMouseDown: handlePopupMouseDown,
+      onTouchEnd: handlePopupMouseDown,
+    };
+  }
+
   return {
     triggerElementIsString,
-    handleMouseLeave,
     getTriggerElement,
     getTriggerNode,
+    getPopupProps,
   };
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<details>
<summary><em><strong>复现代码存档</strong></em>（外部「更多筛选」弹窗可关闭，内部 Select 弹窗无法关闭）</summary>

```tsx
import React, { useState } from 'react';
import { FilterIcon } from 'tdesign-icons-react';

import { Button, Card, Popup, Select, Space } from 'tdesign-react';

const options = Array.from({ length: 10 }).map((_, index) => ({
  label: `选项 ${index + 1}`,
  value: `option-${index + 1}`,
}));

const TestPage = () => {
  const [advanceFilterDlgVisible, setAdvanceFilterDlgVisible] = useState(false);

  const onClickAdvanceFilter = () => {
    setAdvanceFilterDlgVisible(true);
  };

  return (
    <Card size="medium">
      <Space direction="vertical" style={{ width: '100%' }}>
        <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
          <Popup
            visible={advanceFilterDlgVisible}
            placement={'bottom'}
            content={
              <Card size="medium" style={{ padding: '32px' }}>
                <Select
                  options={options}
                  filterable
                  multiple
                  clearable={true}
                  valueType="object"
                  reserveKeyword={true}
                  style={{ width: '240px' }}
                />
              </Card>
            }
            onVisibleChange={(visible) => {
              setAdvanceFilterDlgVisible(visible);
            }}
            showArrow
            trigger="click"
          >
            <>
              <Button
                theme="default"
                variant="outline"
                shape="rectangle"
                onClick={onClickAdvanceFilter}
                style={{ minWidth: '120px', justifyContent: 'center' }}
              >
                <FilterIcon />
                更多筛选
              </Button>
            </>
          </Popup>
        </div>
      </Space>
    </Card>
  );
};
export default TestPage;

```
</details>

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 修复 `1.16.0` 的重构导致嵌套场景下，内层弹窗无法正常关闭的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
