### PR TITLE
fix: enable background clicks in dialog modeless mode

### DIFF
--- a/packages/components/dialog/Dialog.tsx
+++ b/packages/components/dialog/Dialog.tsx
@@ -252,6 +252,7 @@ const Dialog = forwardRef<DialogInstance, DialogProps>((originalProps, ref) => {
           className={classNames(className, `${componentCls}__ctx`, `${componentCls}__${mode}`, {
             [`${componentCls}__ctx--fixed`]: !showInAttachedElement,
             [`${componentCls}__ctx--absolute`]: showInAttachedElement,
+            [`${componentCls}__ctx--modeless`]: mode === 'modeless',
           })}
           style={{ zIndex, display: animationVisible ? undefined : 'none' }}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-react/issues/4060
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 需求背景：mode="modeless" 的 Dialog 仍阻塞页面点击，未实现“非模态可操作背景”的预期。原因是容器缺少样式钩子 t-dialog__ctx--modeless，样式里已有 pointer-events: none 但未生效。
2. 解决方案：在外层容器补充 t-dialog__ctx--modeless class，当 mode === 'modeless' 时激活样式中的 pointer-events: none，让背景可点击，弹框自身仍可操作。
<!--
1. 要解决的具体问题。
4. 列出最终的 API 实现和用法。
5. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

#### tdesign-react
<!--
- feat(组件名称): 处理问题或特性描述
--> 
fix(Dialog): enable background clicks in modeless mode


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
