### PR TITLE
chore: update CHANGELOG.md format

### DIFF
--- a/packages/tdesign-react/CHANGELOG-0.x.md
+++ b/packages/tdesign-react/CHANGELOG-0.x.md
@@ -5,86 +5,98 @@ toc: false
 spline: explain
 ---
 
-## 🌈 0.45.6 `2023-02-08` 
+## 🌈 0.45.6 `2023-02-08`
+
 ### 🚀 Features
+
 - `Input`: 点击 Input 输入框中的任意元素，自动触发聚焦 @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
 - `TagInput`: `collapsedItems` 的参数 `count` 含义更为折叠的数量 @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
+
 ### 🐞 Bug Fixes
-- `Loading`: 修复loading在部分windows设备中晃动的问题 @uyarn ([#1943](https://github.com/Tencent/tdesign-react/pull/1943))
+
+- `Loading`: 修复 loading 在部分 windows 设备中晃动的问题 @uyarn ([#1943](https://github.com/Tencent/tdesign-react/pull/1943))
 - `InputNumber`: 修复小数点后面不能连续输入两个 0 的问题 @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
 - `TreeSelect`:
-    - `onBlur` 和 `onFocus` 的事件参数 `value` 调整为和文档保持一致，始终等于组件选中的值 @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
-    - 修复 `collapsedItems` 的第一个参数缺少 label 信息问题（可能存在 Breaking Change) @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
+  - `onBlur` 和 `onFocus` 的事件参数 `value` 调整为和文档保持一致，始终等于组件选中的值 @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
+  - 修复 `collapsedItems` 的第一个参数缺少 label 信息问题（可能存在 Breaking Change) @chaishi ([#1950](https://github.com/Tencent/tdesign-react/pull/1950))
 - `Dialog & Drawer`: 修复在 next 中 document 报错问题 @honkinglin ([#1944](https://github.com/Tencent/tdesign-react/pull/1944))
 - `ColorPicker`: 修复 slider 初始化 thumb 位置计算问题 @MrWeilian ([#1907](https://github.com/Tencent/tdesign-react/pull/1907))
 
-## 🌈 0.45.5 `2023-02-01` 
+## 🌈 0.45.5 `2023-02-01`
+
 ### 🚀 Features
-- `Timeline`: 
-    - `labelAlign` 默认值由 `left` 更为  `right` @chaishi ([#1905](https://github.com/Tencent/tdesign-react/pull/1905))
-    - `dotColor` 默认值由 `default` 更为 `primary` @chaishi ([#1905](https://github.com/Tencent/tdesign-react/pull/1905))
+
+- `Timeline`:
+  - `labelAlign` 默认值由 `left` 更为 `right` @chaishi ([#1905](https://github.com/Tencent/tdesign-react/pull/1905))
+  - `dotColor` 默认值由 `default` 更为 `primary` @chaishi ([#1905](https://github.com/Tencent/tdesign-react/pull/1905))
 - `TreeSelect`: `data` 中的 `label` 属性，支持 `ReactNode`，修复使用 label 定义下拉选项报错问题 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-- `Guide`: 
-    - 新增 `GuideStep.popupProps` 透传全部属性到 Popup 组件 @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
-    - 去除步骤数非必要的包裹元素 `span` @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
-    - 支持 `children`，含义同 `content` @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
+- `Guide`:
+  - 新增 `GuideStep.popupProps` 透传全部属性到 Popup 组件 @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
+  - 去除步骤数非必要的包裹元素 `span` @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
+  - 支持 `children`，含义同 `content` @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
 - `Upload`:
-    - 可拖拽的单图片/单文件上传，支持自定义文件信息内容 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 一个请求上传多个文件时，去除重复参数 `file`，保留 `file[0]` `file[1]` 即可，同时新增参数 `length` 表示本次上传文件的数量 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - `onError/onSuccess/onProgress` 添加关键事件参数 `XMLHttpRequest`，用于获取上传请求更详细的信息 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - `tips` 支持 `ReactNode` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 新增上传请求超时也会执行 `onError` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 支持事件 `onCancelUpload` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 支持 `mockProgressDuration`，用于设置模拟上传进度间隔时间，大文件大一点，小文件小一点 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 可拖拽的单图片/单文件上传，支持自定义文件信息内容 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 一个请求上传多个文件时，去除重复参数 `file`，保留 `file[0]` `file[1]` 即可，同时新增参数 `length` 表示本次上传文件的数量 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - `onError/onSuccess/onProgress` 添加关键事件参数 `XMLHttpRequest`，用于获取上传请求更详细的信息 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - `tips` 支持 `ReactNode` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 新增上传请求超时也会执行 `onError` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 支持事件 `onCancelUpload` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 支持 `mockProgressDuration`，用于设置模拟上传进度间隔时间，大文件大一点，小文件小一点 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
 - `Avatar`: 图标类名由 `.t-avatar-icon` 更为 `.t-avatar__icon` @chaishi ([#1931](https://github.com/Tencent/tdesign-react/pull/1931))
 
 ### 🐞 Bug Fixes
+
 - `dialog`:
-    - 修复 dialog footer 渲染丢失包裹块问题 @honkinglin ([#1904](https://github.com/Tencent/tdesign-react/pull/1904))
+  - 修复 dialog footer 渲染丢失包裹块问题 @honkinglin ([#1904](https://github.com/Tencent/tdesign-react/pull/1904))
 - `TreeSelect`:
-    - 多选场景，修复搜索功能点击输入框报错问题 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 没有触发事件 `onPopupVisibleChange` @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 修复 onInputChange 触发时机不正确问题，不应该在初始渲染且用户没有进行任何操作时就触发 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 修复过滤功能中，输入关键词发生变化时，没有触发 `onSearch` 问题 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 期望远程搜索事件 onSearch 优先级比本地搜索 filter 高，当前组件表现不符合预期 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 修复 onSearch 事件第一个参数不正确问题，第一个参数期望是输入的关键词，而非当前选中的值 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
-    - 修复 empty text 显示异常 & onClear 后 value 重置问题 @genyuMPj ([#1903](https://github.com/Tencent/tdesign-react/pull/1903))
-- `Image`:  组件内中文改为 `localeProvider` 提供配置 @carolin913 ([#1909](https://github.com/Tencent/tdesign-react/pull/1909))
-- `imageViewer`:  组件内中文改为 localeprovider 提供配置 @carolin913 ([#1909](https://github.com/Tencent/tdesign-react/pull/1909))
+  - 多选场景，修复搜索功能点击输入框报错问题 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 没有触发事件 `onPopupVisibleChange` @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 修复 onInputChange 触发时机不正确问题，不应该在初始渲染且用户没有进行任何操作时就触发 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 修复过滤功能中，输入关键词发生变化时，没有触发 `onSearch` 问题 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 期望远程搜索事件 onSearch 优先级比本地搜索 filter 高，当前组件表现不符合预期 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 修复 onSearch 事件第一个参数不正确问题，第一个参数期望是输入的关键词，而非当前选中的值 @chaishi ([#1899](https://github.com/Tencent/tdesign-react/pull/1899))
+  - 修复 empty text 显示异常 & onClear 后 value 重置问题 @genyuMPj ([#1903](https://github.com/Tencent/tdesign-react/pull/1903))
+- `Image`: 组件内中文改为 `localeProvider` 提供配置 @carolin913 ([#1909](https://github.com/Tencent/tdesign-react/pull/1909))
+- `imageViewer`: 组件内中文改为 localeprovider 提供配置 @carolin913 ([#1909](https://github.com/Tencent/tdesign-react/pull/1909))
 - `SelectInput`: 修复下拉弹窗状态未改变时，重复触发 `onPopupVisibleChange` 事件的问题 @xiaosansiji ([#1902](https://github.com/Tencent/tdesign-react/pull/1902))
 - `Guide`: 修复自定义 `highlightContent` 节点中的类名消失问题 @chaishi ([#1915](https://github.com/Tencent/tdesign-react/pull/1915))
-- `ColorPicker`: 修复打开Mode选择器状态下关闭面板没有正确隐藏Mode选择器的问题 @MrWeilian ([#1914](https://github.com/Tencent/tdesign-react/pull/1914))
+- `ColorPicker`: 修复打开 Mode 选择器状态下关闭面板没有正确隐藏 Mode 选择器的问题 @MrWeilian ([#1914](https://github.com/Tencent/tdesign-react/pull/1914))
 - `Upload`:
-    - 修复 `onSelectChange` 事件第二个参数 `currentSelectedFiles` 不正确问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复 `autoUpload=false` 场景下，即使 `beforeUpload` 函数全部返回 `false` 依然会触发 `onChange` 事件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复 `data` 为函数时，参数为空问题，补充参数 `files` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复 `theme=image-flow` 时，无法使用 `fileListDisplay` 自定义图片列表问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复文件数量超出 `max` 时，且没有可继续上传的文件，依然触发 change 事件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复 `theme=file` 或者 `theme=image-flow` 时，`abridgeName` 无效问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复 `theme=image-flow` 且 `autoUpload=false` 时，change 事件第一个参数丢失 file.url 问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
-    - 修复非自动上传场景 `change` 事件第二个参数 `file` 值并非当前文件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `onSelectChange` 事件第二个参数 `currentSelectedFiles` 不正确问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `autoUpload=false` 场景下，即使 `beforeUpload` 函数全部返回 `false` 依然会触发 `onChange` 事件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `data` 为函数时，参数为空问题，补充参数 `files` @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `theme=image-flow` 时，无法使用 `fileListDisplay` 自定义图片列表问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复文件数量超出 `max` 时，且没有可继续上传的文件，依然触发 change 事件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `theme=file` 或者 `theme=image-flow` 时，`abridgeName` 无效问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复 `theme=image-flow` 且 `autoUpload=false` 时，change 事件第一个参数丢失 file.url 问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
+  - 修复非自动上传场景 `change` 事件第二个参数 `file` 值并非当前文件问题 @chaishi ([#1918](https://github.com/Tencent/tdesign-react/pull/1918))
 - `TimePicker`: 修复自定义 onInput 未触发问题 @carolin913 ([#1912](https://github.com/Tencent/tdesign-react/pull/1912))
 - `DatePicker`: 修复 dayjs 国际化设置问题 @honkinglin ([#1925](https://github.com/Tencent/tdesign-react/pull/1925))
 - `Table`: 修复拖拽滚动条回到顶部白屏问题 @MrWeilian ([#1921](https://github.com/Tencent/tdesign-react/pull/1921))
 
-## 🌈 0.45.4 `2023-01-17` 
+## 🌈 0.45.4 `2023-01-17`
+
 ### 🚀 Features
+
 - `Image`: `onLoad` 和 `onError` 事件新增 `Event` 参数 @chaishi ([#1890](https://github.com/Tencent/tdesign-react/pull/1890))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: 修复 checkbox 样式丢失 @honkinglin ([#1893](https://github.com/Tencent/tdesign-react/pull/1893))
 - `AutoComplete`:
-    - 修复键盘操作时，上下箭头切换失效问题 @chaishi ([#1889](https://github.com/Tencent/tdesign-react/pull/1889))
-    - 没有 `options` 的情况，不显示下拉框所有元素 @chaishi ([#1889](https://github.com/Tencent/tdesign-react/pull/1889))
+  - 修复键盘操作时，上下箭头切换失效问题 @chaishi ([#1889](https://github.com/Tencent/tdesign-react/pull/1889))
+  - 没有 `options` 的情况，不显示下拉框所有元素 @chaishi ([#1889](https://github.com/Tencent/tdesign-react/pull/1889))
 - `Avatar`:
-    - 修复 `icon` `content` 自定义节点无效问题 @chaishi ([#1887](https://github.com/Tencent/tdesign-react/pull/1887))
-    - 修复 AvatarGroup.size 设置无效问题 @chaishi ([#1887](https://github.com/Tencent/tdesign-react/pull/1887))
+  - 修复 `icon` `content` 自定义节点无效问题 @chaishi ([#1887](https://github.com/Tencent/tdesign-react/pull/1887))
+  - 修复 AvatarGroup.size 设置无效问题 @chaishi ([#1887](https://github.com/Tencent/tdesign-react/pull/1887))
 - `Tag`:
-    - 修复文本超出省略时缺少 `title` 属性问题 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
-    - 修复禁用状态依然显示关闭图标问题 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
+  - 修复文本超出省略时缺少 `title` 属性问题 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
+  - 修复禁用状态依然显示关闭图标问题 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
 - `Watermark`: 修复水印默认可删除问题 @haishancai ([#1885](https://github.com/Tencent/tdesign-react/pull/1885))
 - `Cascader`: value is zero can be selected @MrWeilian ([#1884](https://github.com/Tencent/tdesign-react/pull/1884))
 
 ### 🚧 Others
+
 - `package`: 移除 use-resize-observer 依赖 @honkinglin ([#1888](https://github.com/Tencent/tdesign-react/pull/1888))
 - `Image`: 输出完整的测试用例 @chaishi ([#1890](https://github.com/Tencent/tdesign-react/pull/1890))
 - `Input`: 输出完整的测试用例 @chaishi ([#1889](https://github.com/Tencent/tdesign-react/pull/1889))
@@ -94,113 +106,128 @@ spline: explain
 - `TagInput`: 添加完整的测试用例 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
 - `SelectInput`: 添加部分测试用例 @chaishi ([#1892](https://github.com/Tencent/tdesign-react/pull/1892))
 
-## 🌈 0.45.3 `2023-01-11` 
+## 🌈 0.45.3 `2023-01-11`
+
 ### 🚀 Features
+
 - `Radio`:
-    - 新增键盘事件支持，tab 键切换选项，enter 键选中 @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
-    - Radio.Group 新增 `allowUncheck`，支持取消选中（Radio. allowUncheck 本身已支持） @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
-    - `onClick` 参数由 `(e: MouseEvent)` 调整为 `({'\u007B'} e: MouseEvent {'\u007d'})` @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
+  - 新增键盘事件支持，tab 键切换选项，enter 键选中 @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
+  - Radio.Group 新增 `allowUncheck`，支持取消选中（Radio. allowUncheck 本身已支持） @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
+  - `onClick` 参数由 `(e: MouseEvent)` 调整为 `({'\u007B'} e: MouseEvent {'\u007d'})` @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
 
 ### 🐞 Bug Fixes
+
 - `Radio`: 修复 Radio.Group 不支持 `name` 属性问题 @chaishi ([#1865](https://github.com/Tencent/tdesign-react/pull/1865))
 - `Form`: 修复 `FormList` `add` `remove` 未触发 `onValuesChange` 事件 @honkinglin ([#1871](https://github.com/Tencent/tdesign-react/pull/1871))
 - `TreeSelect`:
-    - 修复选项文案过程样式的异常 @uyarn ([#1875](https://github.com/Tencent/tdesign-react/pull/1875))
-    - 修复 value 为 0 无法选中问题 @honkinglin ([#1869](https://github.com/Tencent/tdesign-react/pull/1869))
+  - 修复选项文案过程样式的异常 @uyarn ([#1875](https://github.com/Tencent/tdesign-react/pull/1875))
+  - 修复 value 为 0 无法选中问题 @honkinglin ([#1869](https://github.com/Tencent/tdesign-react/pull/1869))
 - `Popup`: 修复滚动事件执行时机问题 @honkinglin ([#1870](https://github.com/Tencent/tdesign-react/pull/1870))
 
+## 🌈 0.45.2 `2023-01-05`
 
-## 🌈 0.45.2 `2023-01-05` 
 ### 🚀 Features
+
 - `语言包`: 新增阿拉伯语的语言包 @Ylushen ([common #1097](https://github.com/Tencent/tdesign-common/pull/1097))
 - `AutoComplete`:
-    - 新增清空功能 `clearable` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
-    - 新增自动聚焦功能 `autofocus` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
-    - 支持 `style` 和 `className` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
-    - 新增 `enter/blur/compositionend/compositionstar`t 等事件，及相关参数和文档保持一致 @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
-- `Breadcrumb`:  超长文本省略支持悬浮查看完整内容 @yaogengzhu ([#1837](https://github.com/Tencent/tdesign-react/pull/1837))
-- `Popup`:  新增 trigger=mousedown 功能 @honkinglin ([#1857](https://github.com/Tencent/tdesign-react/pull/1857))
+  - 新增清空功能 `clearable` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
+  - 新增自动聚焦功能 `autofocus` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
+  - 支持 `style` 和 `className` @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
+  - 新增 `enter/blur/compositionend/compositionstar`t 等事件，及相关参数和文档保持一致 @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
+- `Breadcrumb`: 超长文本省略支持悬浮查看完整内容 @yaogengzhu ([#1837](https://github.com/Tencent/tdesign-react/pull/1837))
+- `Popup`: 新增 trigger=mousedown 功能 @honkinglin ([#1857](https://github.com/Tencent/tdesign-react/pull/1857))
 
 ### 🐞 Bug Fixes
-- `table`: 修正 onDragSort 使用过期变量的问题 @lich-yoo ([#1844](https://github.com/Tencent/tdesign-react/pull/1844))
+
+- `Table`: 修正 onDragSort 使用过期变量的问题 @lich-yoo ([#1844](https://github.com/Tencent/tdesign-react/pull/1844))
 - `AutoComplete`: 修复 `options` 不存在时，组件因缺少判空报错问题 @chaishi ([#1845](https://github.com/Tencent/tdesign-react/pull/1845))
 - `Dialog`: 修复 `style` 透传问题 @honkinglin ([#1859](https://github.com/Tencent/tdesign-react/pull/1859))
 - `Form`: 修复 `unsafe-eval`报错的问题 @honkinglin ([#1860](https://github.com/Tencent/tdesign-react/pull/1860))
 - `Select`: 修复`readonly`状态下可以通过选项的关闭按钮移除选项的问题 @uyarn ([#1862](https://github.com/Tencent/tdesign-react/pull/1862))
 - `DatePicker`:
-    - 修复输入框变化面板未响应问题 @honkinglin ([#1858](https://github.com/Tencent/tdesign-react/pull/1858))
-    - 修复年份面板禁用样式问题 @honkinglin ([#1861](https://github.com/Tencent/tdesign-react/pull/1861))
-- `ImageViewer`:  z-index层级调整，修复窗口模式拖拽问题 @Ylushen ([#1851](https://github.com/Tencent/tdesign-react/pull/1851))
+  - 修复输入框变化面板未响应问题 @honkinglin ([#1858](https://github.com/Tencent/tdesign-react/pull/1858))
+  - 修复年份面板禁用样式问题 @honkinglin ([#1861](https://github.com/Tencent/tdesign-react/pull/1861))
+- `ImageViewer`: z-index 层级调整，修复窗口模式拖拽问题 @Ylushen ([#1851](https://github.com/Tencent/tdesign-react/pull/1851))
 
+## 🌈 0.45.1 `2022-12-29`
 
-## 🌈 0.45.1 `2022-12-29` 
 ### 🚀 Features
+
 - `Select`: 支持选项`checkAll` 功能 @uyarn ([#1841](https://github.com/Tencent/tdesign-react/pull/1841))
 
 ### 🐞 Bug Fixes
+
 - `TooltipLite`: 修复层叠上下文样式问题 @moecasts ([#1838](https://github.com/Tencent/tdesign-react/pull/1838))
 - `DatePicker`: 修复年份选择器区间错误 @honkinglin ([#1833](https://github.com/Tencent/tdesign-react/pull/1833))
 - `Table`: 修复 onPageChange 回调参数错误 @chaishi ([#1840](https://github.com/Tencent/tdesign-react/pull/1840))
 
-## 🌈 0.45.0 `2022-12-22` 
+## 🌈 0.45.0 `2022-12-22`
 
 ### 🚨 Breaking Changes
+
 - `Dialog`: 重构 Dialog，兼容 mode="normal" 属性更改为 DialogCard 实现，新增控制台警告 @honkinglin ([#1830](https://github.com/Tencent/tdesign-react/pull/1830))
 
 ### 🚀 Features
+
 - `Table`:
-    - 支持设置 `col.stopPropagation` 阻止整列事件冒泡 @chaishi ([#1816](https://github.com/Tencent/tdesign-react/pull/1816))
-    - 可筛选表格，新增 `filter.popupProps` ，支持透传 Popup 组件全部属性，[tdesign-vue-next#2088](https://github.com/Tencent/tdesign-vue-next/issues/2088) @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
-    - 选中行表格，新增 `selectOnRowClick`，支持点击行选中，[tdesign-vue-next#1954](https://github.com/Tencent/tdesign-vue-next/issues/1954) @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
-    - 本地排序功能，支持对默认数据进行排序 @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
+  - 支持设置 `col.stopPropagation` 阻止整列事件冒泡 @chaishi ([#1816](https://github.com/Tencent/tdesign-react/pull/1816))
+  - 可筛选表格，新增 `filter.popupProps` ，支持透传 Popup 组件全部属性，[tdesign-vue-next#2088](https://github.com/Tencent/tdesign-vue-next/issues/2088) @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
+  - 选中行表格，新增 `selectOnRowClick`，支持点击行选中，[tdesign-vue-next#1954](https://github.com/Tencent/tdesign-vue-next/issues/1954) @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
+  - 本地排序功能，支持对默认数据进行排序 @chaishi ([#1817](https://github.com/Tencent/tdesign-react/pull/1817))
 - `Menu`: 弹出菜单中箭头不再翻转，间距等样式与 Dropdown 子菜单对齐 @xiaosansiji ([#1813](https://github.com/Tencent/tdesign-react/pull/1813))
 - `Dialog`: 重构 Dialog，新增 DialogCard 子组件 @honkinglin ([#1830](https://github.com/Tencent/tdesign-react/pull/1830))
 
 ### 🐞 Bug Fixes
+
 - `Input`: 修复 input 动态宽度计算问题 @honkinglin ([#1806](https://github.com/Tencent/tdesign-react/pull/1806))
 - `Table`:
-    - 修复固定表头缺少在数据没有溢出时，缺少背景色问题 @chaishi ([#1812](https://github.com/Tencent/tdesign-react/pull/1812))
-    - 设置展开图标阻止事件冒泡，避免点击展开图标时触发行点击事件，进而触发其他特性 @chaishi ([#1816](https://github.com/Tencent/tdesign-react/pull/1816))
-    - 虚拟滚动支持表格高度动态变化，[tdesign-vue-next#1374](https://github.com/Tencent/tdesign-vue-next/issues/1374) @chaishi ([#1827](https://github.com/Tencent/tdesign-react/pull/1827))
-    - 修复表格宽度过小时抖动问题 @chaishi ([#1827](https://github.com/Tencent/tdesign-react/pull/1827))
+  - 修复固定表头缺少在数据没有溢出时，缺少背景色问题 @chaishi ([#1812](https://github.com/Tencent/tdesign-react/pull/1812))
+  - 设置展开图标阻止事件冒泡，避免点击展开图标时触发行点击事件，进而触发其他特性 @chaishi ([#1816](https://github.com/Tencent/tdesign-react/pull/1816))
+  - 虚拟滚动支持表格高度动态变化，[tdesign-vue-next#1374](https://github.com/Tencent/tdesign-vue-next/issues/1374) @chaishi ([#1827](https://github.com/Tencent/tdesign-react/pull/1827))
+  - 修复表格宽度过小时抖动问题 @chaishi ([#1827](https://github.com/Tencent/tdesign-react/pull/1827))
 - `Dropdown`: 修复多级菜单过长无法选择的问题 @uyarn ([#1821](https://github.com/Tencent/tdesign-react/pull/1821))
-- `Tree`: 修复叶子节点的label区域无法触发选中的问题 @uyarn ([#1822](https://github.com/Tencent/tdesign-react/pull/1822))
+- `Tree`: 修复叶子节点的 label 区域无法触发选中的问题 @uyarn ([#1822](https://github.com/Tencent/tdesign-react/pull/1822))
 - `Form`:
-    - 修复异步渲染 form 组件赋值失败问题 @honkinglin ([#1824](https://github.com/Tencent/tdesign-react/pull/1824))
-    - 修复 formList 嵌套赋值问题 @honkinglin ([#1819](https://github.com/Tencent/tdesign-react/pull/1819))
+  - 修复异步渲染 form 组件赋值失败问题 @honkinglin ([#1824](https://github.com/Tencent/tdesign-react/pull/1824))
+  - 修复 formList 嵌套赋值问题 @honkinglin ([#1819](https://github.com/Tencent/tdesign-react/pull/1819))
 - `Guide`: 部分默认属性通过全局配置获取 @zhangpaopao0609 ([#1808](https://github.com/Tencent/tdesign-react/pull/1808))
 - `Progress`: 修复 label 展示问题 @honkinglin ([#1809](https://github.com/Tencent/tdesign-react/pull/1809))
-- `TreeSelect`:  修复 input 宽度展示问题 @honkinglin ([#1820](https://github.com/Tencent/tdesign-react/pull/1820))
-- `ColorPicker`:  修复 swatchs panel 默认标题错误 @josonyang ([#1810](https://github.com/Tencent/tdesign-react/pull/1810))
+- `TreeSelect`: 修复 input 宽度展示问题 @honkinglin ([#1820](https://github.com/Tencent/tdesign-react/pull/1820))
+- `ColorPicker`: 修复 swatchs panel 默认标题错误 @josonyang ([#1810](https://github.com/Tencent/tdesign-react/pull/1810))
 
+## 🌈 0.44.2 `2022-12-14`
 
-## 🌈 0.44.2 `2022-12-14` 
 ### 🚀 Features
+
 - `Table`:
-    - 支持任意行高虚拟滚动和树形结构虚拟滚动、支持滚动定位到任意元素 @chaishi ([#1798](https://github.com/Tencent/tdesign-react/pull/1798))
-    - 树形结构，支持点击行展开树节点 @chaishi ([#1800](https://github.com/Tencent/tdesign-react/pull/1800))
-    - 树形结构，点击树节点展开图标的时候，不再冒泡到行点击事件 `onRowClick` @chaishi ([#1800](https://github.com/Tencent/tdesign-react/pull/1800))
+  - 支持任意行高虚拟滚动和树形结构虚拟滚动、支持滚动定位到任意元素 @chaishi ([#1798](https://github.com/Tencent/tdesign-react/pull/1798))
+  - 树形结构，支持点击行展开树节点 @chaishi ([#1800](https://github.com/Tencent/tdesign-react/pull/1800))
+  - 树形结构，点击树节点展开图标的时候，不再冒泡到行点击事件 `onRowClick` @chaishi ([#1800](https://github.com/Tencent/tdesign-react/pull/1800))
 
 ### 🐞 Bug Fixes
+
 - `SelectInput`: 修复 `selectInput` 出现异常的`tips` 节点 @pengYYYYY ([#1792](https://github.com/Tencent/tdesign-react/pull/1792))
 - `Form`: 修复 formList 下 error 跳转问题 @honkinglin ([#1794](https://github.com/Tencent/tdesign-react/pull/1794))
 - `Guide`: skip 和 finish 事件正确返回 current；相对元素位置不正确； @zhangpaopao0609 ([#1803](https://github.com/Tencent/tdesign-react/pull/1803))
 - `DatePicker`: 修复右侧面板月份展示错误 @honkinglin ([#1802](https://github.com/Tencent/tdesign-react/pull/1802))
-- `Dialog`:  修复滚动条判断问题 @honkinglin ([#1795](https://github.com/Tencent/tdesign-react/pull/1795))
+- `Dialog`: 修复滚动条判断问题 @honkinglin ([#1795](https://github.com/Tencent/tdesign-react/pull/1795))
 
-## 🌈 0.44.1 `2022-12-08` 
+## 🌈 0.44.1 `2022-12-08`
+
 ### 🚀 Features
+
 - `TimePicker`: 新增`status`、`tips`和`onPick` API @uyarn ([#1786](https://github.com/Tencent/tdesign-react/pull/1786))
 - `ColorPicker`: 新增`showPrimaryColorPreview` API 控制色彩选择条右侧主色区块的展示 @uyarn ([#1788](https://github.com/Tencent/tdesign-react/pull/1788))
 - `Upload`:
-    - `onProgress/onSuccess/onFail` 等事件参数添加 `XMLHttpRequest`，用于获取 http status 等数据 @chaishi ([#1781](https://github.com/Tencent/tdesign-react/pull/1781))
-    - `fileListDisplay` 支持自定义多文件列表 @chaishi ([#1781](https://github.com/Tencent/tdesign-react/pull/1781))
+  - `onProgress/onSuccess/onFail` 等事件参数添加 `XMLHttpRequest`，用于获取 http status 等数据 @chaishi ([#1781](https://github.com/Tencent/tdesign-react/pull/1781))
+  - `fileListDisplay` 支持自定义多文件列表 @chaishi ([#1781](https://github.com/Tencent/tdesign-react/pull/1781))
 
 ### 🐞 Bug Fixes
+
 - `InputNumber`:
-    - 无法输入小数点后面的第一位数字 `0`，[tdesign-vue-next#2103](https://github.com/Tencent/tdesign-vue-next/issues/2103) @chaishi ([#1780](https://github.com/Tencent/tdesign-react/pull/1780))
-    - 修复无法使用清空按钮清除输入数字问题，[issue#1855](https://github.com/Tencent/tdesign-vue/issues/1855) @chaishi ([#1780](https://github.com/Tencent/tdesign-react/pull/1780))
-    - 修复 status 默认值缺失 @honkinglin ([#1790](https://github.com/Tencent/tdesign-react/pull/1790))
+  - 无法输入小数点后面的第一位数字 `0`，[tdesign-vue-next#2103](https://github.com/Tencent/tdesign-vue-next/issues/2103) @chaishi ([#1780](https://github.com/Tencent/tdesign-react/pull/1780))
+  - 修复无法使用清空按钮清除输入数字问题，[issue#1855](https://github.com/Tencent/tdesign-vue/issues/1855) @chaishi ([#1780](https://github.com/Tencent/tdesign-react/pull/1780))
+  - 修复 status 默认值缺失 @honkinglin ([#1790](https://github.com/Tencent/tdesign-react/pull/1790))
 - `Popup`: 快速移动鼠标弹出层闪烁 @HelKyle ([#1769](https://github.com/Tencent/tdesign-react/pull/1769))
 - `dialog`: 修复 dialog instance ts 类型警告 @moecasts ([#1783](https://github.com/Tencent/tdesign-react/pull/1783))
 - `affix`: 新增 content @ontheroad1992 ([#1778](https://github.com/Tencent/tdesign-react/pull/1778))
@@ -211,131 +238,149 @@ spline: explain
 - `InputAdornment`: 修复样式问题 @honkinglin ([#1784](https://github.com/Tencent/tdesign-react/pull/1784))
 - `Dialog`: 修复滚动条宽度计算问题 @honkinglin ([#1787](https://github.com/Tencent/tdesign-react/pull/1787))
 
+## 🌈 0.44.0 `2022-11-30`
 
-## 🌈 0.44.0 `2022-11-30` 
 ### 🚨 Breaking Changes
+
 - `Jumper`: Jumper 更名为 PaginationMini 组件，正在使用 Jumper 组件的同学请从 Pagination 中导出替换 @honkinglin ([#1749](https://github.com/Tencent/tdesign-react/pull/1749))
 - `Tooltip`: 移除 placement 的 mouse 模式，该场景请使用 TooltipLite @carolin913 ([#1751](https://github.com/Tencent/tdesign-react/pull/1751))
 
 ### 🚀 Features
-- `TooltipLite`: placement 支持 mouse 模式，实现原生title体验 @carolin913 ([#1751](https://github.com/Tencent/tdesign-react/pull/1751))
+
+- `TooltipLite`: placement 支持 mouse 模式，实现原生 title 体验 @carolin913 ([#1751](https://github.com/Tencent/tdesign-react/pull/1751))
 - `Table`: 选中行功能，新增 `reserveSelectedRowOnPaginate`，用于支持在分页场景中，仅选中当前页数据，切换分页时清空选中结果，全选仅选中当前页数据 @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
 - `Drawer`: 默认不显示关闭按钮，有取消和确认按钮足矣，同其他框架保持一致 @chaishi ([#1746](https://github.com/Tencent/tdesign-react/pull/1746))
 - `AutoComplete`: 新增组件 `AutoComplete` @chaishi ([#1752](https://github.com/Tencent/tdesign-react/pull/1752))
 - `Calendar`: 调整卡片类型的控制面板尺寸大小 @uyarn ([#1766](https://github.com/Tencent/tdesign-react/pull/1766))
 
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - 减少表格重渲染  #1688 @jsonz1993 ([#1704](https://github.com/Tencent/tdesign-react/pull/1704))
-    - 修复本地数据分页场景中，切换分页大小，`onPageChange` 事件参数返回的数据不正确问题 @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
-    - 序号列支持跨分页显示，[issue#1726](https://github.com/Tencent/tdesign-react/issues/1726)，[tdesign-vue-next#2072](https://github.com/Tencent/tdesign-vue-next/issues/2072) @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
-    - 修复分页场景下，设置 max-height 和 bordered 之后，边框线位置不正确 [tdesign-vue-next#2062](https://github.com/Tencent/tdesign-vue-next/issues/2062) @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
+  - 减少表格重渲染 #1688 @jsonz1993 ([#1704](https://github.com/Tencent/tdesign-react/pull/1704))
+  - 修复本地数据分页场景中，切换分页大小，`onPageChange` 事件参数返回的数据不正确问题 @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
+  - 序号列支持跨分页显示，[issue#1726](https://github.com/Tencent/tdesign-react/issues/1726)，[tdesign-vue-next#2072](https://github.com/Tencent/tdesign-vue-next/issues/2072) @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
+  - 修复分页场景下，设置 max-height 和 bordered 之后，边框线位置不正确 [tdesign-vue-next#2062](https://github.com/Tencent/tdesign-vue-next/issues/2062) @chaishi ([#1755](https://github.com/Tencent/tdesign-react/pull/1755))
 - `Card`: 修复 Card 组件 loading 高度塌陷 @HelKyle ([#1754](https://github.com/Tencent/tdesign-react/pull/1754))
 - `TagInput`:
-    - 标签边距和图标位置调整 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
-    - 右侧图标会和标签重合问题 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
-    - 修复 `onRemove` 事件参数未能返回最新 `value` 问题 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
+  - 标签边距和图标位置调整 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
+  - 右侧图标会和标签重合问题 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
+  - 修复 `onRemove` 事件参数未能返回最新 `value` 问题 @chaishi ([#1758](https://github.com/Tencent/tdesign-react/pull/1758))
 - `Calendar`: 修复控制面板对齐的问题 @uyarn ([#1766](https://github.com/Tencent/tdesign-react/pull/1766))
 - `Menu`: 修复纵向类型二级菜单左边间距丢失的问题 @uyarn ([#1766](https://github.com/Tencent/tdesign-react/pull/1766))
-- `Dropdown`:  修复透传 className 和 style 的问题 @insekkei ([#1745](https://github.com/Tencent/tdesign-react/pull/1745))
-- `Message`:  修复在 offset 不存在时 style 生效 @kenzyyang ([#1762](https://github.com/Tencent/tdesign-react/pull/1762))
+- `Dropdown`: 修复透传 className 和 style 的问题 @insekkei ([#1745](https://github.com/Tencent/tdesign-react/pull/1745))
+- `Message`: 修复在 offset 不存在时 style 生效 @kenzyyang ([#1762](https://github.com/Tencent/tdesign-react/pull/1762))
 - `TreeSelect`: 修复 valueDisplay 清空按钮不展示问题 @honkinglin ([#1757](https://github.com/Tencent/tdesign-react/pull/1757))
-- `SelectInput`: 修复某些场景下select-input 无法输入的问题 @HelKyle ([#1760](https://github.com/Tencent/tdesign-react/pull/1760))
+- `SelectInput`: 修复某些场景下 select-input 无法输入的问题 @HelKyle ([#1760](https://github.com/Tencent/tdesign-react/pull/1760))
 - `Drawer`: 修复动画效果异常 @honkinglin ([#1761](https://github.com/Tencent/tdesign-react/pull/1761))
 
+## 🌈 0.43.1 `2022-11-23`
 
-## 🌈 0.43.1 `2022-11-23` 
 ### 🚀 Features
-- `Select`: Select option子组件搜索以label优先 支持复杂children为node节点的搜索 @uyarn ([#1717](https://github.com/Tencent/tdesign-react/pull/1717))
-- `ColorPicker`: 增加对OnChange事件区分最近使用和预设的颜色的点击事件 @josonyang ([#1722](https://github.com/Tencent/tdesign-react/pull/1722))
+
+- `Select`: Select option 子组件搜索以 label 优先 支持复杂 children 为 node 节点的搜索 @uyarn ([#1717](https://github.com/Tencent/tdesign-react/pull/1717))
+- `ColorPicker`: 增加对 OnChange 事件区分最近使用和预设的颜色的点击事件 @josonyang ([#1722](https://github.com/Tencent/tdesign-react/pull/1722))
 - `InputNumber`:
-    - 支持 `allowInputOverLimit`，用于设置是否允许输入数字超过 `max` `min` 范围的值 @chaishi ([#1723](https://github.com/Tencent/tdesign-react/pull/1723))
-    -  新增和减少按钮支持 `allowInputOverLimit ` @chaishi ([#1727](https://github.com/Tencent/tdesign-react/pull/1727))
-- `ColorPicker`: 增加对OnChange事件区分最近使用和预设的颜色的点击事件 @josonyang ([#1722](https://github.com/Tencent/tdesign-react/pull/1722))
+  - 支持 `allowInputOverLimit`，用于设置是否允许输入数字超过 `max` `min` 范围的值 @chaishi ([#1723](https://github.com/Tencent/tdesign-react/pull/1723))
+  - 新增和减少按钮支持 `allowInputOverLimit ` @chaishi ([#1727](https://github.com/Tencent/tdesign-react/pull/1727))
+- `ColorPicker`: 增加对 OnChange 事件区分最近使用和预设的颜色的点击事件 @josonyang ([#1722](https://github.com/Tencent/tdesign-react/pull/1722))
 - `Table`: 减少表格渲染次数，[issue#1731](https://github.com/Tencent/tdesign-react/issues/1731) @chaishi ([#1732](https://github.com/Tencent/tdesign-react/pull/1732))
 - `TreeSelect`: 优化`checkable`时点击非叶子节点选中的问题 @uyarn ([#1734](https://github.com/Tencent/tdesign-react/pull/1734))
-- `Dialog`:  优化关闭动画不流畅问题 @honkinglin ([#1729](https://github.com/Tencent/tdesign-react/pull/1729))
+- `Dialog`: 优化关闭动画不流畅问题 @honkinglin ([#1729](https://github.com/Tencent/tdesign-react/pull/1729))
 - `Other`: 兼容 React 18 render 警告 @honkinglin ([#1718](https://github.com/Tencent/tdesign-react/pull/1718))
 
 ### 🐞 Bug Fixes
+
 - `InputNumber`: 修复上个版本无法输入小数点问题 @chaishi ([#1723](https://github.com/Tencent/tdesign-react/pull/1723))
-- `Select`: 支持valueDisplay API在单选模式的使用 @uyarn ([#1733](https://github.com/Tencent/tdesign-react/pull/1733))
-- `Table`: 
-    - 吸底表尾默认位置不正确 @chaishi ([#1737](https://github.com/Tencent/tdesign-react/pull/1737))
-    - 添加依赖到 `onRuleChange`，以保证数据最新 @chaishi ([#1739](https://github.com/Tencent/tdesign-react/pull/1739))
+- `Select`: 支持 valueDisplay API 在单选模式的使用 @uyarn ([#1733](https://github.com/Tencent/tdesign-react/pull/1733))
+- `Table`:
+  - 吸底表尾默认位置不正确 @chaishi ([#1737](https://github.com/Tencent/tdesign-react/pull/1737))
+  - 添加依赖到 `onRuleChange`，以保证数据最新 @chaishi ([#1739](https://github.com/Tencent/tdesign-react/pull/1739))
 - `Popup`: 修复 `delay` 无效问题 @honkinglin ([#1740](https://github.com/Tencent/tdesign-react/pull/1740))
 
+## 🌈 0.43.0 `2022-11-17`
 
-## 🌈 0.43.0 `2022-11-17` 
 ### 🚨 Breaking Changes
+
 - `Comment/Slider/ImageViewer`: 组件 DOM 结构调整，有覆盖样式的同学请关注 @honkinglin ([#1785](https://github.com/Tencent/tdesign-react/pull/1707)、[#1794](https://github.com/Tencent/tdesign-react/pull/1708)、[#1788](https://github.com/Tencent/tdesign-react/pull/1711))
-- 部分组件间距、尺寸等样式统一调整，支持使用尺寸相关Design Token调整间距、尺寸大小 @uyarn ([common #993](https://github.com/Tencent/tdesign-common/pull/993)) @Wen1kang ([common #977](https://github.com/Tencent/tdesign-common/pull/977)) 
+- 部分组件间距、尺寸等样式统一调整，支持使用尺寸相关 Design Token 调整间距、尺寸大小 @uyarn ([common #993](https://github.com/Tencent/tdesign-common/pull/993)) @Wen1kang ([common #977](https://github.com/Tencent/tdesign-common/pull/977))
 
 ### 🚀 Features
+
 - `Breadcrumb`: 新增`icon` API @uyarn ([#1702](https://github.com/Tencent/tdesign-react/pull/1702))
-- `Select`: 支持使用Option Children形式时使用过滤等功能 @uyarn ([#1715](https://github.com/Tencent/tdesign-react/pull/1715))
+- `Select`: 支持使用 Option Children 形式时使用过滤等功能 @uyarn ([#1715](https://github.com/Tencent/tdesign-react/pull/1715))
+
 ### 🐞 Bug Fixes
-- `swiper`: swiper控制current交互和正常保持一致 @duenyang ([#1693](https://github.com/Tencent/tdesign-react/pull/1693))
-- `Loading`: 处理loading在dialog等场景中样式异常的问题 @uyarn ([#1694](https://github.com/Tencent/tdesign-react/pull/1694))
+
+- `swiper`: swiper 控制 current 交互和正常保持一致 @duenyang ([#1693](https://github.com/Tencent/tdesign-react/pull/1693))
+- `Loading`: 处理 loading 在 dialog 等场景中样式异常的问题 @uyarn ([#1694](https://github.com/Tencent/tdesign-react/pull/1694))
 - `Breadcrumbe`: 修复文字省略样式丢失的问题 @uyarn ([#1702](https://github.com/Tencent/tdesign-react/pull/1702))
-- `popconfirm`: 修复官网demo气泡框描述文案字体颜色 @iLunZ ([#1705](https://github.com/Tencent/tdesign-react/pull/1705))
+- `popconfirm`: 修复官网 demo 气泡框描述文案字体颜色 @iLunZ ([#1705](https://github.com/Tencent/tdesign-react/pull/1705))
 - `InputNumber`: 组件支持受控 @chaishi ([#1703](https://github.com/Tencent/tdesign-react/pull/1703))
 - `Form`: 修复拦截 checkbox 默认值为 undefined 控制台警告问题 @honkinglin ([#1682](https://github.com/Tencent/tdesign-react/pull/1682))
-- `popconfirm`: 修复官网demo气泡框描述文案字体颜色 @iLunZ ([#1705](https://github.com/Tencent/tdesign-react/pull/1705))
+- `popconfirm`: 修复官网 demo 气泡框描述文案字体颜色 @iLunZ ([#1705](https://github.com/Tencent/tdesign-react/pull/1705))
 - `TreeSelect`:
-    - 当 valueType="object" 且 value 不在 tree.data 中时, 优先展示  @moecasts ([#1681](https://github.com/Tencent/tdesign-react/pull/1681))
-    - 修复浮层样式问题 @honkinglin ([#1689](https://github.com/Tencent/tdesign-react/pull/1689))
-    - 暴露 treeRef 的方法 @moecasts ([#1698](https://github.com/Tencent/tdesign-react/pull/1698))
+  - 当 valueType="object" 且 value 不在 tree.data 中时, 优先展示 @moecasts ([#1681](https://github.com/Tencent/tdesign-react/pull/1681))
+  - 修复浮层样式问题 @honkinglin ([#1689](https://github.com/Tencent/tdesign-react/pull/1689))
+  - 暴露 treeRef 的方法 @moecasts ([#1698](https://github.com/Tencent/tdesign-react/pull/1698))
 - `Tooltip`: 修复非受控问题 @honkinglin ([#1712](https://github.com/Tencent/tdesign-react/pull/1712))
 
-## 🌈 0.42.6 `2022-11-07` 
+## 🌈 0.42.6 `2022-11-07`
+
 ### 🚀 Features
+
 - `Guide`: support guide component @Yilun-Sun ([#1581](https://github.com/Tencent/tdesign-react/pull/1581))
 
 ### 🐞 Bug Fixes
-- `Table`: 当禁用resizable时，基础表格表头默认使用用户定义的列宽 @ZTao-z ([#1662](https://github.com/Tencent/tdesign-react/pull/1662))
-- `Dropdown`: 修复Children变化时没有重新渲染的异常 @uyarn ([#1673](https://github.com/Tencent/tdesign-react/pull/1673))
+
+- `Table`: 当禁用 resizable 时，基础表格表头默认使用用户定义的列宽 @ZTao-z ([#1662](https://github.com/Tencent/tdesign-react/pull/1662))
+- `Dropdown`: 修复 Children 变化时没有重新渲染的异常 @uyarn ([#1673](https://github.com/Tencent/tdesign-react/pull/1673))
 - `Select`:
-    - 修复选项文案过程内容未正确显示的问题 @uyarn ([#1676](https://github.com/Tencent/tdesign-react/pull/1676))
-    - 修复可过滤选择器选中项目失去焦点选中失败问题 @honkinglin ([#1675](https://github.com/Tencent/tdesign-react/pull/1675))
-- `InputNumber`: 修复最小值为0仍可点击减号至-1的问题 @lilonghe @uyarn ([#1676](https://github.com/Tencent/tdesign-react/pull/1676))
+  - 修复选项文案过程内容未正确显示的问题 @uyarn ([#1676](https://github.com/Tencent/tdesign-react/pull/1676))
+  - 修复可过滤选择器选中项目失去焦点选中失败问题 @honkinglin ([#1675](https://github.com/Tencent/tdesign-react/pull/1675))
+- `InputNumber`: 修复最小值为 0 仍可点击减号至-1 的问题 @lilonghe @uyarn ([#1676](https://github.com/Tencent/tdesign-react/pull/1676))
 - `Input`: 修复在输入框进行预渲染处于 `display: none` 状态时，宽度计算不正确问题，[tdesign-vue#1678](https://github.com/Tencent/tdesign-vue/issues/1678) @chaishi ([#1669](https://github.com/Tencent/tdesign-react/pull/1669))
 - `Pagination`: 修复 `selectProps` warn @chaishi ([#1669](https://github.com/Tencent/tdesign-react/pull/1669))
 - `Form`: 修复提交后 onChange 校验不清除状态问题 @honkinglin ([#1664](https://github.com/Tencent/tdesign-react/pull/1664))
 - `TreeSelect`: 修复 valueDisplay 和 filterable 同时设置时的显示问题 @moecasts ([#1674](https://github.com/Tencent/tdesign-react/pull/1674))
 
-## 🌈 0.42.5 `2022-11-02` 
+## 🌈 0.42.5 `2022-11-02`
+
 ### 🚀 Features
+
 - `Collapse`: 支持 expandIcon 属性 @asbstty ([#1651](https://github.com/Tencent/tdesign-react/pull/1651))
 - `Pagination`: 透传`selectProps` 和 `selectProps.popupProps` 到组件 `Pagination`，以便实现挂载节点等复杂场景需求， [issue#1611](https://github.com/Tencent/tdesign-react/issues/1611) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
 - `Input`:
-    - 支持在输入框实时显示数字限制 @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
-    - 支持对 `unicode` 字符长度的判定 @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
+  - 支持在输入框实时显示数字限制 @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
+  - 支持对 `unicode` 字符长度的判定 @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
 
 ### 🐞 Bug Fixes
+
 - `Form`: 修复不同 trigger 下校验结果互相覆盖问题 @honkinglin ([#1630](https://github.com/Tencent/tdesign-react/pull/1630))
 - `Cascader`: 修复出现重复的 `options` @pengYYYYY ([#1628](https://github.com/Tencent/tdesign-react/pull/1628))
 - `Table`:
-    - 提高 `dragSortOptions` 优先级，以便父组件自定义全部参数，[issue#1556](https://github.com/Tencent/tdesign-react/issues/1556) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
-    - 修复可编辑表格，行编辑，数据校验问题，[issue#1514](https://github.com/Tencent/tdesign-react/issues/1514) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
-    - 修复吸顶表头超出省略问题，[tdesign-vue#1639](https://github.com/Tencent/tdesign-vue/issues/1639) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
+  - 提高 `dragSortOptions` 优先级，以便父组件自定义全部参数，[issue#1556](https://github.com/Tencent/tdesign-react/issues/1556) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
+  - 修复可编辑表格，行编辑，数据校验问题，[issue#1514](https://github.com/Tencent/tdesign-react/issues/1514) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
+  - 修复吸顶表头超出省略问题，[tdesign-vue#1639](https://github.com/Tencent/tdesign-vue/issues/1639) @chaishi ([#1638](https://github.com/Tencent/tdesign-react/pull/1638))
 - `Input`:
-    - 输入框达到数量 `maxlength` 时，无法删除且无法修改输入框内容，[issue#1633](https://github.com/Tencent/tdesign-react/issues/1633) @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
-    - 修复聚焦的时候未恢复 format 之前的值问题 [issue#1634](https://github.com/Tencent/tdesign-react/issues/1634) @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
+  - 输入框达到数量 `maxlength` 时，无法删除且无法修改输入框内容，[issue#1633](https://github.com/Tencent/tdesign-react/issues/1633) @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
+  - 修复聚焦的时候未恢复 format 之前的值问题 [issue#1634](https://github.com/Tencent/tdesign-react/issues/1634) @chaishi ([#1635](https://github.com/Tencent/tdesign-react/pull/1635))
 - `Datepicker`: 修复 `popupProps.onVisibleChange` 方法不能正常触发的问题 @xiaosansiji ([#1644](https://github.com/Tencent/tdesign-react/pull/1644))
-- `Button`: 修复动画在disabled状态切换后失效的问题 @uyarn ([#1653](https://github.com/Tencent/tdesign-react/pull/1653))
-- `Pagination`: 修复相同页码也会触发onChange的问题 @honkinglin ([#1650](https://github.com/Tencent/tdesign-react/pull/1650))
+- `Button`: 修复动画在 disabled 状态切换后失效的问题 @uyarn ([#1653](https://github.com/Tencent/tdesign-react/pull/1653))
+- `Pagination`: 修复相同页码也会触发 onChange 的问题 @honkinglin ([#1650](https://github.com/Tencent/tdesign-react/pull/1650))
 - `Message`: 支持异步渲染组件 @kenzyyang ([#1641](https://github.com/Tencent/tdesign-react/pull/1641))
 - `DatePicker`: 修复单选日期时间无法确定问题 @honkinglin ([#1645](https://github.com/Tencent/tdesign-react/pull/1645))
 
-## 🌈 0.42.4 `2022-10-26` 
+## 🌈 0.42.4 `2022-10-26`
+
 ### 🚀 Features
+
 - `Tag`: 样式优化，实现 light-outline 风格 @HelKyle ([#1590](https://github.com/Tencent/tdesign-react/pull/1590))
 - `Upload`: 多图片上传，图片文件名支持 `abridgeName` @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
 - `Comment`: 样式优化 @zhangpaopao0609 ([#1614](https://github.com/Tencent/tdesign-react/pull/1614))
 - `InputAdornment`: 样式优化 @zhangpaopao0609 ([#1606](https://github.com/Tencent/tdesign-react/pull/1606))
 
 ### 🐞 Bug Fixes
+
 - `Drawer`: 修复浮层关闭后聚焦问题 @NWYLZW ([#1591](https://github.com/Tencent/tdesign-react/pull/1591))
 - `Input`: 修复 input 限制字符无效问题 @honkinglin ([#1624](https://github.com/Tencent/tdesign-react/pull/1624))
 - `Slider`: 修复 slider marks 为 object 时刻度位置异常 @HelKyle ([#1600](https://github.com/Tencent/tdesign-react/pull/1600))
@@ -344,470 +389,523 @@ spline: explain
 - `Select`: 修复 onChange 回调参数缺失问题 @uyarn ([#1603](https://github.com/Tencent/tdesign-react/pull/1603))
 - `Swiper`: 当轮播只有一个时，点击左侧按钮后，按钮失效问题 @yatessss ([#1604](https://github.com/Tencent/tdesign-react/pull/1604))
 - `Dropdown`:
-    - 修复子组件平铺渲染时渲染异常的问题 @uyarn ([#1599](https://github.com/Tencent/tdesign-react/pull/1599))
-    - 修复无法使用三元表达式渲染item组件的问题 @uyarn ([#1599](https://github.com/Tencent/tdesign-react/pull/1599))
+  - 修复子组件平铺渲染时渲染异常的问题 @uyarn ([#1599](https://github.com/Tencent/tdesign-react/pull/1599))
+  - 修复无法使用三元表达式渲染 item 组件的问题 @uyarn ([#1599](https://github.com/Tencent/tdesign-react/pull/1599))
 - `Upload`:
-    - 修复 `name` 无效问题 @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
-    - 图片上传，自定义上传方法不支持图片回显问题 @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
-    - 修复结果无法识别 `interface` 文件问题，[issue#1586](https://github.com/Tencent/tdesign-react/issues/1586) @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
-    - 修复 Form 控制禁用状态失效问题 @chaishi ([#1621](https://github.com/Tencent/tdesign-react/pull/1621))
+  - 修复 `name` 无效问题 @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
+  - 图片上传，自定义上传方法不支持图片回显问题 @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
+  - 修复结果无法识别 `interface` 文件问题，[issue#1586](https://github.com/Tencent/tdesign-react/issues/1586) @chaishi ([#1616](https://github.com/Tencent/tdesign-react/pull/1616))
+  - 修复 Form 控制禁用状态失效问题 @chaishi ([#1621](https://github.com/Tencent/tdesign-react/pull/1621))
 - `Tabs`:
-    - 支持 list api @NWYLZW ([#1598](https://github.com/Tencent/tdesign-react/pull/1598))
-    - 修复 activeId 下划线不能跟随内容变动而变化的问题 @insekkei ([#1607](https://github.com/Tencent/tdesign-react/pull/1607))
+  - 支持 list api @NWYLZW ([#1598](https://github.com/Tencent/tdesign-react/pull/1598))
+  - 修复 activeId 下划线不能跟随内容变动而变化的问题 @insekkei ([#1607](https://github.com/Tencent/tdesign-react/pull/1607))
 
 ### 🚧 Others
+
 - 测试框架切换至 vitest @honkinglin ([#1596](https://github.com/Tencent/tdesign-react/pull/1596))
 
-## 🌈 0.42.3 `2022-10-14` 
+## 🌈 0.42.3 `2022-10-14`
+
 ### 🚀 Features
+
 - `Form`: 调整 requiredMark api 可独立控制星号展示 @honkinglin ([#1580](https://github.com/Tencent/tdesign-react/pull/1580))
+
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - 唯一 key 不再和 rowIndex 相加，避免重复问题 @chaishi ([#1594](https://github.com/Tencent/tdesign-react/pull/1594))
-    - 拖拽排序失效问题，primaryTableRef 丢失 @chaishi ([#1594](https://github.com/Tencent/tdesign-react/pull/1594))
--  `DatePicker`: 修复 range 数据格式化异常问题 @honkinglin ([#1587](https://github.com/Tencent/tdesign-react/pull/1587))
-- `Collapse`:  修复 defaultExpandAll 属性没有生效 & 包含 form 表单的时候样式出现溢出问题 @duanbaosheng ([#1579](https://github.com/Tencent/tdesign-react/pull/1579))
+  - 唯一 key 不再和 rowIndex 相加，避免重复问题 @chaishi ([#1594](https://github.com/Tencent/tdesign-react/pull/1594))
+  - 拖拽排序失效问题，primaryTableRef 丢失 @chaishi ([#1594](https://github.com/Tencent/tdesign-react/pull/1594))
+- `DatePicker`: 修复 range 数据格式化异常问题 @honkinglin ([#1587](https://github.com/Tencent/tdesign-react/pull/1587))
+- `Collapse`: 修复 defaultExpandAll 属性没有生效 & 包含 form 表单的时候样式出现溢出问题 @duanbaosheng ([#1579](https://github.com/Tencent/tdesign-react/pull/1579))
 - `Form`: 修复 `getInternalHooks` 警告问题 @honkinglin ([#1577](https://github.com/Tencent/tdesign-react/pull/1577))
 
-## 🌈 0.42.2 `2022-10-09` 
+## 🌈 0.42.2 `2022-10-09`
+
 ### 🚀 Features
+
 - `Select`: 调整下拉交互 允许输入时不关闭下拉面板 减少相关交互问题 @uyarn ([#1570](https://github.com/Tencent/tdesign-react/pull/1570))
 - `DatePicker`: 支持`valueType` API @honkinglin ([#1554](https://github.com/Tencent/tdesign-react/pull/1554))
 - `Table`:
-    - 新增 `showHeader`，支持隐藏表头 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 新增 `column.colKey = serial-number`，支持序号列功能，[#1517](https://github.com/Tencent/tdesign-vue-next/issues/1517) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 新增 `showSortColumnBgColor`，用于控制是否显示排序列背景色 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 支持属性 `tree.treeNodeColumnIndex` 动态修改， [#1487](https://github.com/Tencent/tdesign-vue-next/issues/1487) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 表格列属性 `attrs` 支持自定义任意单元格属性 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 新增列属性 `colspan`，用于设置单行表头合并 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 超出省略功能，支持同时设置省略浮层内容 `ellipsis.content` 和属性透传 `ellipsis.props` @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 支持泛型 @chaishi ([#1552](https://github.com/Tencent/tdesign-react/pull/1552))
+  - 新增 `showHeader`，支持隐藏表头 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 新增 `column.colKey = serial-number`，支持序号列功能，[#1517](https://github.com/Tencent/tdesign-vue-next/issues/1517) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 新增 `showSortColumnBgColor`，用于控制是否显示排序列背景色 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 支持属性 `tree.treeNodeColumnIndex` 动态修改， [#1487](https://github.com/Tencent/tdesign-vue-next/issues/1487) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 表格列属性 `attrs` 支持自定义任意单元格属性 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 新增列属性 `colspan`，用于设置单行表头合并 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 超出省略功能，支持同时设置省略浮层内容 `ellipsis.content` 和属性透传 `ellipsis.props` @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 支持泛型 @chaishi ([#1552](https://github.com/Tencent/tdesign-react/pull/1552))
 
 ### 🐞 Bug Fixes
+
 - `InputNumber`: 输入中文或特殊符号时，清空数字为 `undefined` @chaishi ([#1553](https://github.com/Tencent/tdesign-react/pull/1553))
 - `Upload`:
-    - 请求支持带上自定义 `headers` @chaishi ([#1553](https://github.com/Tencent/tdesign-react/pull/1553))
-    - 请求支持 `withCredentials` @chaishi ([#1553](https://github.com/Tencent/tdesign-react/pull/1553))
-    - 添加参数 `response` 到事件 `onSuccess`，单文件是对象，多文件是数组，[tdesign-vue-next#1774](https://github.com/Tencent/tdesign-vue-next/issues/1774) @chaishi ([#1558](https://github.com/Tencent/tdesign-react/pull/1558))
-- `Card`: 修复`shadow` API不生效的问题 @Flower-F ([#1555](https://github.com/Tencent/tdesign-react/pull/1555))
+  - 请求支持带上自定义 `headers` @chaishi ([#1553](https://github.com/Tencent/tdesign-react/pull/1553))
+  - 请求支持 `withCredentials` @chaishi ([#1553](https://github.com/Tencent/tdesign-react/pull/1553))
+  - 添加参数 `response` 到事件 `onSuccess`，单文件是对象，多文件是数组，[tdesign-vue-next#1774](https://github.com/Tencent/tdesign-vue-next/issues/1774) @chaishi ([#1558](https://github.com/Tencent/tdesign-react/pull/1558))
+- `Card`: 修复`shadow` API 不生效的问题 @Flower-F ([#1555](https://github.com/Tencent/tdesign-react/pull/1555))
 - `Select`: 修复新创建的条目与已有项重复时重复显示的问题 @samhou1988 ([#1550](https://github.com/Tencent/tdesign-react/pull/1550))
 - `TreeSelect`: 修复 filterable 时，点击 treeselect 闪的问题 @HelKyle ([#1569](https://github.com/Tencent/tdesign-react/pull/1569))
 - `Form`: 修复 FormList 动态设置节点初始值丢失问题 @honkinglin ([#1571](https://github.com/Tencent/tdesign-react/pull/1571))
 - `Input`: 兼容异步渲染组件计算宽度异常情况 @honkinglin ([#1568](https://github.com/Tencent/tdesign-react/pull/1568))
 - `Table`:
-    - 筛选功能，修复 `filterRow={null}` 无法隐藏过滤行问题，[issue#1438](https://github.com/Tencent/tdesign-react/issues/1438) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 树形结构，叶子节点缩进距离修正 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 超出省略功能，`ellipsisTitle`优先级应当高于 `ellipsis`， [tdesign-vue#1404](https://github.com/Tencent/tdesign-vue/issues/1404) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 行选中功能，修复 `column.type=single` 时，`column.title` 无效问题，[issue#1372](https://github.com/Tencent/tdesign-vue/issues/1372) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 过滤功能，`list.value` 值为 `number` 无法高亮过滤图标问题 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 行选中功能，数据变化时，选中的数据依旧是变化前的数据，[#1722](https://github.com/Tencent/tdesign-vue-next/issues/1722) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
-    - 不提供`expandedRowKeys`的绑定会报错 ，缺少判空，[#1704](https://github.com/Tencent/tdesign-vue-next/issues/1704) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 筛选功能，修复 `filterRow={null}` 无法隐藏过滤行问题，[issue#1438](https://github.com/Tencent/tdesign-react/issues/1438) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 树形结构，叶子节点缩进距离修正 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 超出省略功能，`ellipsisTitle`优先级应当高于 `ellipsis`， [tdesign-vue#1404](https://github.com/Tencent/tdesign-vue/issues/1404) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 行选中功能，修复 `column.type=single` 时，`column.title` 无效问题，[issue#1372](https://github.com/Tencent/tdesign-vue/issues/1372) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 过滤功能，`list.value` 值为 `number` 无法高亮过滤图标问题 @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 行选中功能，数据变化时，选中的数据依旧是变化前的数据，[#1722](https://github.com/Tencent/tdesign-vue-next/issues/1722) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
+  - 不提供`expandedRowKeys`的绑定会报错 ，缺少判空，[#1704](https://github.com/Tencent/tdesign-vue-next/issues/1704) @chaishi ([#1566](https://github.com/Tencent/tdesign-react/pull/1566))
 - `Dialog`: 修复初次点击内容区域移到 mask 区域后关闭弹窗问题 @honkinglin ([#1573](https://github.com/Tencent/tdesign-react/pull/1573))
 - `Pagination`: 修复 `jumper` 输入框联动问题 @honkinglin ([#1574](https://github.com/Tencent/tdesign-react/pull/1574))
 
+## 🌈 0.42.1 `2022-09-27`
 
-## 🌈 0.42.1 `2022-09-27` 
 ### 🚀 Features
-- `Form`: 
-    - `FormList` name 支持传入数组 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
-    - `FormItem` 支持函数渲染子节点 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
-    - `FormItem` 支持 shouldUpdate api 自定义控制渲染时机 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
+
+- `Form`:
+  - `FormList` name 支持传入数组 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
+  - `FormItem` 支持函数渲染子节点 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
+  - `FormItem` 支持 shouldUpdate api 自定义控制渲染时机 @honkinglin ([#1518](https://github.com/Tencent/tdesign-react/pull/1518))
 - `Upload`:
-    - 所有风格支持 `tips` 和 `status`，用于定义说明文本 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
-    - 支持 `files` 数据类型泛型 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
+  - 所有风格支持 `tips` 和 `status`，用于定义说明文本 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
+  - 支持 `files` 数据类型泛型 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
 - `Table`: 新增 column.resizable 支持自定义任意列是否可拖拽调整宽度 @ZTao-z ([#1535](https://github.com/Tencent/tdesign-react/pull/1535))
-- `Tooltip`: 新增lite模式子组件，rate/imageviewer改用lite版本 @carolin913 ([#1546](https://github.com/Tencent/tdesign-react/pull/1546))
-- `TimePicker`:  优化边距 ui @wanghanzhen ([#1531](https://github.com/Tencent/tdesign-react/pull/1531))
-- `ImageViewer`:  优化内部 dom 节点class bem 命名规范 @Ylushen ([#1533](https://github.com/Tencent/tdesign-react/pull/1533))
+- `Tooltip`: 新增 lite 模式子组件，rate/imageviewer 改用 lite 版本 @carolin913 ([#1546](https://github.com/Tencent/tdesign-react/pull/1546))
+- `TimePicker`: 优化边距 ui @wanghanzhen ([#1531](https://github.com/Tencent/tdesign-react/pull/1531))
+- `ImageViewer`: 优化内部 dom 节点 class bem 命名规范 @Ylushen ([#1533](https://github.com/Tencent/tdesign-react/pull/1533))
 
 ### 🐞 Bug Fixes
-- `Upload`:
-    - 修复无法多次拖拽上传文件问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
-    - 修复文件大小超出时无法显示错误问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
-    - 修复文件上传进度仅显示 0% 和 100%，缺少中间进度 问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
-- `Input`:
-    - 修复input的 autoWidth 配置开启下,计算宽度时取的 placeholder不正确问题 @yusongH ([#1537](https://github.com/Tencent/tdesign-react/pull/1537))
-    - 修复默认状态提示文字颜色错误问题 @xiaosansiji ([#1486](https://github.com/Tencent/tdesign-react/pull/1486))
-- `TimePicker`: 修复部分场景滚动异常无法选中23:59:59的问题 @uyarn ([#1511](https://github.com/Tencent/tdesign-react/pull/1511))
-- `Dropdown`: 修复点击选项没有触发onVisibleChange的问题 @uyarn ([#1516](https://github.com/Tencent/tdesign-react/pull/1516))
-- `Tree`: 支持树可拖拽 @HelKyle ([#1534](https://github.com/Tencent/tdesign-react/pull/1534))
-- `Select`: 修复Select组件多选情况下禁用组件后还能点击删除选项的问题 @AqingCyan ([#1529](https://github.com/Tencent/tdesign-react/pull/1529))
-- `TagInput`: 修复 react 16 版本 event 对象缺失 code 属性判断错误 @honkinglin ([#1526](https://github.com/Tencent/tdesign-react/pull/1526))
-- `DatePicker`:  修复输入框清空后关闭弹窗未重置问题 @honkinglin ([#1543](https://github.com/Tencent/tdesign-react/pull/1543))
 
-## 🌈 0.42.0 `2022-09-20` 
+- `Upload`:
+  - 修复无法多次拖拽上传文件问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
+  - 修复文件大小超出时无法显示错误问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
+  - 修复文件上传进度仅显示 0% 和 100%，缺少中间进度 问题 @chaishi ([#1524](https://github.com/Tencent/tdesign-react/pull/1524))
+- `Input`:
+  - 修复 input 的 autoWidth 配置开启下,计算宽度时取的 placeholder 不正确问题 @yusongH ([#1537](https://github.com/Tencent/tdesign-react/pull/1537))
+  - 修复默认状态提示文字颜色错误问题 @xiaosansiji ([#1486](https://github.com/Tencent/tdesign-react/pull/1486))
+- `TimePicker`: 修复部分场景滚动异常无法选中 23:59:59 的问题 @uyarn ([#1511](https://github.com/Tencent/tdesign-react/pull/1511))
+- `Dropdown`: 修复点击选项没有触发 onVisibleChange 的问题 @uyarn ([#1516](https://github.com/Tencent/tdesign-react/pull/1516))
+- `Tree`: 支持树可拖拽 @HelKyle ([#1534](https://github.com/Tencent/tdesign-react/pull/1534))
+- `Select`: 修复 Select 组件多选情况下禁用组件后还能点击删除选项的问题 @AqingCyan ([#1529](https://github.com/Tencent/tdesign-react/pull/1529))
+- `TagInput`: 修复 react 16 版本 event 对象缺失 code 属性判断错误 @honkinglin ([#1526](https://github.com/Tencent/tdesign-react/pull/1526))
+- `DatePicker`: 修复输入框清空后关闭弹窗未重置问题 @honkinglin ([#1543](https://github.com/Tencent/tdesign-react/pull/1543))
+
+## 🌈 0.42.0 `2022-09-20`
+
 ### 🚨 Breaking Changes
+
 - `DatePicker`: 移除 `valueType` api，可使用返回的 dayjs 对象自行格式化 @honkinglin ([#1487](https://github.com/Tencent/tdesign-react/pull/1487))
 - `Select`: 移除 `onVisibleChange`、`bordered` 多余 api，可使用 `onPopupVisibleChange`、`borderless` 替代 @honkinglin ([#1505](https://github.com/Tencent/tdesign-react/pull/1505))
 
 ### 🚀 Features
+
 - `Form`: 新增 `useWatch` hook @honkinglin ([#1490](https://github.com/Tencent/tdesign-react/pull/1490))
 - `DatePicker`:
-    - 优化动态更新年份滚动交互体验 @honkinglin ([#1502](https://github.com/Tencent/tdesign-react/pull/1502))
-    - 优化二次修改日期不规范时清空另一侧数据 @honkinglin ([#1492](https://github.com/Tencent/tdesign-react/pull/1492))
+  - 优化动态更新年份滚动交互体验 @honkinglin ([#1502](https://github.com/Tencent/tdesign-react/pull/1502))
+  - 优化二次修改日期不规范时清空另一侧数据 @honkinglin ([#1492](https://github.com/Tencent/tdesign-react/pull/1492))
 
 ### 🐞 Bug Fixes
+
 - `Icon`: 修复使用 `classprefix` 替换组件前缀对图标的影响 [#common842](https://github.com/Tencent/tdesign-common/pull/842) @uyarn @honkinglin ([#1500](https://github.com/Tencent/tdesign-react/pull/1500))
 - `Cascader`: 修复 `options` 动态设置为空失效 @pengYYYYY ([#1501](https://github.com/Tencent/tdesign-react/pull/1501))
-- `Checkbox`: 修复非规范属性引起的告警  @leosxie ([#1496](https://github.com/Tencent/tdesign-react/pull/1496))
+- `Checkbox`: 修复非规范属性引起的告警 @leosxie ([#1496](https://github.com/Tencent/tdesign-react/pull/1496))
 - `TagInput`: 修复清除按钮未调用 `onClear ` 事件 @pengYYYYY ([#1506](https://github.com/Tencent/tdesign-react/pull/1506))
 - `Select`: 修复透传 `tagProps` 属性失败问题 @honkinglin ([#1497](https://github.com/Tencent/tdesign-react/pull/1497))
 - `Notification`: 修复 offset 定位问题 @kenzyyang ([#1504](https://github.com/Tencent/tdesign-react/pull/1504))
 - `SelectInput`:
-    - 修复select-input使用valueDisplay渲染自定义tag筛选项展示居中错误 @AqingCyan ([#1503](https://github.com/Tencent/tdesign-react/pull/1503))
-    - 修复 SelectInput 自适应换行问题 @honkinglin ([#1500](https://github.com/Tencent/tdesign-react/pull/1500))
+  - 修复 select-input 使用 valueDisplay 渲染自定义 tag 筛选项展示居中错误 @AqingCyan ([#1503](https://github.com/Tencent/tdesign-react/pull/1503))
+  - 修复 SelectInput 自适应换行问题 @honkinglin ([#1500](https://github.com/Tencent/tdesign-react/pull/1500))
 
 ### 🚧 Others
+
 - 修复 lodash 全量导入问题 @honkinglin ([#1491](https://github.com/Tencent/tdesign-react/pull/1491))
 
-## 🌈 0.41.1 `2022-09-14` 
+## 🌈 0.41.1 `2022-09-14`
+
 ### 🚀 Features
+
 - `Upload`:
-    - 自定义方法 `requestMethod`参数在单文件时文件对象，多文件上传时，是数组文件对象 @chaishi ([#1484](https://github.com/Tencent/tdesign-react/pull/1484))
-    - `trigger/dragContent` 参数使用 `files` 而非 `displayFiles` @chaishi ([#1484](https://github.com/Tencent/tdesign-react/pull/1484))
+  - 自定义方法 `requestMethod`参数在单文件时文件对象，多文件上传时，是数组文件对象 @chaishi ([#1484](https://github.com/Tencent/tdesign-react/pull/1484))
+  - `trigger/dragContent` 参数使用 `files` 而非 `displayFiles` @chaishi ([#1484](https://github.com/Tencent/tdesign-react/pull/1484))
 - `ImageViewer`:
-    - 新增 `title`属性，作为相册标题展示 @Ylushen ([#1471](https://github.com/Tencent/tdesign-react/pull/1471))
-    - 适配移动端展示 @honkinglin ([#1480](https://github.com/Tencent/tdesign-react/pull/1480))
+  - 新增 `title`属性，作为相册标题展示 @Ylushen ([#1471](https://github.com/Tencent/tdesign-react/pull/1471))
+  - 适配移动端展示 @honkinglin ([#1480](https://github.com/Tencent/tdesign-react/pull/1480))
 - `DatePicker`: 支持二次更改时间选择器时可单次变更日期 @honkinglin ([#1478](https://github.com/Tencent/tdesign-react/pull/1478))
 - `Table`: 优化列宽调整策略 @ZTao-z ([#1483](https://github.com/Tencent/tdesign-react/pull/1483))
 
 ### 🐞 Bug Fixes
+
 - `TreeSelect`: 修复 data 异步更新，input 值没有及时更新的问题 @HelKyle ([#1481](https://github.com/Tencent/tdesign-react/pull/1481))
 
+## 🌈 0.41.0 `2022-09-13`
 
-## 🌈 0.41.0 `2022-09-13` 
 ### 🚨 Breaking Changes
+
 - 支持 `es module` 导出不带样式产物，调整 lib 包内容，新增 `cjs` 产物支持 `commonjs` 导出不带样式产物 @honkinglin ([#1455](https://github.com/Tencent/tdesign-react/pull/1455))
 
 ### 🚀 Features
+
 - `Popup`: 支持 `popperOptions`、`delay`、`hideEmptyPopup` api @honkinglin ([#1444](https://github.com/Tencent/tdesign-react/pull/1444))
-- `Upload`: 
-    -  重构 upload 组件，修复众多问题，支持更多 api
-    - `UploadFile` 对象新增 `uploadTime` 属性，用于表示上传时间 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - `theme=file` 支持多文件上传 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 文件上传前处理函数 `beforeUpload` 存在时，依然支持 `sizeLimit` 检测 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增`beforeAllFilesUpload`，所有文件上传之前执行，支持一次性判定所有文件是否继续上传。已经存在的 `beforeUpload` 用于判定单个文件的是否继续上传 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增事件 `onValidate`，文件校验不通过时触发，可能情况有：自定义全文件校验不通过、文件数量校验不通过、文件数量校验不通过、文件名重复（允许重复文件名场景下不会触发）等 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增事件 `onOneFileSuccess` ，多文件上传场景下，在单个文件上传成功后触发 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增事件 `onOneFileFail` ，多文件上传场景下，在单个文件上传失败后触发 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增 `formatRequest` 用于新增或修改上传请求参数（现有的 `format` 用于格式化文件对象） @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
-    - 新增 `triggerButtonProps` 用于指定文件选择触发按钮风格 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+- `Upload`:
+  - 重构 upload 组件，修复众多问题，支持更多 api
+  - `UploadFile` 对象新增 `uploadTime` 属性，用于表示上传时间 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - `theme=file` 支持多文件上传 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 文件上传前处理函数 `beforeUpload` 存在时，依然支持 `sizeLimit` 检测 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增`beforeAllFilesUpload`，所有文件上传之前执行，支持一次性判定所有文件是否继续上传。已经存在的 `beforeUpload` 用于判定单个文件的是否继续上传 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增事件 `onValidate`，文件校验不通过时触发，可能情况有：自定义全文件校验不通过、文件数量校验不通过、文件数量校验不通过、文件名重复（允许重复文件名场景下不会触发）等 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增事件 `onOneFileSuccess` ，多文件上传场景下，在单个文件上传成功后触发 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增事件 `onOneFileFail` ，多文件上传场景下，在单个文件上传失败后触发 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增 `formatRequest` 用于新增或修改上传请求参数（现有的 `format` 用于格式化文件对象） @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
+  - 新增 `triggerButtonProps` 用于指定文件选择触发按钮风格 @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
 
 ### 🐞 Bug Fixes
+
 - `Dropdown`:
-    - 优化dropdown样式细节 @uyarn ([#1440](https://github.com/Tencent/tdesign-react/pull/1440))
-    - 修复 value 缺失点击异常 @HelKyle ([#1465](https://github.com/Tencent/tdesign-react/pull/1465))
+  - 优化 dropdown 样式细节 @uyarn ([#1440](https://github.com/Tencent/tdesign-react/pull/1440))
+  - 修复 value 缺失点击异常 @HelKyle ([#1465](https://github.com/Tencent/tdesign-react/pull/1465))
 - `RangeInput`: 优化 icon 居中展示的问题 @honkinglin ([#1447](https://github.com/Tencent/tdesign-react/pull/1447))
 - `DatePicker`: 修复 `cellClick` 返回日期错误 @honkinglin ([#1458](https://github.com/Tencent/tdesign-react/pull/1458))
-- `Tabs`: 修复未替换部分classPrefix导致样式异常的问题 @uyarn ([#1476](https://github.com/Tencent/tdesign-react/pull/1476))
+- `Tabs`: 修复未替换部分 classPrefix 导致样式异常的问题 @uyarn ([#1476](https://github.com/Tencent/tdesign-react/pull/1476))
 - `tree`: 修复 `disabled` 下不可展开的问题 @uyarn ([#1474](https://github.com/Tencent/tdesign-react/pull/1474))
 - `Upload`: 修复 `autoUpload=false` 时，没有触发 `onChange` 事件问题（可能存在 breaking change） @chaishi ([#1461](https://github.com/Tencent/tdesign-react/pull/1461))
 - `Popup`: 修复 ref 透传丢失属性问题 @honkinglin ([#1468](https://github.com/Tencent/tdesign-react/pull/1468))
 - `Select`: 修复布尔值选中没有显示对应的文字问题 @samhou1988 ([#1441](https://github.com/Tencent/tdesign-react/pull/1441))
 
+## 🌈 0.40.6 `2022-09-06`
 
-## 🌈 0.40.6 `2022-09-06` 
 ### 🚀 Features
+
 - `Table`:
-    - 树形结构，新增 `getTreeExpandedRow`，用于获取展开的树形节点，[issue#1309](https://github.com/Tencent/tdesign-react/issues/1309) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
-    - 可编辑单元格，`edit.rules` 新增数据类型 `function`，用于动态设置校验规则，[tdesign-vue-next#1472](https://github.com/Tencent/tdesign-vue-next/issues/1472) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
-    - 文本超出省略由 `Popup` 更为 `Tooltip`，方便定义提醒文本主题色，[issue#1369](https://github.com/Tencent/tdesign-react/issues/1369) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
-- `Dropdown`:  
-    - 支持下拉菜单项自定义不同主题 @Isabella327 @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
-    - 支持下拉菜单项向左展开 @uyarn  @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
-    - 优化下拉菜单的样式 @Isabella327 @uyarn  @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
-- `Nofitication`: 插件模式支持config @carolin913 ([#1417](https://github.com/Tencent/tdesign-react/pull/1417))
+  - 树形结构，新增 `getTreeExpandedRow`，用于获取展开的树形节点，[issue#1309](https://github.com/Tencent/tdesign-react/issues/1309) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+  - 可编辑单元格，`edit.rules` 新增数据类型 `function`，用于动态设置校验规则，[tdesign-vue-next#1472](https://github.com/Tencent/tdesign-vue-next/issues/1472) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+  - 文本超出省略由 `Popup` 更为 `Tooltip`，方便定义提醒文本主题色，[issue#1369](https://github.com/Tencent/tdesign-react/issues/1369) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+- `Dropdown`:
+  - 支持下拉菜单项自定义不同主题 @Isabella327 @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
+  - 支持下拉菜单项向左展开 @uyarn @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
+  - 优化下拉菜单的样式 @Isabella327 @uyarn @uyarn ([#1434](https://github.com/Tencent/tdesign-react/pull/1434))
+- `Nofitication`: 插件模式支持 config @carolin913 ([#1417](https://github.com/Tencent/tdesign-react/pull/1417))
 
 ### 🐞 Bug Fixes
-- `InputAdornment`: 修复formItem 包裹 inputAdornment 组件 onChange 冲突问题 @honkinglin ([#1419](https://github.com/Tencent/tdesign-react/pull/1419))
+
+- `InputAdornment`: 修复 formItem 包裹 inputAdornment 组件 onChange 冲突问题 @honkinglin ([#1419](https://github.com/Tencent/tdesign-react/pull/1419))
 - `TimePicker`: 修复边界滚动异常问题 @HelKyle ([#1426](https://github.com/Tencent/tdesign-react/pull/1426))
 - `Cascader`:
-    - 修复 `loadingText` 无效 ([vue-next #1555](https://github.com/Tencent/tdesign-vue-next/issues/1555)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
-    - 修复 `value` 为 `number` 类型时有告警 ([vue-next #1570](https://github.com/Tencent/tdesign-vue-next/issues/1570)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
-    - 修复在输入时 `entry` 键会默认全选第一个选项的全部内容 ([vue-next #1529](https://github.com/Tencent/tdesign-vue-next/issues/1529)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
-    - 修复通过 `SelectInputProps`  透传方法属性导致传入 `SelectInput` 的数据变成的数组 ([vue-next #1502](https://github.com/Tencent/tdesign-vue-next/issues/1502)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
-    - 修复多选状态下点击 `label` 展开子级表现异常 @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
+  - 修复 `loadingText` 无效 ([vue-next #1555](https://github.com/Tencent/tdesign-vue-next/issues/1555)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
+  - 修复 `value` 为 `number` 类型时有告警 ([vue-next #1570](https://github.com/Tencent/tdesign-vue-next/issues/1570)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
+  - 修复在输入时 `entry` 键会默认全选第一个选项的全部内容 ([vue-next #1529](https://github.com/Tencent/tdesign-vue-next/issues/1529)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
+  - 修复通过 `SelectInputProps` 透传方法属性导致传入 `SelectInput` 的数据变成的数组 ([vue-next #1502](https://github.com/Tencent/tdesign-vue-next/issues/1502)) @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
+  - 修复多选状态下点击 `label` 展开子级表现异常 @pengYYYYY ([#1428](https://github.com/Tencent/tdesign-react/pull/1428))
 - `Nofitication`: 修复 classname 透传问题，closebtn/icon 无法支持 bool 设置 @carolin913 ([#1417](https://github.com/Tencent/tdesign-react/pull/1417))
-- `Table`: 
-    - 修复 `editableCellState` 返回值与期望相反问题（Breaking Change） @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
-    - 修复表格部分元素无法随 table 变化而变化，如：空数据，[issue#1319](https://github.com/Tencent/tdesign-react/issues/1319) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
-    - 修复全选时，事件参数`selectedRowData` 为空的问题 @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+- `Table`:
+  - 修复 `editableCellState` 返回值与期望相反问题（Breaking Change） @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+  - 修复表格部分元素无法随 table 变化而变化，如：空数据，[issue#1319](https://github.com/Tencent/tdesign-react/issues/1319) @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
+  - 修复全选时，事件参数`selectedRowData` 为空的问题 @chaishi ([#1420](https://github.com/Tencent/tdesign-react/pull/1420))
 - `Alert`: 修复 close 不支持 function 类型 @carolin913 ([#1433](https://github.com/Tencent/tdesign-react/pull/1433))
 - `Tabs`: 修复 debounce 问题 @HelKyle ([#1424](https://github.com/Tencent/tdesign-react/pull/1424))
 - `TimePicker`: 修复 debounce 问题 @HelKyle ([#1424](https://github.com/Tencent/tdesign-react/pull/1424))
 - `Table`: 修复 debounce 问题 @HelKyle ([#1424](https://github.com/Tencent/tdesign-react/pull/1424))
 - `Popup`: 修复 debounce 问题 @HelKyle ([#1424](https://github.com/Tencent/tdesign-react/pull/1424))
-- `Radio`:  修复 `onChange` 触发两次问题 @Lmmmmmm-bb ([#1422](https://github.com/Tencent/tdesign-react/pull/1422))
-- `Button`: 调整loading状态的样式问题 @uyarn ([#1437](https://github.com/Tencent/tdesign-react/pull/1437))
+- `Radio`: 修复 `onChange` 触发两次问题 @Lmmmmmm-bb ([#1422](https://github.com/Tencent/tdesign-react/pull/1422))
+- `Button`: 调整 loading 状态的样式问题 @uyarn ([#1437](https://github.com/Tencent/tdesign-react/pull/1437))
 - `Form`:
-    - 兼容 FormItem 未定义字段调用 setFields 方法异常场景 @honkinglin ([#1394](https://github.com/Tencent/tdesign-react/pull/1394))
-    - 禁用 input 输入框回车自动提交表单 @honkinglin ([#1403](https://github.com/Tencent/tdesign-react/pull/1403))
+  - 兼容 FormItem 未定义字段调用 setFields 方法异常场景 @honkinglin ([#1394](https://github.com/Tencent/tdesign-react/pull/1394))
+  - 禁用 input 输入框回车自动提交表单 @honkinglin ([#1403](https://github.com/Tencent/tdesign-react/pull/1403))
 - `DatePicker`:
-    - 修复 cell-click 事件失效问题 @honkinglin ([#1399](https://github.com/Tencent/tdesign-react/pull/1399))
-    - 修复传入空字符串导致页面崩溃问题 @honkinglin ([#1418](https://github.com/Tencent/tdesign-react/pull/1418))
+  - 修复 cell-click 事件失效问题 @honkinglin ([#1399](https://github.com/Tencent/tdesign-react/pull/1399))
+  - 修复传入空字符串导致页面崩溃问题 @honkinglin ([#1418](https://github.com/Tencent/tdesign-react/pull/1418))
 - `Message`: 修复更改前缀后插件调用展示异常问题 @kenzyyang ([#1431](https://github.com/Tencent/tdesign-react/pull/1431))
 
+## 🌈 0.40.5 `2022-08-29`
 
-## 🌈 0.40.5 `2022-08-29` 
 ### 🚀 Features
+
 - `Form`: 新增 `useForm` hook 获取 form 实例 & 支持 `initialData` 全局设置初始值 @honkinglin ([#1351](https://github.com/Tencent/tdesign-react/pull/1351))
 - `DatePicker`: 优化不设置 `valueType` 场景下与 `format` 一致 @honkinglin ([#1382](https://github.com/Tencent/tdesign-react/pull/1382))
-- `Dialog`:  非模态对话框优化拖拽事件鼠标表现 @huoyuhao ([#1355](https://github.com/Tencent/tdesign-react/pull/1355))
+- `Dialog`: 非模态对话框优化拖拽事件鼠标表现 @huoyuhao ([#1355](https://github.com/Tencent/tdesign-react/pull/1355))
 - `Transfer`: 支持 `showCheckAll` api @HelKyle ([#1385](https://github.com/Tencent/tdesign-react/pull/1385))
 
 ### 🐞 Bug Fixes
+
 - `InputAdornment`: 修复在 form 组件下 disabled 设置问题 @honkinglin ([#1381](https://github.com/Tencent/tdesign-react/pull/1381))
 - `Slider`: 修复点击 marks 触发 cannot read properties of null 异常 @PBK-B ([#1297](https://github.com/Tencent/tdesign-react/pull/1297))
-- `Upload`: 支持受控使用时`files`可设置为null @uyarn ([#1358](https://github.com/Tencent/tdesign-react/pull/1358))
+- `Upload`: 支持受控使用时`files`可设置为 null @uyarn ([#1358](https://github.com/Tencent/tdesign-react/pull/1358))
 - `Popup`: 修复 popup 显示状态点击页面事件重复触发问题 @honkinglin ([#1371](https://github.com/Tencent/tdesign-react/pull/1371))
 - `Alert`: 增加关闭动画 && 修复 `onClosed` 回调事件 @HelKyle ([#1368](https://github.com/Tencent/tdesign-react/pull/1368))
 - `Select`: option 设置 content 未生效问题 @carolin913 ([#1383](https://github.com/Tencent/tdesign-react/pull/1383))
 - `Table`:
-    - 修复 tree-select 首次渲染出现 key 为 undefined 的问题 @HelKyle ([#1332](https://github.com/Tencent/tdesign-react/pull/1332))
-    - 修复排序按钮的样式问题 @uyarn ([#1384](https://github.com/Tencent/tdesign-react/pull/1384))
-    - 允许在表头分割线一定范围内触发列宽调整逻辑 @ZTao-z ([#1378](https://github.com/Tencent/tdesign-react/pull/1378))
+  - 修复 tree-select 首次渲染出现 key 为 undefined 的问题 @HelKyle ([#1332](https://github.com/Tencent/tdesign-react/pull/1332))
+  - 修复排序按钮的样式问题 @uyarn ([#1384](https://github.com/Tencent/tdesign-react/pull/1384))
+  - 允许在表头分割线一定范围内触发列宽调整逻辑 @ZTao-z ([#1378](https://github.com/Tencent/tdesign-react/pull/1378))
 
-## 🌈 0.40.4 `2022-08-22` 
+## 🌈 0.40.4 `2022-08-22`
+
 ### 🚀 Features
-- `Table`: 
-    - BaseTable 新增组件实例方法 `refreshTable`，用于父组件在特殊场景刷新表格 DOM 信息 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
-    - PrimaryTable 新增 BaseTable 的全部组件实例方法 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
-    - 支持行拖拽排序和列拖拽排序同时存在，[issue#1290](https://github.com/Tencent/tdesign-vue/issues/1290) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
-    - 可编辑单元格/行功能，新增 `editableCellState` 用于控制单元格是否可编辑，([issue#1387](https://github.com/Tencent/tdesign-vue-next/issues/1387)) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
-    - 可编辑单元格/行功能，新增 `edit.defaultEditable` 用于设置初始状态是否为编辑态 @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
-    - 行展开功能，新增事件参数 `currentRowData`，表示当前展开行，[issue#1296](https://github.com/Tencent/tdesign-react/issues/1296) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+
+- `Table`:
+  - BaseTable 新增组件实例方法 `refreshTable`，用于父组件在特殊场景刷新表格 DOM 信息 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
+  - PrimaryTable 新增 BaseTable 的全部组件实例方法 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
+  - 支持行拖拽排序和列拖拽排序同时存在，[issue#1290](https://github.com/Tencent/tdesign-vue/issues/1290) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+  - 可编辑单元格/行功能，新增 `editableCellState` 用于控制单元格是否可编辑，([issue#1387](https://github.com/Tencent/tdesign-vue-next/issues/1387)) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+  - 可编辑单元格/行功能，新增 `edit.defaultEditable` 用于设置初始状态是否为编辑态 @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+  - 行展开功能，新增事件参数 `currentRowData`，表示当前展开行，[issue#1296](https://github.com/Tencent/tdesign-react/issues/1296) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
 - `Dialog`: 新增 `confirmOnEnter` API @huoyuhao ([#1328](https://github.com/Tencent/tdesign-react/pull/1328))
--  `Popup`: 支持 `overlayInnerClassName` api @honkinglin ([#1347](https://github.com/Tencent/tdesign-react/pull/1347))
+- `Popup`: 支持 `overlayInnerClassName` api @honkinglin ([#1347](https://github.com/Tencent/tdesign-react/pull/1347))
 - `Timeline`: 新增 `Timeline` 组件 @southorange1228 ([#1156](https://github.com/Tencent/tdesign-react/pull/1156))
 
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - [吸顶表头，最后一列有 1px 未对齐](https://github.com/Tencent/tdesign-vue-next/issues/1434) @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
-    - 窗口变动时，固定列阴影效果更新 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
-    - 修复可编辑行，联动数据校验问题，([issue#1444](https://github.com/Tencent/tdesign-vue-next/issues/1444)) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
-    - 修复行选中功能，多选，分页数据异步加载，`onSelectChange` 参数 `selectedRowData` 数据不完整问题 @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+  - [吸顶表头，最后一列有 1px 未对齐](https://github.com/Tencent/tdesign-vue-next/issues/1434) @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
+  - 窗口变动时，固定列阴影效果更新 @chaishi ([#1312](https://github.com/Tencent/tdesign-react/pull/1312))
+  - 修复可编辑行，联动数据校验问题，([issue#1444](https://github.com/Tencent/tdesign-vue-next/issues/1444)) @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
+  - 修复行选中功能，多选，分页数据异步加载，`onSelectChange` 参数 `selectedRowData` 数据不完整问题 @chaishi ([#1341](https://github.com/Tencent/tdesign-react/pull/1341))
 - `Textarea`:
-    - 修复 `maxlength` safari 浏览器兼容性问题 @carolin913 ([#1324]
-    - 修复 `maxcharactor` 设置后中文拼音无法输入问题 @carolin913 ([#1324](https://github.com/Tencent/tdesign-react/pull/1324))
-    - 修复出现在 dialog 无法 autosize 问题 @carolin913 ([#1324](https://github.com/Tencent/tdesign-react/pull/1324))
-    - 修正 emoji 字符长度计算 @HelKyle ([#1331](https://github.com/Tencent/tdesign-react/pull/1331))
+  - 修复 `maxlength` safari 浏览器兼容性问题 @carolin913 ([#1324]
+  - 修复 `maxcharactor` 设置后中文拼音无法输入问题 @carolin913 ([#1324](https://github.com/Tencent/tdesign-react/pull/1324))
+  - 修复出现在 dialog 无法 autosize 问题 @carolin913 ([#1324](https://github.com/Tencent/tdesign-react/pull/1324))
+  - 修正 emoji 字符长度计算 @HelKyle ([#1331](https://github.com/Tencent/tdesign-react/pull/1331))
 - `Cascader`: 修复 `value` 不是 options 的健值会报错 ([issue #1293](https://github.com/Tencent/tdesign-react/issues/1293)) @pengYYYYY ([#1342](https://github.com/Tencent/tdesign-react/pull/1342))
-- `select`: 调整loading态显示优先于empty属性 @skytt ([#1343](https://github.com/Tencent/tdesign-react/pull/1343))
+- `select`: 调整 loading 态显示优先于 empty 属性 @skytt ([#1343](https://github.com/Tencent/tdesign-react/pull/1343))
 - `Input`: 修正 emoji 字符长度计算 @HelKyle ([#1331](https://github.com/Tencent/tdesign-react/pull/1331))
 
 ### 🚧 Others
+
 - `Link`: 完善组件单元测试 @sommouns ([#1339](https://github.com/Tencent/tdesign-react/pull/1339))
 - `Space`: 完善组件单元测试 @StephenArk30 ([#1337](https://github.com/Tencent/tdesign-react/pull/1337))
 - `Steps`: 完善组件单元测试 @insekkei ([#1317](https://github.com/Tencent/tdesign-react/pull/1317))
 - `Radio`: 完善组件单元测试 @Skyenought ([#1334](https://github.com/Tencent/tdesign-react/pull/1334))
 
-## 🌈 0.40.3 `2022-08-17` 
+## 🌈 0.40.3 `2022-08-17`
+
 ### 🐞 Bug Fixes
-- `Message`:  修复 `message` 主题设置失效 @kenzyyang ([#1310](https://github.com/Tencent/tdesign-react/pull/1310))
+
+- `Message`: 修复 `message` 主题设置失效 @kenzyyang ([#1310](https://github.com/Tencent/tdesign-react/pull/1310))
 - `Tooltip`: 修复 `tooltip` 主题失效 @honkinglin ([#749](https://github.com/Tencent/tdesign-common/pull/749))
 
-## 🌈 0.40.2 `2022-08-16` 
+## 🌈 0.40.2 `2022-08-16`
+
 ### 🐞 Bug Fixes
-- `DatePicker`: 
-    - 修复点击空白区域输入框被清空问题 @honkinglin ([#1306](https://github.com/Tencent/tdesign-react/pull/1306))
-    - 修复 safari 下周选择器样式问题 @honkinglin ([#742](https://github.com/Tencent/tdesign-common/pull/742/files))
 
-## 🌈 0.40.1 `2022-08-16` 
+- `DatePicker`:
+  - 修复点击空白区域输入框被清空问题 @honkinglin ([#1306](https://github.com/Tencent/tdesign-react/pull/1306))
+  - 修复 safari 下周选择器样式问题 @honkinglin ([#742](https://github.com/Tencent/tdesign-common/pull/742/files))
+
+## 🌈 0.40.1 `2022-08-16`
+
 ### 🐞 Bug Fixes
-- `DatePicker`:  修复在左侧输入框聚焦时右侧面板切换月份失效问题 @honkinglin ([#1292](https://github.com/Tencent/tdesign-react/pull/1292))
-- `Form`:  修复 FormItem status 受控问题 @honkinglin ([#1298](https://github.com/Tencent/tdesign-react/pull/1298))
-- `Radio`:  修复 `Radio.Group` 反选问题 @carolin913 ([#1304](https://github.com/Tencent/tdesign-react/pull/1304))
-- `Dropdown`:  
-    - 修复 `DropdownMenu` 属性透传问题 @carolin913 ([#1304](https://github.com/Tencent/tdesign-react/pull/1304))
-    - 修复下拉菜单展开位置的异常 @uyarn ([#1300](https://github.com/Tencent/tdesign-react/pull/1300))
 
+- `DatePicker`: 修复在左侧输入框聚焦时右侧面板切换月份失效问题 @honkinglin ([#1292](https://github.com/Tencent/tdesign-react/pull/1292))
+- `Form`: 修复 FormItem status 受控问题 @honkinglin ([#1298](https://github.com/Tencent/tdesign-react/pull/1298))
+- `Radio`: 修复 `Radio.Group` 反选问题 @carolin913 ([#1304](https://github.com/Tencent/tdesign-react/pull/1304))
+- `Dropdown`:
+  - 修复 `DropdownMenu` 属性透传问题 @carolin913 ([#1304](https://github.com/Tencent/tdesign-react/pull/1304))
+  - 修复下拉菜单展开位置的异常 @uyarn ([#1300](https://github.com/Tencent/tdesign-react/pull/1300))
 
-## 🌈 0.40.0 `2022-08-15` 
+## 🌈 0.40.0 `2022-08-15`
+
 ### 🚨 Breaking Changes
-- `Popup` : 重构了该组件，修复了较多问题 @honkinglin ([#1256](https://github.com/Tencent/tdesign-react/pull/1256)):  
-    - 不再生成 div 节点包裹 trigger 元素，`className`、`style` 属性废弃，可自行包裹 div 节点调整 `className`、`style` 属性。
-    - `overlayStyle` 调整为控制 `t-popup` 层级，新增 `overlayInnerStyle` 控制 `t-popup__content` 层级与原先 `overlayStyle` 效果一致。
-    - `overlayClassName` 调整为控制 `t-popup` 层级。
+
+- `Popup` : 重构了该组件，修复了较多问题 @honkinglin ([#1256](https://github.com/Tencent/tdesign-react/pull/1256)):
+  - 不再生成 div 节点包裹 trigger 元素，`className`、`style` 属性废弃，可自行包裹 div 节点调整 `className`、`style` 属性。
+  - `overlayStyle` 调整为控制 `t-popup` 层级，新增 `overlayInnerStyle` 控制 `t-popup__content` 层级与原先 `overlayStyle` 效果一致。
+  - `overlayClassName` 调整为控制 `t-popup` 层级。
 
 ### 🚀 Features
-- `Image`:  新增 `Image` 组件 @insekkei ([#1209](https://github.com/Tencent/tdesign-react/pull/1209))
-- `Link`:  新增 `Link` 组件 @zFitness ([#1277](https://github.com/Tencent/tdesign-react/pull/1277))
+
+- `Image`: 新增 `Image` 组件 @insekkei ([#1209](https://github.com/Tencent/tdesign-react/pull/1209))
+- `Link`: 新增 `Link` 组件 @zFitness ([#1277](https://github.com/Tencent/tdesign-react/pull/1277))
 - `Table`:
-    - 支持使用插槽 `footer-summary` 定义通栏表尾，同时支持同名属性 Props `footer-summary` 渲染通栏表尾 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 由于表格支持定义多行表尾，因而本次支持使用 `rowspanAndColspanInFooter` 定义表尾行数据合并单元格，使用方法同 `rowspanAndColspan` @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 支持 `min-width` 透传到元素 `<col>` @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    -  新增 `cellEmptyContent`，当列数据为空时显示指定值 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 可编辑行功能，新增实例方法 `validate`，支持校验表格内的全部数据 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-- `DatePicker`: 
-    - 支持季度国际化配置 @honkinglin ([#1261](https://github.com/Tencent/tdesign-react/pull/1261))
-    - 支持滚动年份选择器自动加载更多年份 @honkinglin ([#1263](https://github.com/Tencent/tdesign-react/pull/1263))
-- `InputNumber`:  重构组件，支持16 位大数字 @honkinglin ([#1266](https://github.com/Tencent/tdesign-react/pull/1266))
+  - 支持使用插槽 `footer-summary` 定义通栏表尾，同时支持同名属性 Props `footer-summary` 渲染通栏表尾 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 由于表格支持定义多行表尾，因而本次支持使用 `rowspanAndColspanInFooter` 定义表尾行数据合并单元格，使用方法同 `rowspanAndColspan` @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 支持 `min-width` 透传到元素 `<col>` @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 新增 `cellEmptyContent`，当列数据为空时显示指定值 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 可编辑行功能，新增实例方法 `validate`，支持校验表格内的全部数据 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+- `DatePicker`:
+  - 支持季度国际化配置 @honkinglin ([#1261](https://github.com/Tencent/tdesign-react/pull/1261))
+  - 支持滚动年份选择器自动加载更多年份 @honkinglin ([#1263](https://github.com/Tencent/tdesign-react/pull/1263))
+- `InputNumber`: 重构组件，支持 16 位大数字 @honkinglin ([#1266](https://github.com/Tencent/tdesign-react/pull/1266))
 - `Icon`: 新增 qq、wechat、wecom、relativity 和 pin-filled 等图标 @uyarn ([#1289](https://github.com/Tencent/tdesign-react/pull/1289))
-- `Message`:  支持 `config` api @kenzyyang ([#1239](https://github.com/Tencent/tdesign-react/pull/1239))
-- `Form`:  `FormItem` 支持 `status`、`tips` 自定义控制校验状态及提示信息 @honkinglin ([#1288](https://github.com/Tencent/tdesign-react/pull/1288))
+- `Message`: 支持 `config` api @kenzyyang ([#1239](https://github.com/Tencent/tdesign-react/pull/1239))
+- `Form`: `FormItem` 支持 `status`、`tips` 自定义控制校验状态及提示信息 @honkinglin ([#1288](https://github.com/Tencent/tdesign-react/pull/1288))
 
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - 行选中会触发重置列宽调整的结果 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 可编辑行功能，提交校验时只校验了第一列 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 列配置功能，带边框模式，移除分页组件边框下方多余的边框 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
-    - 列宽度和小于表宽的情况下，调整列宽的结果与预期不符 @ZTao-z ([#1284](https://github.com/Tencent/tdesign-react/pull/1284))
-- `Progress`: 修复`progress` style属性失效的问题 @NWYLZW ([#1260](https://github.com/Tencent/tdesign-react/pull/1260))
+  - 行选中会触发重置列宽调整的结果 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 可编辑行功能，提交校验时只校验了第一列 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 列配置功能，带边框模式，移除分页组件边框下方多余的边框 @chaishi ([#1259](https://github.com/Tencent/tdesign-react/pull/1259))
+  - 列宽度和小于表宽的情况下，调整列宽的结果与预期不符 @ZTao-z ([#1284](https://github.com/Tencent/tdesign-react/pull/1284))
+- `Progress`: 修复`progress` style 属性失效的问题 @NWYLZW ([#1260](https://github.com/Tencent/tdesign-react/pull/1260))
 - `Cascader`: 修复点击清除按钮无法一次性清空所有选项 ([issue #1236](https://github.com/Tencent/tdesign-react/issues/1236)) @pengYYYYY ([#1275](https://github.com/Tencent/tdesign-react/pull/1275))
-- `Select`: 修复autoWidth在multiple模式下失效的问题 @uyarn ([#1279](https://github.com/Tencent/tdesign-react/pull/1279))
+- `Select`: 修复 autoWidth 在 multiple 模式下失效的问题 @uyarn ([#1279](https://github.com/Tencent/tdesign-react/pull/1279))
 - `Tabs`: 修复动态渲染 `panel` 下划线丢失问题 @NWYLZW ([#1258](https://github.com/Tencent/tdesign-react/pull/1258))
-- `Layout`:  修复 `width`、`height` 不生效问题 @southorange1228 ([#1287](https://github.com/Tencent/tdesign-react/pull/1287))
+- `Layout`: 修复 `width`、`height` 不生效问题 @southorange1228 ([#1287](https://github.com/Tencent/tdesign-react/pull/1287))
 - `Popup`: 修复函数组件未透传 ref 导致气泡失效问题 @honkinglin ([#1256](https://github.com/Tencent/tdesign-react/pull/1256))
 
+## 🌈 0.39.0 `2022-08-08`
 
-## 🌈 0.39.0 `2022-08-08` 
 ### 🚨 Breaking Changes
+
 - `Pagination`: 调整快速跳转样式，`simple` 主题下合并分页控制器与快速跳转控制器 @honkinglin ([#1242](https://github.com/Tencent/tdesign-react/pull/1242))
-- `Tooltip`: 调整 `theme` 主题文字颜色和背景色  @honkinglin([#703](https://github.com/Tencent/tdesign-common/pull/703))
+- `Tooltip`: 调整 `theme` 主题文字颜色和背景色 @honkinglin([#703](https://github.com/Tencent/tdesign-common/pull/703))
 
 ### 🚀 Features
-- 新增字体相关CSS Token，支持通过CSS Token修改字体相关配置 具体请参考 [font tokens](https://github.com/Tencent/tdesign-common/blob/develop/style/web/theme/_font.less)
+
+- 新增字体相关 CSS Token，支持通过 CSS Token 修改字体相关配置 具体请参考 [font tokens](https://github.com/Tencent/tdesign-common/blob/develop/style/web/theme/_font.less)
 - 主题生成器: 支持字体相关配置
 - `Icon`: 优化全局 `Icon` 属性类型 @uyarn ([#1219](https://github.com/Tencent/tdesign-react/pull/1219))
 - `form`: `setFields` 支持 `validateMessage` 参数 @honkinglin ([#1226](https://github.com/Tencent/tdesign-react/pull/1226))
-- `ImageViewer`: 新增ImageViewer组件 @Ylushen ([#954](https://github.com/Tencent/tdesign-react/pull/954))
+- `ImageViewer`: 新增 ImageViewer 组件 @Ylushen ([#954](https://github.com/Tencent/tdesign-react/pull/954))
 - `Rate`: 支持 `icon` 属性 @honkinglin ([#1211](https://github.com/Tencent/tdesign-react/pull/1211))
 - `Popup`: 优化内容为空时不展示气泡 @southorange1228 ([#1222](https://github.com/Tencent/tdesign-react/pull/1222))
 - `ColorPicker`: 面板 ui 优化 @insekkei ([#1048](https://github.com/Tencent/tdesign-react/pull/1048))
 
 ### 🐞 Bug Fixes
-- `Table`: 
-    - 多级表头场景下，修复表尾信息不对齐问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
-    - 树形结构，修复某些场景下无法完全重置数据的问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
-    - 树形结构，修复懒加载节点重置时（即调用 setData）没有清空子节点信息问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
-    - 树形结构，展开全部功能，不应该展开懒加载节点 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
-    - 修复吸顶的多级表头，缺少左侧边线问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
-    - 行内有多条规则时，只生效第一条规则 @yatessss ([#1244](https://github.com/Tencent/tdesign-react/pull/1244))
+
+- `Table`:
+  - 多级表头场景下，修复表尾信息不对齐问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
+  - 树形结构，修复某些场景下无法完全重置数据的问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
+  - 树形结构，修复懒加载节点重置时（即调用 setData）没有清空子节点信息问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
+  - 树形结构，展开全部功能，不应该展开懒加载节点 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
+  - 修复吸顶的多级表头，缺少左侧边线问题 @chaishi ([#1207](https://github.com/Tencent/tdesign-react/pull/1207))
+  - 行内有多条规则时，只生效第一条规则 @yatessss ([#1244](https://github.com/Tencent/tdesign-react/pull/1244))
 - `DatePicker`:
-    - 修复年份范围和面板年份不一致问题 @CodingOnStar ([#1218](https://github.com/Tencent/tdesign-react/pull/1218))
-    - 修复面板初始化月份问题 @honkinglin ([#1225](https://github.com/Tencent/tdesign-react/pull/1225))
+  - 修复年份范围和面板年份不一致问题 @CodingOnStar ([#1218](https://github.com/Tencent/tdesign-react/pull/1218))
+  - 修复面板初始化月份问题 @honkinglin ([#1225](https://github.com/Tencent/tdesign-react/pull/1225))
 - `Jumper`: 修复 `onChange` 报错问题 @southorange1228 ([#1224](https://github.com/Tencent/tdesign-react/pull/1224))
 - `Upload`: 修复 `onRemove` 失效问题 @honkinglin ([#1245](https://github.com/Tencent/tdesign-react/pull/1245))
-- `tooltip`: disable状态及popup为trigger时不响应问题 @carolin913 ([#1203](https://github.com/Tencent/tdesign-react/pull/1203))
+- `tooltip`: disable 状态及 popup 为 trigger 时不响应问题 @carolin913 ([#1203](https://github.com/Tencent/tdesign-react/pull/1203))
 
-
-## 🌈 0.38.0 `2022-08-01` 
+## 🌈 0.38.0 `2022-08-01`
 
 ### 🚨 Breaking Changes
+
 - 调整全局 `border-radius` token，`@border-radius` 改名为 `@border-radius-default`，支持更多圆角 token。 使用 esm 包修改 less token 的业务需要注意。 @mingrutough1 (https://github.com/Tencent/tdesign-common/pull/666) (https://github.com/Tencent/tdesign-common/pull/648)
 
 ### 🚀 Features
+
 - 支持全局替换 `tdesign` 内置 `Icon` @honkinglin ([#1181](https://github.com/Tencent/tdesign-react/pull/1181))
 - `DatePicker`: 支持季度选择器 @honkinglin ([#1178](https://github.com/Tencent/tdesign-react/pull/1178))
-- `Rate`: 新增 rate组件 @RedDevi1s ([#1014](https://github.com/Tencent/tdesign-react/pull/1014)) @honkinglin ([#1195](https://github.com/Tencent/tdesign-react/pull/1195))
-- `Select`:  展开面板后二次点击输入框调整为关闭面板 @honkinglin ([#1174](https://github.com/Tencent/tdesign-react/pull/1174))
-- `Grid`:  `col` 组件支持跨层级响应 `gutter` 配置 @honkinglin ([#1171](https://github.com/Tencent/tdesign-react/pull/1171))
+- `Rate`: 新增 rate 组件 @RedDevi1s ([#1014](https://github.com/Tencent/tdesign-react/pull/1014)) @honkinglin ([#1195](https://github.com/Tencent/tdesign-react/pull/1195))
+- `Select`: 展开面板后二次点击输入框调整为关闭面板 @honkinglin ([#1174](https://github.com/Tencent/tdesign-react/pull/1174))
+- `Grid`: `col` 组件支持跨层级响应 `gutter` 配置 @honkinglin ([#1171](https://github.com/Tencent/tdesign-react/pull/1171))
 
 ### 🐞 Bug Fixes
+
 - `Cascader`: 修复在异步获取 `option` 的情况下，参数校验导致用户行为异常 @pengYYYYY ([#1170](https://github.com/Tencent/tdesign-react/pull/1170))
 - `Select`: 修复回删空字符串不触发`onSearch`的缺陷 @uyarn ([#1176](https://github.com/Tencent/tdesign-react/pull/1176))
 - `Select`: 修复过滤时输入值为空未显示全部选项的问题 @southorange1228 ([#1157](https://github.com/Tencent/tdesign-react/pull/1157))
-- `Dropdown`:  修复 className 继承问题 @CodingOnStar ([#1187](https://github.com/Tencent/tdesign-react/pull/1187))
-- `Tree`:  修复更改 data 数据后展开状态丢失问题 @CodingOnStar ([#1168](https://github.com/Tencent/tdesign-react/pull/1168))
+- `Dropdown`: 修复 className 继承问题 @CodingOnStar ([#1187](https://github.com/Tencent/tdesign-react/pull/1187))
+- `Tree`: 修复更改 data 数据后展开状态丢失问题 @CodingOnStar ([#1168](https://github.com/Tencent/tdesign-react/pull/1168))
 
+## 🌈 0.37.1 `2022-07-25`
 
-## 🌈 0.37.1 `2022-07-25` 
 ### 🚀 Features
+
 - `Upload`: 支持单组件的文案配置 @uyarn ([#1158](https://github.com/Tencent/tdesign-react/pull/1158))
 - `DatePicker`: 支持周选择器 @honkinglin ([#1138](https://github.com/Tencent/tdesign-react/pull/1138))
 - `Chekbox`: 优化 label 为空字符串不渲染节点 @Blackn-L ([#1131](https://github.com/Tencent/tdesign-react/pull/1131))
-- 支持通过CSS Token配置组件圆角 @mingrutough1 ([common#648](https://github.com/Tencent/tdesign-common/pull/648))
+- 支持通过 CSS Token 配置组件圆角 @mingrutough1 ([common#648](https://github.com/Tencent/tdesign-common/pull/648))
 
 ### 🐞 Bug Fixes
+
 - `Form`: 修复 form 数字字符串长度校验错误问题 @honkinglin ([#1129](https://github.com/Tencent/tdesign-react/pull/1129))
 - `List`: 修复 ListItem 透传 style 问题 @honkinglin ([#1161](https://github.com/Tencent/tdesign-react/pull/1161))
 - `DatePicker`: 修复重置日期后面板月份未重置问题 @honkinglin ([#1133](https://github.com/Tencent/tdesign-react/pull/1133))
-- `ColorPicker`:  修复添加颜色受控/非受控不能点击的问题 @insekkei ([#1134](https://github.com/Tencent/tdesign-react/pull/1134))
+- `ColorPicker`: 修复添加颜色受控/非受控不能点击的问题 @insekkei ([#1134](https://github.com/Tencent/tdesign-react/pull/1134))
 
-
-## 🌈 0.37.0 `2022-07-18` 
+## 🌈 0.37.0 `2022-07-18`
 
 ### 🚨 Breaking Changes
-- `DatePicker`: 调整组件dom 节点 class 命名 @honkinglin ([#1101](https://github.com/Tencent/tdesign-react/pull/1101))
+
+- `DatePicker`: 调整组件 dom 节点 class 命名 @honkinglin ([#1101](https://github.com/Tencent/tdesign-react/pull/1101))
 
 ### 🚀 Features
+
 - `Icon`: 新增`mirror`和`rotation`图标 @uyarn ([#1075](https://github.com/Tencent/tdesign-react/pull/1075))
 - `DatePicker`: 支持面板年月动态响应 value 变化 @honkinglin ([#1077](https://github.com/Tencent/tdesign-react/pull/1077))
 - `Form`: form 支持同步获取最新数据 @honkinglin ([#1081](https://github.com/Tencent/tdesign-react/pull/1081))
-- `table`: 树形结构，支持同时添加多个根节点 @chaishi ([#1099](https://github.com/Tencent/tdesign-react/pull/1099))
-- `table`: 可编辑单元格/可编辑行，新增 `showEditIcon`，用于控制是否显示编辑图标 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
-- `table`: 新增可编辑行的表格 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
-- `table`: 可调整列宽，无边框表格，悬浮到表头时显示边框，方便用户寻找调整列宽的位置 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Table`: 树形结构，支持同时添加多个根节点 @chaishi ([#1099](https://github.com/Tencent/tdesign-react/pull/1099))
+- `Table`: 可编辑单元格/可编辑行，新增 `showEditIcon`，用于控制是否显示编辑图标 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Table`: 新增可编辑行的表格 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Table`: 可调整列宽，无边框表格，悬浮到表头时显示边框，方便用户寻找调整列宽的位置 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
 - `Button`: 支持 href、tag、suffix API @honkinglin ([#1120](https://github.com/Tencent/tdesign-react/pull/1120))
 
 ### 🐞 Bug Fixes
-- `Icon`: 修复iconfont高级用法由于t-icon的干扰导致渲染异常的情况 @uyarn ([#1075](https://github.com/Tencent/tdesign-react/pull/1075))
-- `table`: 修复可选中行table组件，data为空数据时，默认全选按钮会选中的问题 @qdzhaoxiaodao ([#1061](https://github.com/Tencent/tdesign-react/pull/1061))
-- `table`: 列宽拖拽调整到边界时无法重新调整 @chaishi ([#1086](https://github.com/Tencent/tdesign-react/pull/1086))
-- `table`: 多级表头场景下的列配置，无法全选 @chaishi ([#1086](https://github.com/Tencent/tdesign-react/pull/1086))
+
+- `Icon`: 修复 iconfont 高级用法由于 t-icon 的干扰导致渲染异常的情况 @uyarn ([#1075](https://github.com/Tencent/tdesign-react/pull/1075))
+- `Table`: 修复可选中行 table 组件，data 为空数据时，默认全选按钮会选中的问题 @qdzhaoxiaodao ([#1061](https://github.com/Tencent/tdesign-react/pull/1061))
+- `Table`: 列宽拖拽调整到边界时无法重新调整 @chaishi ([#1086](https://github.com/Tencent/tdesign-react/pull/1086))
+- `Table`: 多级表头场景下的列配置，无法全选 @chaishi ([#1086](https://github.com/Tencent/tdesign-react/pull/1086))
 - `Pagination`: 修复左右切换禁用失效问题 @honkinglin ([#1089](https://github.com/Tencent/tdesign-react/pull/1089))
-- `table`: 修复树形结构，懒加载顺序问题 @chaishi ([#1097](https://github.com/Tencent/tdesign-react/pull/1097))
-- `TagInput`: 修复hover时组件换行的样式异常 @uyarn ([#1118](https://github.com/Tencent/tdesign-react/pull/1118))
+- `Table`: 修复树形结构，懒加载顺序问题 @chaishi ([#1097](https://github.com/Tencent/tdesign-react/pull/1097))
+- `TagInput`: 修复 hover 时组件换行的样式异常 @uyarn ([#1118](https://github.com/Tencent/tdesign-react/pull/1118))
 - `drawer`: 修复开启 destroyOnClose 时多次打开关闭时动效丢失问题 @LittlehorseXie ([#1119](https://github.com/Tencent/tdesign-react/pull/1119))
-- `table`: 可编辑单元格，修复无法透传 ReactNode 属性到组件 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
-- `table`: 可编辑单元格，修复 `onEnter` 无法触发 `onEdited` 问题，[issue#1084](https://github.com/Tencent/tdesign-react/issues/1084) @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
-- `table`: 可编辑单元格，一旦校验不通过，后续编辑无法退出编辑态问题，[issue#1106](https://github.com/Tencent/tdesign-react/issues/1106) @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
-- `card`: card component header render issues @weikee94 ([#1125](https://github.com/Tencent/tdesign-react/pull/1125))
-- `Select`:  修复手动控制 popupVisible 展示空白内容 @samhou1988 ([#1105](https://github.com/Tencent/tdesign-react/pull/1105))
--  `ColorPicker`: 修复切换渐变节点 hue 饱和度未更新的问题 @insekkei ([#1121](https://github.com/Tencent/tdesign-react/pull/1121))
+- `Table`: 可编辑单元格，修复无法透传 ReactNode 属性到组件 @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Table`: 可编辑单元格，修复 `onEnter` 无法触发 `onEdited` 问题，[issue#1084](https://github.com/Tencent/tdesign-react/issues/1084) @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Table`: 可编辑单元格，一旦校验不通过，后续编辑无法退出编辑态问题，[issue#1106](https://github.com/Tencent/tdesign-react/issues/1106) @chaishi ([#1108](https://github.com/Tencent/tdesign-react/pull/1108))
+- `Card`: card component header render issues @weikee94 ([#1125](https://github.com/Tencent/tdesign-react/pull/1125))
+- `Select`: 修复手动控制 popupVisible 展示空白内容 @samhou1988 ([#1105](https://github.com/Tencent/tdesign-react/pull/1105))
+- `ColorPicker`: 修复切换渐变节点 hue 饱和度未更新的问题 @insekkei ([#1121](https://github.com/Tencent/tdesign-react/pull/1121))
 - `Form`: 修复 React 18 useEffect 触发两次导致表单自动校验问题 @honkinglin ([#1076](https://github.com/Tencent/tdesign-react/pull/1076))
 - `Form`: 修复 rule min max 不支持数组校验 @honkinglin ([#1127](https://github.com/Tencent/tdesign-react/pull/1127))
 
+## 🌈 0.36.4 `2022-07-11`
 
-## 🌈 0.36.4 `2022-07-11` 
 ### 🚀 Features
+
 - `Table`: 树形结构，支持懒加载 @chaishi ([#1046](https://github.com/Tencent/tdesign-react/pull/1046))
 - `CascaderPanel`: 增加 `cascader-panel` 组件 @pengYYYYY ([#1045](https://github.com/Tencent/tdesign-react/pull/1045))
 - `Cascader`: 增加 `inputProps`, ` tagInputProps`, `tagProps` 属性 @pengYYYYY ([#1045](https://github.com/Tencent/tdesign-react/pull/1045))
 - `Dialog`: 修复打开对话框，出现滚动条([#1163](https://github.com/Tencent/tdesign-vue-next/issues/1163)) @pengYYYYY ([#1045](https://github.com/Tencent/tdesign-react/pull/1045))
-- `Form`: 支持 formList 初始化渲染initialData 数据 @honkinglin ([#1058](https://github.com/Tencent/tdesign-react/pull/1058))
+- `Form`: 支持 formList 初始化渲染 initialData 数据 @honkinglin ([#1058](https://github.com/Tencent/tdesign-react/pull/1058))
 - `Drawer`: 新增`sizeDraggable` 支持通过拖拽改变抽屉宽度/高度 @uyarn ([#1059](https://github.com/Tencent/tdesign-react/pull/1059))
 - `TimePicker`: 支持毫秒场景使用 @uyarn ([#1069](https://github.com/Tencent/tdesign-react/pull/1069))
 
 ### 🐞 Bug Fixes
+
 - `Table`: 可编辑功能，值为 `null` 时会导致页面报错，如清除 Select 数据，[issue#1043](https://github.com/Tencent/tdesign-react/issues/1043)，[dac72dfd](https://github.com/Tencent/tdesign-react/pull/1046/commits/dac72dfd58c47ec46cfa7d00e9ae13365c81edfa) @chaishi ([#1046](https://github.com/Tencent/tdesign-react/pull/1046))
 - `Dialog`: 修复 dialog 阻止冒泡导致 popup 无法正常关闭 @honkinglin ([#1057](https://github.com/Tencent/tdesign-react/pull/1057))
 - `Input`: 修复在 dialog 内中文输入导致光标定位错误问题 @honkinglin ([#1066](https://github.com/Tencent/tdesign-react/pull/1066))
 - `Button`: 修复渲染空字符串样式问题 @honkinglin ([#1063](https://github.com/Tencent/tdesign-react/pull/1063))
 - `Form`: 修复 getFieldsValue 类型定义 @zousandian ([#1020](https://github.com/Tencent/tdesign-react/pull/1020))
 
-## 🌈 0.36.3 `2022-07-05` 
+## 🌈 0.36.3 `2022-07-05`
 
 ### 🚀 Features
+
 - `TimePicker`: 优化可输入改动时的体验 @honkinglin ([#1040](https://github.com/Tencent/tdesign-react/pull/1040))
 - `DatePicker`: 新增 `panelPreselection` api @honkinglin ([#1040](https://github.com/Tencent/tdesign-react/pull/1040))
 
 ### 🐞 Bug Fixes
-- `Select`: 修复多选模式filter失效的问题 @uyarn ([#1039](https://github.com/Tencent/tdesign-react/pull/1039))
-- `Space`: 更改Space组件children属性为React.ReactNode @vikeychen ([#1042](https://github.com/Tencent/tdesign-react/pull/1042))
+
+- `Select`: 修复多选模式 filter 失效的问题 @uyarn ([#1039](https://github.com/Tencent/tdesign-react/pull/1039))
+- `Space`: 更改 Space 组件 children 属性为 React.ReactNode @vikeychen ([#1042](https://github.com/Tencent/tdesign-react/pull/1042))
 - `DatePicker`: 修复左右切换面板时间跳动问题 @honkinglin ([#1040](https://github.com/Tencent/tdesign-react/pull/1040))
 - `DatePicker`: 修复输入框更改时间异常问题 @honkinglin ([#1040](https://github.com/Tencent/tdesign-react/pull/1040))
 
+## 🌈 0.36.2 `2022-07-04`
 
-## 🌈 0.36.2 `2022-07-04` 
 ### 🚀 Features
+
 - `Form`: 添加内置校验方法 whitespace @pengYYYYY ([#1011](https://github.com/Tencent/tdesign-react/pull/1011))
 - `Table`: 新增 `indeterminateSelectedRowKeys` ，用于控制选中行半选状态 @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
 - `Table`: 可编辑单元格，支持编辑组件联动， [issue#995](https://github.com/Tencent/tdesign-react/issues/995) @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
 - `Table`: 树形结构行选中，支持中层节点半选状态，[issue#996](https://github.com/Tencent/tdesign-react/issues/996)，[issue#1004](https://github.com/Tencent/tdesign-react/issues/1004) @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
 - `Table`: EnhancedTable 新增对外实例对象 `treeDataMap` @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
-- `Cascader`: 增加 `popupVisible, readonly, selectInputProps, onPopupVisibleChange` 属性，具体描述查看文档  @pengYYYYY ([#990](https://github.com/Tencent/tdesign-react/pull/990))
+- `Cascader`: 增加 `popupVisible, readonly, selectInputProps, onPopupVisibleChange` 属性，具体描述查看文档 @pengYYYYY ([#990](https://github.com/Tencent/tdesign-react/pull/990))
 - `Jumper`: 新增 jumper 组件 @honkinglin ([#998](https://github.com/Tencent/tdesign-react/pull/998))
-- `Space`:  优化空元素渲染 @zFitness ([#1009](https://github.com/Tencent/tdesign-react/pull/1009))
+- `Space`: 优化空元素渲染 @zFitness ([#1009](https://github.com/Tencent/tdesign-react/pull/1009))
 - `Cascader`: 基于 `select-input` 重构, 文本过长省略使用原生 title 展示全文本，不再使用 `tooltip` 组件。 @pengYYYYY ([#990](https://github.com/Tencent/tdesign-react/pull/990))
 
 ### 🐞 Bug Fixes
-- `table`: 表头吸顶显示问题 @chaishi ([#1003](https://github.com/Tencent/tdesign-react/pull/1003))
-- `table`: `paginationAffixedBottom` 支持配置 Affix 组件全部特性 @chaishi ([#1003](https://github.com/Tencent/tdesign-react/pull/1003))
-- `treeselect`:  默认lazy异步加载开启，与api保持一致 @carolin913 ([#1017](https://github.com/Tencent/tdesign-react/pull/1017))
+
+- `Table`: 表头吸顶显示问题 @chaishi ([#1003](https://github.com/Tencent/tdesign-react/pull/1003))
+- `Table`: `paginationAffixedBottom` 支持配置 Affix 组件全部特性 @chaishi ([#1003](https://github.com/Tencent/tdesign-react/pull/1003))
+- `Treeselect`: 默认 lazy 异步加载开启，与 api 保持一致 @carolin913 ([#1017](https://github.com/Tencent/tdesign-react/pull/1017))
 - `DatePicker`: 修复 presetsPlacement 不生效的问题 @honkinglin ([#1013](https://github.com/Tencent/tdesign-react/pull/1013))
 - `Tree`: 优化 tree 组件的类型问题 @honkinglin ([#1006](https://github.com/Tencent/tdesign-react/pull/1006))
-- `colorpicker`: 修复最近使用颜色的功能 @LittlehorseXie ([#1019](https://github.com/Tencent/tdesign-react/pull/1019))
+- `ColorPicker`: 修复最近使用颜色的功能 @LittlehorseXie ([#1019](https://github.com/Tencent/tdesign-react/pull/1019))
 - `Table`: 树形结构行选中，没有配置 `tree`，则当作普通表格行选中处理，[issue#1001](https://github.com/Tencent/tdesign-react/issues/1001) @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
 - `Table`: 修复树形数据表格，选中子节点时，会导致父节点自动折叠问题，[issue#999](https://github.com/Tencent/tdesign-react/issues/999)，[871f42f6](https://github.com/Tencent/tdesign-react/pull/1028/commits/871f42f6a85f21e4bd0f2887e762021a188d28e6) @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
 - `Table`: 修复合并单元格，动态数据显示异常问题，[issue#966](https://github.com/Tencent/tdesign-react/issues/966)，[8c05f53d](https://github.com/Tencent/tdesign-react/pull/1028/commits/8c05f53ddeb9b5af3ac0ab49abea8ae36eb330fb) @chaishi ([#1028](https://github.com/Tencent/tdesign-react/pull/1028))
@@ -818,387 +916,393 @@ spline: explain
 - `Dialog`: 修复滚动失效问题 @honkinglin ([#1021](https://github.com/Tencent/tdesign-react/pull/1021))
 - `select`: 修复多选下换行提前占满一行的问题 @uyarn ([#1032](https://github.com/Tencent/tdesign-react/pull/1032))
 - `Upload`: 修复 disabled 依然可删除问题 @honkinglin ([#1036](https://github.com/Tencent/tdesign-react/pull/1036))
-- `colorPicker`: 修复在ColorTrigger输入色值时，自动format输入值并回填的问题 @LittlehorseXie ([#1000](https://github.com/Tencent/tdesign-react/pull/1000))
-- `table`: 兼容树状表格未传入tree属性的场景 @southorange1228 ([#1002](https://github.com/Tencent/tdesign-react/pull/1002))
-
+- `ColorPicker`: 修复在 ColorTrigger 输入色值时，自动 format 输入值并回填的问题 @LittlehorseXie ([#1000](https://github.com/Tencent/tdesign-react/pull/1000))
+- `Table`: 兼容树状表格未传入 tree 属性的场景 @southorange1228 ([#1002](https://github.com/Tencent/tdesign-react/pull/1002))
 
 ## 🌈 0.36.1 `2022-06-27`
 
 ### 🐞 Bug Fixes
+
 - `Style`: 修复 reset 文件移除后组件样式错乱问题
 
-
-## 🌈 0.36.0 `2022-06-27` 
+## 🌈 0.36.0 `2022-06-27`
 
 ### 🚨 Breaking Changes
+
 - `reset`: 默认移除全局 reset 样式引入，可从 `tdesign-react/dist/reset.css` 中单独引入 @xiaosansiji ([#899](https://github.com/Tencent/tdesign-react/pull/899))
 
 ### 🚀 Features
-- `radioGroup`: 支持 className 和 style @LittlehorseXie ([#913](https://github.com/Tencent/tdesign-react/pull/913))
+
+- `RadioGroup`: 支持 className 和 style @LittlehorseXie ([#913](https://github.com/Tencent/tdesign-react/pull/913))
 - `Space`: 新增 Space 组件 @honkinglin ([#915](https://github.com/Tencent/tdesign-react/pull/915))
 - `taginput`: `excessTagsDisplayType` 默认值更为 `break-line` @LittlehorseXie ([#914](https://github.com/Tencent/tdesign-react/pull/914))
 - `Table`: `firstFullRow`不参与排序 @uyarn ([#923](https://github.com/Tencent/tdesign-react/pull/923))
-- `ConfigProvider`: 增加 `input` 组件 `autocomplete` 配置，增加 `dialog` 组件  `closeOnEscKeydown`, `closeOnOverlayClick` 配置,  增加 `select` 组件 `filterable`  配置，增加 `drawer` 组件  `closeOnEscKeydown`, `closeOnOverlayClick` 配置 ([issue #848](https://github.com/Tencent/tdesign-vue-next/issues/848)) @pengYYYYY ([#972](https://github.com/Tencent/tdesign-react/pull/972))
+- `ConfigProvider`: 增加 `input` 组件 `autocomplete` 配置，增加 `dialog` 组件 `closeOnEscKeydown`, `closeOnOverlayClick` 配置, 增加 `select` 组件 `filterable` 配置，增加 `drawer` 组件 `closeOnEscKeydown`, `closeOnOverlayClick` 配置 ([issue #848](https://github.com/Tencent/tdesign-vue-next/issues/848)) @pengYYYYY ([#972](https://github.com/Tencent/tdesign-react/pull/972))
 - `Form`: 支持 `validateOnly` 函数 & `validate` 函数支持 `showErrorMessage` 参数 & 修复类型问题 @honkinglin ([#895](https://github.com/Tencent/tdesign-react/pull/895))
 - `Locale`: 新增日文韩文翻译 @honkinglin ([#943](https://github.com/Tencent/tdesign-react/pull/943))
--  `Select`:  label 支持 TNode 类型 @samhou1988 ([#973](https://github.com/Tencent/tdesign-react/pull/973))
+- `Select`: label 支持 TNode 类型 @samhou1988 ([#973](https://github.com/Tencent/tdesign-react/pull/973))
 
 ### 🐞 Bug Fixes
-- `table`: 修复加载更多的加载组件尺寸异常问题 @uyarn ([#907](https://github.com/Tencent/tdesign-react/pull/907))
+
+- `Table`: 修复加载更多的加载组件尺寸异常问题 @uyarn ([#907](https://github.com/Tencent/tdesign-react/pull/907))
 - `Select`: 修复输入部分特殊符号过滤时组件崩溃的问题 @southorange1228 ([#916](https://github.com/Tencent/tdesign-react/pull/916))
 - `Table`: 修复仅有`firstFullRow`渲染为空的问题 @uyarn ([#923](https://github.com/Tencent/tdesign-react/pull/923))
-- `Table`: 修复SSR渲染异常的问题 @uyarn ([#923](https://github.com/Tencent/tdesign-react/pull/923))
+- `Table`: 修复 SSR 渲染异常的问题 @uyarn ([#923](https://github.com/Tencent/tdesign-react/pull/923))
 - `HeadMenu`: 修复 ts 类型问题 @honkinglin ([#934](https://github.com/Tencent/tdesign-react/pull/934))
 - `Select`: `onChange`事件回调参数缺失 @uyarn ([#951](https://github.com/Tencent/tdesign-react/pull/951))
--  `RangeInput`: 修复 `disabled` 失效问题 @honkinglin ([#921](https://github.com/Tencent/tdesign-react/pull/921))
--  `Form`: 修复 `number` 校验无效问题 @honkinglin ([#976](https://github.com/Tencent/tdesign-react/pull/976))
+- `RangeInput`: 修复 `disabled` 失效问题 @honkinglin ([#921](https://github.com/Tencent/tdesign-react/pull/921))
+- `Form`: 修复 `number` 校验无效问题 @honkinglin ([#976](https://github.com/Tencent/tdesign-react/pull/976))
 
 ### 🚧 Others
 
 - `Demo`: 组件示例代码统一使用 `Space` 组件实现 @southorange1228 @smilebuz([#920](https://github.com/Tencent/tdesign-react/issues/920))
 
-
-## 🌈 0.35.1 `2022-06-20` 
+## 🌈 0.35.1 `2022-06-20`
 
 ### 🚀 Features
-- `table`: 支持拖拽调整宽度，设置 `resizable=true` 即可 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
-- `table`: 表头吸顶、表尾吸底、滚动条吸底、分页器吸底 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
+
+- `Table`: 支持拖拽调整宽度，设置 `resizable=true` 即可 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
+- `Table`: 表头吸顶、表尾吸底、滚动条吸底、分页器吸底 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
 - `DatePicker`: 完善 panel 事件逻辑 @honkinglin ([#873](https://github.com/Tencent/tdesign-react/pull/873))
 - `DatePicker`: 优化面板交互 @honkinglin ([#887](https://github.com/Tencent/tdesign-react/pull/887))
 
 ### 🐞 Bug Fixes
-- `table`: 修复table透传loading size为枚举无效的问题 @uyarn ([#870](https://github.com/Tencent/tdesign-react/pull/870))
-- `Select`: option子组件没有透传style实现的问题 @uyarn ([#889](https://github.com/Tencent/tdesign-react/pull/889))
-- `Anchor`: 修复affix参数类型问题 @southorange1228 ([#896](https://github.com/Tencent/tdesign-react/pull/896))
-- `table`: 支持动态数据合并单元格 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
-- `table`: 吸顶表头和自定义显示列场景，支持列拖拽调整顺序 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
-- `table`: 修复 `firstFullRow` 存在时，拖拽排序的顺序不正确问题 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
+
+- `Table`: 修复 table 透传 loading size 为枚举无效的问题 @uyarn ([#870](https://github.com/Tencent/tdesign-react/pull/870))
+- `Select`: option 子组件没有透传 style 实现的问题 @uyarn ([#889](https://github.com/Tencent/tdesign-react/pull/889))
+- `Anchor`: 修复 affix 参数类型问题 @southorange1228 ([#896](https://github.com/Tencent/tdesign-react/pull/896))
+- `Table`: 支持动态数据合并单元格 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
+- `Table`: 吸顶表头和自定义显示列场景，支持列拖拽调整顺序 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
+- `Table`: 修复 `firstFullRow` 存在时，拖拽排序的顺序不正确问题 @chaishi ([#902](https://github.com/Tencent/tdesign-react/pull/902))
 - `timepicker`: 修复初始化滚动问题 @uyarn ([#876](https://github.com/Tencent/tdesign-react/pull/876))
 - `Select`: 修复 `minCollapsedNum` 无效问题 @samhou1988 ([#878](https://github.com/Tencent/tdesign-react/pull/878))
-- `Skeleton`: 修复 ts 类型问题  @Yilun-Sun ([#883](https://github.com/Tencent/tdesign-react/pull/883))
--  `Tabs`: 修复左右切换渲染问题 @honkinglin ([#894](https://github.com/Tencent/tdesign-react/pull/894))
+- `Skeleton`: 修复 ts 类型问题 @Yilun-Sun ([#883](https://github.com/Tencent/tdesign-react/pull/883))
+- `Tabs`: 修复左右切换渲染问题 @honkinglin ([#894](https://github.com/Tencent/tdesign-react/pull/894))
 - `Dialog`: 修复 mask 关闭问题 @huoyuhao ([#900](https://github.com/Tencent/tdesign-react/pull/900))
 
-
-## 🌈 0.35.0 `2022-06-10` 
+## 🌈 0.35.0 `2022-06-10`
 
 ### 🚨 Breaking Changes
-- `DatePicker`:  重构 `DatePickerPanel`、`DateRangePickerPanel` 逻辑，API 重新规划 @honkinglin ([#858](https://github.com/Tencent/tdesign-react/pull/858))
+
+- `DatePicker`: 重构 `DatePickerPanel`、`DateRangePickerPanel` 逻辑，API 重新规划 @honkinglin ([#858](https://github.com/Tencent/tdesign-react/pull/858))
 - `Dialog`: 移除 `transform` 动画方案，dom 结构有所调整 @huoyuhao ([#776](https://github.com/Tencent/tdesign-react/pull/776))
-- `InputAdornment`: 移除 `Addon` 组件，替换为 `InputAdornment`，用法保持一致只需更改组件名即可  @honkinglin ([#849](https://github.com/Tencent/tdesign-react/pull/849))
+- `InputAdornment`: 移除 `Addon` 组件，替换为 `InputAdornment`，用法保持一致只需更改组件名即可 @honkinglin ([#849](https://github.com/Tencent/tdesign-react/pull/849))
 
 ### 🚀 Features
-- `table`: 树形结构，支持默认展开全部，以及自由控制展开全部或收起全部 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 树形结构，支持空数据插入新节点、当前数据之前插入新节点、当前数据之后插入新节点、获取树形结构等方法 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 树形结构，支持自定义树形结构展开收起图标 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 树形结构，支持拖拽调整同层级顺序 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 拖拽排序事件，新增参数 data 和 newData，分别表示变更前后的数据 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 过滤功能，Input 输入框支持 Enter 键触发确认搜索 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 排序功能，支持隐藏排序图标文本提示 `hideSortTips` @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `table`: 新增可编辑单元格功能 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
-- `textarea`: 新增`allowInputOvermax` 支持超出字数限制可以输入 @carolin913 ([#838](https://github.com/Tencent/tdesign-react/pull/838))
+
+- `Table`: 树形结构，支持默认展开全部，以及自由控制展开全部或收起全部 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 树形结构，支持空数据插入新节点、当前数据之前插入新节点、当前数据之后插入新节点、获取树形结构等方法 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 树形结构，支持自定义树形结构展开收起图标 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 树形结构，支持拖拽调整同层级顺序 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 拖拽排序事件，新增参数 data 和 newData，分别表示变更前后的数据 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 过滤功能，Input 输入框支持 Enter 键触发确认搜索 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 排序功能，支持隐藏排序图标文本提示 `hideSortTips` @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Table`: 新增可编辑单元格功能 @chaishi ([#842](https://github.com/Tencent/tdesign-react/pull/842))
+- `Textarea`: 新增`allowInputOvermax` 支持超出字数限制可以输入 @carolin913 ([#838](https://github.com/Tencent/tdesign-react/pull/838))
 - `DatePicker`: 优化 `DatePicker` 组件逻辑 @honkinglin ([#858](https://github.com/Tencent/tdesign-react/pull/858))
 - `CollapsePanel`: 箭头样式优化 @samhou1988 ([#851](https://github.com/Tencent/tdesign-react/pull/851))
 - `InputAdornment`: 新增 `InputAdornment` 组件 @honkinglin ([#849](https://github.com/Tencent/tdesign-react/pull/849))
 
 ### 🐞 Bug Fixes
-- `tab`: tabnav无法自适应宽度 fix#846 @carolin913 ([#838](https://github.com/Tencent/tdesign-react/pull/838))
-- `table`: 合并单元格支持动态数据，[issue#973](https://github.com/Tencent/tdesign-vue/issues/973) @chaishi ([#866](https://github.com/Tencent/tdesign-react/pull/866))
+
+- `Tab`: tabnav 无法自适应宽度 fix#846 @carolin913 ([#838](https://github.com/Tencent/tdesign-react/pull/838))
+- `Table`: 合并单元格支持动态数据，[issue#973](https://github.com/Tencent/tdesign-vue/issues/973) @chaishi ([#866](https://github.com/Tencent/tdesign-react/pull/866))
 - `MenuItem`: 修复 `MenuItem` 在 active 状态点击失效问题 @leosxie ([#848](https://github.com/Tencent/tdesign-react/pull/848))
 - `InputNumber`: 修复减号按钮触发两次点击事件问题 @moecasts ([#857](https://github.com/Tencent/tdesign-react/pull/857))
 - `Drawer`: 修复 `cancelBtn` 传入字符串无效 @honkinglin ([#860](https://github.com/Tencent/tdesign-react/pull/860))
 - `Dialog`: 优化 `transform` 定位问题导致子节点的 fixed 属性定位失效 @huoyuhao ([#776](https://github.com/Tencent/tdesign-react/pull/776))
 
+## 🌈 0.34.4 `2022-06-02`
 
-## 🌈 0.34.4 `2022-06-02` 
 ### 🚀 Features
+
 - `Skeleton`: 延时关闭功能 @ontheroad1992 ([#808](https://github.com/Tencent/tdesign-react/pull/808))
 - `Dialog`: 增强 dialog 组件 confirmBtn & cancelBtn @psaren ([#813](https://github.com/Tencent/tdesign-react/pull/813))
 - `Notification`: 新增样式命名区分 theme @honkinglin ([#834](https://github.com/Tencent/tdesign-react/pull/834))
 
 ### 🐞 Bug Fixes
-- `Loading`: 修复loading plugin类型缺失style和class的问题 @uyarn ([#810](https://github.com/Tencent/tdesign-react/pull/810))
-- `skeleton`: 动画结束后，父级无意义的 div 导致样式无法继承、计算 @ontheroad1992 ([#808](https://github.com/Tencent/tdesign-react/pull/808))
+
+- `Loading`: 修复 loading plugin 类型缺失 style 和 class 的问题 @uyarn ([#810](https://github.com/Tencent/tdesign-react/pull/810))
+- `Skeleton`: 动画结束后，父级无意义的 div 导致样式无法继承、计算 @ontheroad1992 ([#808](https://github.com/Tencent/tdesign-react/pull/808))
 - `TimePicker`: 修复`RangePicker`的聚焦样式丢失的问题 @uyarn ([#811](https://github.com/Tencent/tdesign-react/pull/811))
-- `Form`: 修复 `addon` 在form表单下数据劫持失败问题 @honkinglin ([#802](https://github.com/Tencent/tdesign-react/pull/802))
+- `Form`: 修复 `addon` 在 form 表单下数据劫持失败问题 @honkinglin ([#802](https://github.com/Tencent/tdesign-react/pull/802))
 - `Select`: 当 multiple 为 true 的时候，筛选(filter)功能无法关闭 @samhou1988 ([#814](https://github.com/Tencent/tdesign-react/pull/814))
 - `Menu`: 兼容 menu 子元素为 null 场景报错问题 @honkinglin ([#818](https://github.com/Tencent/tdesign-react/pull/818))
 - `Upload`: 修复错误信息不消失问题 @wookaoer ([#827](https://github.com/Tencent/tdesign-react/pull/827))
-- `TagInput`:  修复中文输入法enter时，既触发添加tag也input框有输入的字母的问题 @LittlehorseXie ([#835](https://github.com/Tencent/tdesign-react/pull/835))
+- `TagInput`: 修复中文输入法 enter 时，既触发添加 tag 也 input 框有输入的字母的问题 @LittlehorseXie ([#835](https://github.com/Tencent/tdesign-react/pull/835))
 
 ### 🚧 Others
+
 - 官网: 新增主题配置生成器 @uyarn ([#655](https://github.com/Tencent/tdesign-react/pull/655))
 
-## 🌈 0.34.3 `2022-05-25` 
+## 🌈 0.34.3 `2022-05-25`
 
 ### 🚧 Others
+
 - fix: 修复构建报错 @honkinglin ([#799](https://github.com/Tencent/tdesign-react/pull/799))
 
-## 🌈 0.34.2 `2022-05-25` 
+## 🌈 0.34.2 `2022-05-25`
 
 ### 🐞 Bug Fixes
-- `Table`: 处理table过滤输入失焦问题 @uyarn ([#793](https://github.com/Tencent/tdesign-react/pull/793))
-- `Form`:  修复 `FormItem` 拦截组件受控属性默认值为数组时传入 undefined 报错问题 @honkinglin ([#792]
-- `Form`:  修复 `FormItem` rules 失效问题 @honkinglin ([#794](https://github.com/Tencent/tdesign-react/pull/794))
-- `Pagination`:  修复  `totalContent` jsx 渲染失败问题 @honkinglin ([#796](https://github.com/Tencent/tdesign-react/pull/796))
 
+- `Table`: 处理 table 过滤输入失焦问题 @uyarn ([#793](https://github.com/Tencent/tdesign-react/pull/793))
+- `Form`: 修复 `FormItem` 拦截组件受控属性默认值为数组时传入 undefined 报错问题 @honkinglin ([#792]
+- `Form`: 修复 `FormItem` rules 失效问题 @honkinglin ([#794](https://github.com/Tencent/tdesign-react/pull/794))
+- `Pagination`: 修复 `totalContent` jsx 渲染失败问题 @honkinglin ([#796](https://github.com/Tencent/tdesign-react/pull/796))
 
-## 🌈 0.34.1 `2022-05-24` 
+## 🌈 0.34.1 `2022-05-24`
 
 ### 🐞 Bug Fixes
+
 - `Datepicker`: 修复 popupProps 透传优先级问题 @honkinglin ([#785](https://github.com/Tencent/tdesign-react/pull/785))
 
 ### 🚧 Others
+
 - fix: 修复构建产物报错 @honkinglin ([#789](https://github.com/Tencent/tdesign-react/pull/789))
 
-
-## 🌈 0.34.0 `2022-05-20` 
+## 🌈 0.34.0 `2022-05-20`
 
 ### 🚨 Breaking Changes
+
 - `DatePicker`: onChange 回调第二个参数调整为对象，支持更多类型返回值 @honkinglin ([#777](https://github.com/Tencent/tdesign-react/pull/777))
 - `Form`: 不再默认渲染 `help` 空节点 @honkinglin ([#772](https://github.com/Tencent/tdesign-react/pull/772))
 
 ### 🚀 Features
+
 - `Form`: `FormList` 支持手动赋值 @honkinglin ([#769](https://github.com/Tencent/tdesign-react/pull/769))
-- `Form`:  支持 `help` 节点与错误提示同时展示，无 `help` 不再默认占位 @honkinglin ([#772](https://github.com/Tencent/tdesign-react/pull/772))
+- `Form`: 支持 `help` 节点与错误提示同时展示，无 `help` 不再默认占位 @honkinglin ([#772](https://github.com/Tencent/tdesign-react/pull/772))
 - `DatePicker`: 支持 `onChange` 返回 `trigger` 参数定位事件触发源 & 单选模式支持 `onPick` 事件 @honkinglin ([#777](https://github.com/Tencent/tdesign-react/pull/777))
-- `Watermark`: 新增水印watermark组件 @docoder ([#753](https://github.com/Tencent/tdesign-react/pull/753))
-- `Calendar`:  新增 `month`、`year` API @skytt ([#775](https://github.com/Tencent/tdesign-react/pull/775))
-- `Tree`: `label` 支持多行文本  @ccccpj https://github.com/Tencent/tdesign-common/pull/460
+- `Watermark`: 新增水印 watermark 组件 @docoder ([#753](https://github.com/Tencent/tdesign-react/pull/753))
+- `Calendar`: 新增 `month`、`year` API @skytt ([#775](https://github.com/Tencent/tdesign-react/pull/775))
+- `Tree`: `label` 支持多行文本 @ccccpj https://github.com/Tencent/tdesign-common/pull/460
 
 ### 🐞 Bug Fixes
+
 - `Table`: 修复异步加载数据时，分页非受控展示错误行数的问题 @uyarn ([#778](https://github.com/Tencent/tdesign-react/pull/778))
 - `TimePicker`: 修复`TimePicker`展开宽度问题 @uyarn ([#780](https://github.com/Tencent/tdesign-react/pull/780))
 
 ### 🚧 Others
+
 - 统一全局受控 hooks & 优化组件初始值设置 @honkinglin ([#773](https://github.com/Tencent/tdesign-react/pull/773))
 
+## 🌈 0.33.2 `2022-05-14`
 
-## 🌈 0.33.2 `2022-05-14` 
 ### 🚀 Features
+
 - `Steps`: 支持 separator api & 完善反转逻辑 @honkinglin ([#752](https://github.com/Tencent/tdesign-react/pull/752))
-- `Form`:  支持整理嵌套数据 @honkinglin ([#758](https://github.com/Tencent/tdesign-react/pull/758)) ([#762](https://github.com/Tencent/tdesign-react/pull/762))
-- `Affix`:  优化滚动逻辑 @ontheroad1992 ([#759](https://github.com/Tencent/tdesign-react/pull/759))
-- `Tabs`:  `TabPanel` 支持 `className` 透传 @honkinglin ([#763](https://github.com/Tencent/tdesign-react/pull/763))
+- `Form`: 支持整理嵌套数据 @honkinglin ([#758](https://github.com/Tencent/tdesign-react/pull/758)) ([#762](https://github.com/Tencent/tdesign-react/pull/762))
+- `Affix`: 优化滚动逻辑 @ontheroad1992 ([#759](https://github.com/Tencent/tdesign-react/pull/759))
+- `Tabs`: `TabPanel` 支持 `className` 透传 @honkinglin ([#763](https://github.com/Tencent/tdesign-react/pull/763))
+
 ### 🐞 Bug Fixes
+
 - `Table`: 修复 多级表头 + 列配置 综合示例中，列数量超出一定限制时报错，[issue#713](https://github.com/Tencent/tdesign-vue-next/issues/713) @chaishi ([#757](https://github.com/Tencent/tdesign-react/pull/757))
 - `Tabs`: 修复 `TabPanel` ts 类型报错 @wleven ([#761](https://github.com/Tencent/tdesign-react/pull/761))
 - `DatePicker`: 修复宽度计算问题 @honkinglin ([#754](https://github.com/Tencent/tdesign-react/pull/754))
-- `Slider`: 修复 `inputNumberProps` 类型问题  @andyjxli ([#745](https://github.com/Tencent/tdesign-react/pull/745))
+- `Slider`: 修复 `inputNumberProps` 类型问题 @andyjxli ([#745](https://github.com/Tencent/tdesign-react/pull/745))
 
 ## 🌈 0.33.1 `2022-05-09`
 
 ### 🐞 Bug Fixes
+
 `Jumper`: 修复 style 文件引用报错问题 [@honkinglin](https://github.com/honkinglin) ([0d5726d](https://github.com/Tencent/tdesign-react/commit/0d5726d30b17bda68a39f1ab90568e2dbb0708d8))
 
-
-## 🌈 0.33.0 `2022-05-09` 
+## 🌈 0.33.0 `2022-05-09`
 
 ### 🚨 Breaking Changes
-- 重构 DatePicker、TimePicker 组件，样式结构有所调整 @honkinglin @uyarn ([#559](https://github.com/Tencent/tdesign-react/pull/559)) 
+
+- 重构 DatePicker、TimePicker 组件，样式结构有所调整 @honkinglin @uyarn ([#559](https://github.com/Tencent/tdesign-react/pull/559))
 - `DatePicker`
   - 移除 `range` api，分别导出 `Datepicker` 与 `DateRangePicker` 组件
   - 支持 `DatePickerPanel` 与 `DateRangePickerPanel` 单独使用
   - 支持年份、月份区间选择
   - 支持 `allowInput` api
 - `TimePicker`
-   - 重新调整样式、允许输入交互重新设计
-   - 调整交互为点击`确认`按钮保留改动 直接关闭弹窗不保留改动 恢复初始值
-   - `disableTime`、`onFocus`、`onBlur`、`onInput` 等API存在breaking change
-   - 新增`TimePickerPanel`组件 用于单独使用面板的场景 
+  - 重新调整样式、允许输入交互重新设计
+  - 调整交互为点击`确认`按钮保留改动 直接关闭弹窗不保留改动 恢复初始值
+  - `disableTime`、`onFocus`、`onBlur`、`onInput` 等 API 存在 breaking change
+  - 新增`TimePickerPanel`组件 用于单独使用面板的场景
 
 ### 🚀 Features
+
 - `Icon`: 更新图标 新增`file-icon`图标 调整`file-excel`、`file-pdf`、`file-powerpoint`、`file-unknown`、`file-word`和`star-filled`图标的绘制路径 @uyarn ([#741](https://github.com/Tencent/tdesign-react/pull/741))
 - `Jumper`: 新增 `Jumper` 组件 @honkinglin ([#559](https://github.com/Tencent/tdesign-react/pull/559))
-- `RangeInput`:  新增 `RangeInput` 组件 @honkinglin ([#559](https://github.com/Tencent/tdesign-react/pull/559))
-- `RangeInputPopup`:  新增 `RangeInputPopup` 组件 @honkinglin ([#559](https://github.com/Tencent/tdesign-react/pull/559))
+- `RangeInput`: 新增 `RangeInput` 组件 @honkinglin ([#559](https://github.com/Tencent/tdesign-react/pull/559))
+- `RangeInputPopup`: 新增 `RangeInputPopup` 组件 @honkinglin ([#559](https://github.com/Tencent/tdesign-react/pull/559))
 
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: 受控问题修复 @insekkei ([#712](https://github.com/Tencent/tdesign-react/pull/712))
-- `Upload`:   修复组件 value undifined 场景校验失败问题 @honkinglin ([#738](https://github.com/Tencent/tdesign-react/pull/738))
+- `Upload`: 修复组件 value undifined 场景校验失败问题 @honkinglin ([#738](https://github.com/Tencent/tdesign-react/pull/738))
 
+## 🌈 0.32.3 `2022-05-07`
 
-## 🌈 0.32.3 `2022-05-07` 
 ### 🚀 Features
+
 - `Table`: 新增 API `ellipsisTitle` 用于单独控制表头的超出省略 [@chaishi](https://github.com/chaishi) ([#722](https://github.com/Tencent/tdesign-react/pull/722))
-- `Upload`: 修改uploadFiles类型参数除url外为非必填 [@uyarn](https://github.com/uyarn) ([#730](https://github.com/Tencent/tdesign-react/pull/730))
+- `Upload`: 修改 uploadFiles 类型参数除 url 外为非必填 [@uyarn](https://github.com/uyarn) ([#730](https://github.com/Tencent/tdesign-react/pull/730))
+
 ### 🐞 Bug Fixes
+
 - `slider`: 修复`slider`在非受控模式下行为异常 [@southorange1228](https://github.com/southorange1228) ([#709](https://github.com/Tencent/tdesign-react/pull/709))
-- `Table`:  加载状态与拖拽配合使用时，拖拽功能失效，[issue#708](https://github.com/Tencent/tdesign-react/issues/708) [@chaishi](https://github.com/chaishi) ([#722](https://github.com/Tencent/tdesign-react/pull/722))
-- `Card`:  修复未添加header属性，Card组件布局错误 [@yilaierwang](https://github.com/yilaierwang) ([#724](https://github.com/Tencent/tdesign-react/pull/724))
-- `Card`: 头部渲染逻辑不完善的问题 缺失了status的渲染 [@uyarn](https://github.com/uyarn) ([#731](https://github.com/Tencent/tdesign-react/pull/731))
+- `Table`: 加载状态与拖拽配合使用时，拖拽功能失效，[issue#708](https://github.com/Tencent/tdesign-react/issues/708) [@chaishi](https://github.com/chaishi) ([#722](https://github.com/Tencent/tdesign-react/pull/722))
+- `Card`: 修复未添加 header 属性，Card 组件布局错误 [@yilaierwang](https://github.com/yilaierwang) ([#724](https://github.com/Tencent/tdesign-react/pull/724))
+- `Card`: 头部渲染逻辑不完善的问题 缺失了 status 的渲染 [@uyarn](https://github.com/uyarn) ([#731](https://github.com/Tencent/tdesign-react/pull/731))
 - `Table`: `renderExpandedRow`改为非必填 [@uyarn](https://github.com/uyarn) ([#732](https://github.com/Tencent/tdesign-react/pull/732))
-- `InputNumber`:  修复小数输入问题 [@Fnll](https://github.com/Fnll) ([#729](https://github.com/Tencent/tdesign-react/pull/729)) [@docoder](https://github.com/docoder) ([#728](https://github.com/Tencent/tdesign-react/pull/728))
+- `InputNumber`: 修复小数输入问题 [@Fnll](https://github.com/Fnll) ([#729](https://github.com/Tencent/tdesign-react/pull/729)) [@docoder](https://github.com/docoder) ([#728](https://github.com/Tencent/tdesign-react/pull/728))
 
 ## 0.32.2 `2022-04-28`
 
 ### Bug Fixes
 
-* Table:
-  * 修复 `getBoundingClientRect` 在 `jsdom` 环境为 null 问题 ([22077bd](https://github.com/Tencent/tdesign-react/commit/22077bdf0dc406bd92a9c5d25362382bfdf23f6e)) [@uyarn](https://github.com/uyarn)
-  * 修复 `loading` 状态文案问题 ([e021c8b](https://github.com/Tencent/tdesign-react/commit/e021c8b3c75274eca9842ad8ef3c8839b60d4eab)) [@uyarn](https://github.com/uyarn)
-* Datepicker: 修复空数组确定事件报错问题 ([#697](https://github.com/Tencent/tdesign-react/issues/697)) ([871065d](https://github.com/Tencent/tdesign-react/commit/871065d35c75d87fd9002f16b438246da80fd10a)) [@honkinglin](https://github.com/honkinglin)
-* Dialog: 修复组件销毁后 body 样式不重置问题 & 移除多余 div 渲染 ([#690](https://github.com/Tencent/tdesign-react/issues/690)) ([d6d5131](https://github.com/Tencent/tdesign-react/commit/d6d513151f7548b3ea3b1f0b8c26fa96ecdbb1dc)) [@honkinglin](https://github.com/honkinglin)
-* Textarea: 修复在 `Form` 组件下换行问题 ([507eaf3](https://github.com/Tencent/tdesign-react/commit/507eaf3b9533b19681e9bd10f666ded9e61b430d)) [@honkinglin](https://github.com/honkinglin)
-* Colorpicker: 修复 Popupprops 透传问题 ([#700](https://github.com/Tencent/tdesign-react/issues/700)) ([804c7b4](https://github.com/Tencent/tdesign-react/commit/804c7b4f64968d12d2ca665b23289e0cd1037fff)), closes [#698](https://github.com/Tencent/tdesign-react/issues/698) [@carolin913](https://github.com/carolin913)
-* Form: 修复 `help` 文案状态响应样式问题 ([#682](https://github.com/Tencent/tdesign-react/issues/682)) ([282602d](https://github.com/Tencent/tdesign-react/commit/282602d8ab3a1ff10a1146b5519d13b08fc7a2c6)) [@honkinglin](https://github.com/honkinglin)
-* Upload: 修复 `onDrop` 事件不响应问题 ([3efa2c6](https://github.com/Tencent/tdesign-react/commit/3efa2c6c9758725aa4159b122bfad3b154959404)) [@wookaoer](https://github.com/wookaoer)
-
+- Table:
+  - 修复 `getBoundingClientRect` 在 `jsdom` 环境为 null 问题 ([22077bd](https://github.com/Tencent/tdesign-react/commit/22077bdf0dc406bd92a9c5d25362382bfdf23f6e)) [@uyarn](https://github.com/uyarn)
+  - 修复 `loading` 状态文案问题 ([e021c8b](https://github.com/Tencent/tdesign-react/commit/e021c8b3c75274eca9842ad8ef3c8839b60d4eab)) [@uyarn](https://github.com/uyarn)
+- Datepicker: 修复空数组确定事件报错问题 ([#697](https://github.com/Tencent/tdesign-react/issues/697)) ([871065d](https://github.com/Tencent/tdesign-react/commit/871065d35c75d87fd9002f16b438246da80fd10a)) [@honkinglin](https://github.com/honkinglin)
+- Dialog: 修复组件销毁后 body 样式不重置问题 & 移除多余 div 渲染 ([#690](https://github.com/Tencent/tdesign-react/issues/690)) ([d6d5131](https://github.com/Tencent/tdesign-react/commit/d6d513151f7548b3ea3b1f0b8c26fa96ecdbb1dc)) [@honkinglin](https://github.com/honkinglin)
+- Textarea: 修复在 `Form` 组件下换行问题 ([507eaf3](https://github.com/Tencent/tdesign-react/commit/507eaf3b9533b19681e9bd10f666ded9e61b430d)) [@honkinglin](https://github.com/honkinglin)
+- Colorpicker: 修复 Popupprops 透传问题 ([#700](https://github.com/Tencent/tdesign-react/issues/700)) ([804c7b4](https://github.com/Tencent/tdesign-react/commit/804c7b4f64968d12d2ca665b23289e0cd1037fff)), closes [#698](https://github.com/Tencent/tdesign-react/issues/698) [@carolin913](https://github.com/carolin913)
+- Form: 修复 `help` 文案状态响应样式问题 ([#682](https://github.com/Tencent/tdesign-react/issues/682)) ([282602d](https://github.com/Tencent/tdesign-react/commit/282602d8ab3a1ff10a1146b5519d13b08fc7a2c6)) [@honkinglin](https://github.com/honkinglin)
+- Upload: 修复 `onDrop` 事件不响应问题 ([3efa2c6](https://github.com/Tencent/tdesign-react/commit/3efa2c6c9758725aa4159b122bfad3b154959404)) [@wookaoer](https://github.com/wookaoer)
 
 ### Features
 
-* Collapse: 新增 `Collapse` 组件 ([9c2ce29](https://github.com/Tencent/tdesign-react/commit/9c2ce29625a11979aff5de6adeda157b319d7ad3)) [@ZhaoRB](https://github.com/ZhaoRB)
-* Pagination:
-  * 新增 `showPageSize`、`showPageNumber` API ([#696](https://github.com/Tencent/tdesign-react/issues/696)) ([c11e692](https://github.com/Tencent/tdesign-react/commit/c11e69218df8bcf20f5b5104f6967e04246dc182)) [@honkinglin](https://github.com/honkinglin)
-  * 新增 `showFirstAndLastBtn` api ([#694](https://github.com/Tencent/tdesign-react/issues/694)) ([d085cf8](https://github.com/Tencent/tdesign-react/commit/d085cf862454173e0a191f842cc0a5b44c0477a5)) [@honkinglin](https://github.com/honkinglin)
-* InputNumber: 完善尺寸类型 ([#694](https://github.com/Tencent/tdesign-react/issues/694)) ([d085cf8](https://github.com/Tencent/tdesign-react/commit/d085cf862454173e0a191f842cc0a5b44c0477a5)) [@honkinglin](https://github.com/honkinglin)
-* Tooltip: 支持 `plcement="mouse"` 基于鼠标位置 ([26afab8](https://github.com/Tencent/tdesign-react/commit/26afab81ce1bd3bcaaf51618123e7b21e1241279)), closes [#608](https://github.com/Tencent/tdesign-react/issues/608) [@carolin913](https://github.com/carolin913)
-
+- Collapse: 新增 `Collapse` 组件 ([9c2ce29](https://github.com/Tencent/tdesign-react/commit/9c2ce29625a11979aff5de6adeda157b319d7ad3)) [@ZhaoRB](https://github.com/ZhaoRB)
+- Pagination:
+  - 新增 `showPageSize`、`showPageNumber` API ([#696](https://github.com/Tencent/tdesign-react/issues/696)) ([c11e692](https://github.com/Tencent/tdesign-react/commit/c11e69218df8bcf20f5b5104f6967e04246dc182)) [@honkinglin](https://github.com/honkinglin)
+  - 新增 `showFirstAndLastBtn` api ([#694](https://github.com/Tencent/tdesign-react/issues/694)) ([d085cf8](https://github.com/Tencent/tdesign-react/commit/d085cf862454173e0a191f842cc0a5b44c0477a5)) [@honkinglin](https://github.com/honkinglin)
+- InputNumber: 完善尺寸类型 ([#694](https://github.com/Tencent/tdesign-react/issues/694)) ([d085cf8](https://github.com/Tencent/tdesign-react/commit/d085cf862454173e0a191f842cc0a5b44c0477a5)) [@honkinglin](https://github.com/honkinglin)
+- Tooltip: 支持 `plcement="mouse"` 基于鼠标位置 ([26afab8](https://github.com/Tencent/tdesign-react/commit/26afab81ce1bd3bcaaf51618123e7b21e1241279)), closes [#608](https://github.com/Tencent/tdesign-react/issues/608) [@carolin913](https://github.com/carolin913)
 
 ## 0.32.1 `2022-04-24`
 
 ### Bug Fixes
 
-* Table: 修复 jsdom 测试环境报错问题 ([#676](https://github.com/Tencent/tdesign-react/issues/676)) ([af7a35b](https://github.com/Tencent/tdesign-react/commit/af7a35b3ee917bdc36634d71712174e0074c61e2)) [@honkinglin](https://github.com/honkinglin)
-* Dialog: 修复 ts 问题 ([0e278a1](https://github.com/Tencent/tdesign-react/commit/0e278a179dae4b0b6b36b10ce026dab3a4dcb7eb)) [@pengYYYYY](https://github.com/pengYYYYY)
-
+- Table: 修复 jsdom 测试环境报错问题 ([#676](https://github.com/Tencent/tdesign-react/issues/676)) ([af7a35b](https://github.com/Tencent/tdesign-react/commit/af7a35b3ee917bdc36634d71712174e0074c61e2)) [@honkinglin](https://github.com/honkinglin)
+- Dialog: 修复 ts 问题 ([0e278a1](https://github.com/Tencent/tdesign-react/commit/0e278a179dae4b0b6b36b10ce026dab3a4dcb7eb)) [@pengYYYYY](https://github.com/pengYYYYY)
 
 ### Features
 
-* Select: 列表选择体验优化 ([#659](https://github.com/Tencent/tdesign-react/issues/659)) ([3a792bd](https://github.com/Tencent/tdesign-react/commit/3a792bddc9d9226016f282a2af6fd7e8eb715e73)) [@smilebuz](https://github.com/smilebuz)
-
+- Select: 列表选择体验优化 ([#659](https://github.com/Tencent/tdesign-react/issues/659)) ([3a792bd](https://github.com/Tencent/tdesign-react/commit/3a792bddc9d9226016f282a2af6fd7e8eb715e73)) [@smilebuz](https://github.com/smilebuz)
 
 ## 0.32.0 `2022-04-22`
 
 ### BREAKING CHANGES
 
-* Table: 重构 `table` 组件, 样式结构有所变动，废弃`minWidth`，`排序功能`使用有所调整，详情请参考API和demo的写法 ([ea678be](https://github.com/Tencent/tdesign-react/commit/ea678be56e466a5a7f4cfaecdea4413d3753ba09)) [@chaishi](https://github.com/chaishi) [@uyarn](https://github.com/uyarn)
+- Table: 重构 `Table` 组件, 样式结构有所变动，废弃`minWidth`，`排序功能`使用有所调整，详情请参考 API 和 demo 的写法 ([ea678be](https://github.com/Tencent/tdesign-react/commit/ea678be56e466a5a7f4cfaecdea4413d3753ba09)) [@chaishi](https://github.com/chaishi) [@uyarn](https://github.com/uyarn)
 
 ### Bug Fixes
 
-* Select:
-  * 修复多选+可搜索条件下输入问题 ([91c4025](https://github.com/Tencent/tdesign-react/commit/91c40258712ffac4abb00fdf8805028bc061200b)) [@samhou1988](https://github.com/samhou1988)
-  * 修复 `multiple` 模式删除问题 ([dedb2ee](https://github.com/Tencent/tdesign-react/commit/dedb2eebc8d6db4cb422635a526f1729f1f9ab87)), closes [#654](https://github.com/Tencent/tdesign-react/issues/654) [@joriewong](https://github.com/joriewong)
-* Progress: 修复 `trackColor` 默认值导致背景色显示错误问题 ([faff9ad](https://github.com/Tencent/tdesign-react/commit/faff9add954cb3cd2078de33dd8e592ef17bee9d)) [@honkinglin](https://github.com/honkinglin)
-* Dialog: 修复 `destroyOnClose` 为 true 时 visible 失效问题 ([d8721cb](https://github.com/Tencent/tdesign-react/commit/d8721cb0c01d4c24bebfe076b9283a98c3c33f72)) [@psaren](https://github.com/psaren)
-* Layout: 修复 ts 类型警告 ([26e1ee3](https://github.com/Tencent/tdesign-react/commit/26e1ee33fc54dbd3a504e4889db7cafbacc97972)) [@honkinglin](https://github.com/honkinglin)
-* table: 修复 pagination 数据同步问题 ([77d692e](https://github.com/Tencent/tdesign-react/commit/77d692e0db136b9299e85ce3f1ce955a3ea14e39)) [@uyarn](https://github.com/uyarn)
-
+- Select:
+  - 修复多选+可搜索条件下输入问题 ([91c4025](https://github.com/Tencent/tdesign-react/commit/91c40258712ffac4abb00fdf8805028bc061200b)) [@samhou1988](https://github.com/samhou1988)
+  - 修复 `multiple` 模式删除问题 ([dedb2ee](https://github.com/Tencent/tdesign-react/commit/dedb2eebc8d6db4cb422635a526f1729f1f9ab87)), closes [#654](https://github.com/Tencent/tdesign-react/issues/654) [@joriewong](https://github.com/joriewong)
+- Progress: 修复 `trackColor` 默认值导致背景色显示错误问题 ([faff9ad](https://github.com/Tencent/tdesign-react/commit/faff9add954cb3cd2078de33dd8e592ef17bee9d)) [@honkinglin](https://github.com/honkinglin)
+- Dialog: 修复 `destroyOnClose` 为 true 时 visible 失效问题 ([d8721cb](https://github.com/Tencent/tdesign-react/commit/d8721cb0c01d4c24bebfe076b9283a98c3c33f72)) [@psaren](https://github.com/psaren)
+- Layout: 修复 ts 类型警告 ([26e1ee3](https://github.com/Tencent/tdesign-react/commit/26e1ee33fc54dbd3a504e4889db7cafbacc97972)) [@honkinglin](https://github.com/honkinglin)
+- table: 修复 pagination 数据同步问题 ([77d692e](https://github.com/Tencent/tdesign-react/commit/77d692e0db136b9299e85ce3f1ce955a3ea14e39)) [@uyarn](https://github.com/uyarn)
 
 ### Features
 
-* Card: 新增 `Card` 组件 ([9c66dc3](https://github.com/Tencent/tdesign-react/commit/9c66dc36c351d80e22926fe2d4ff56783cda334d)) [@weikee94](https://github.com/weikee94)
-* ColorPicker: 新增 `ColorPicker` 组件 ([920263a](https://github.com/Tencent/tdesign-react/commit/920263af9c5ec3671f214182f26b6fc7ce0528b8)) [insekkei](https://github.com/insekkei) [@carolin913](https://github.com/carolin913)
-* Table: 重构 `table` 组件, 支持表头吸顶、简易列拖拽排序、自定义列配置、懒加载、自定义展开图标及树形结构 ([ea678be](https://github.com/Tencent/tdesign-react/commit/ea678be56e466a5a7f4cfaecdea4413d3753ba09)) [@chaishi](https://github.com/chaishi) [@uyarn](https://github.com/uyarn)
-  
-* Divider: 优化文本模式在竖型模式下样式问题 ([#662](https://github.com/Tencent/tdesign-react/issues/662)) ([213c67d](https://github.com/Tencent/tdesign-react/commit/213c67d9107960e02dff6baf8861770a8a822272)) [@honkinglin](https://github.com/honkinglin)
-
-
+- Card: 新增 `Card` 组件 ([9c66dc3](https://github.com/Tencent/tdesign-react/commit/9c66dc36c351d80e22926fe2d4ff56783cda334d)) [@weikee94](https://github.com/weikee94)
+- ColorPicker: 新增 `ColorPicker` 组件 ([920263a](https://github.com/Tencent/tdesign-react/commit/920263af9c5ec3671f214182f26b6fc7ce0528b8)) [insekkei](https://github.com/insekkei) [@carolin913](https://github.com/carolin913)
+- Table: 重构 `Table` 组件, 支持表头吸顶、简易列拖拽排序、自定义列配置、懒加载、自定义展开图标及树形结构 ([ea678be](https://github.com/Tencent/tdesign-react/commit/ea678be56e466a5a7f4cfaecdea4413d3753ba09)) [@chaishi](https://github.com/chaishi) [@uyarn](https://github.com/uyarn)
+- Divider: 优化文本模式在竖型模式下样式问题 ([#662](https://github.com/Tencent/tdesign-react/issues/662)) ([213c67d](https://github.com/Tencent/tdesign-react/commit/213c67d9107960e02dff6baf8861770a8a822272)) [@honkinglin](https://github.com/honkinglin)
 
 ## 0.31.1 `2022-04-18`
 
 ### Bug Fixes
 
-* Form: 修复 `formItem` 包裹组件 `onChange` 其他参数丢失问题 ([#637](https://github.com/Tencent/tdesign-react/issues/637)) ([f1b2256](https://github.com/Tencent/tdesign-react/commit/f1b225605803299405f558b06d681507326e1e44)) [@honkinglin](https://github.com/honkinglin)
-* Datepicker: 修复 `range` 模式空数组报错问题 ([679d933](https://github.com/Tencent/tdesign-react/commit/679d933e9b30eb153efab86743488648b5ed5b1d)) [@honkinglin](https://github.com/honkinglin)
-* Menu: menuGroup 类型修复 ([d52942a](https://github.com/Tencent/tdesign-react/commit/d52942ac2ecfe7ac14aa9ac26ef30c773386fc39)) [@ZhaoRB](https://github.com/ZhaoRB)
-* Upload:
-  * 修复 draggable custom theme 同时存在组件不渲染 ([f1f6fd1](https://github.com/Tencent/tdesign-react/commit/f1f6fd1001e807c526983543bf46b7fa195788a1)) [@samhou1988](https://github.com/samhou1988)
-  * 修复上传参数 `file` 丢失问题 ([bd9f545](https://github.com/Tencent/tdesign-react/commit/bd9f545a27c236cec843d95861239414773eed27)) [@wookaoer](https://github.com/wookaoer)
+- Form: 修复 `formItem` 包裹组件 `onChange` 其他参数丢失问题 ([#637](https://github.com/Tencent/tdesign-react/issues/637)) ([f1b2256](https://github.com/Tencent/tdesign-react/commit/f1b225605803299405f558b06d681507326e1e44)) [@honkinglin](https://github.com/honkinglin)
+- Datepicker: 修复 `range` 模式空数组报错问题 ([679d933](https://github.com/Tencent/tdesign-react/commit/679d933e9b30eb153efab86743488648b5ed5b1d)) [@honkinglin](https://github.com/honkinglin)
+- Menu: menuGroup 类型修复 ([d52942a](https://github.com/Tencent/tdesign-react/commit/d52942ac2ecfe7ac14aa9ac26ef30c773386fc39)) [@ZhaoRB](https://github.com/ZhaoRB)
+- Upload:
+  - 修复 draggable custom theme 同时存在组件不渲染 ([f1f6fd1](https://github.com/Tencent/tdesign-react/commit/f1f6fd1001e807c526983543bf46b7fa195788a1)) [@samhou1988](https://github.com/samhou1988)
+  - 修复上传参数 `file` 丢失问题 ([bd9f545](https://github.com/Tencent/tdesign-react/commit/bd9f545a27c236cec843d95861239414773eed27)) [@wookaoer](https://github.com/wookaoer)
 
 ### Features
 
-* Icon: 升级 Icon 包版本，支持React 18 + 的使用 ([5d0de7c](https://github.com/Tencent/tdesign-react/commit/5d0de7ce97f782cbe90fcb6181866421bfa3e8cd)) [@uyarn](https://github.com/uyarn)
-
-
+- Icon: 升级 Icon 包版本，支持 React 18 + 的使用 ([5d0de7c](https://github.com/Tencent/tdesign-react/commit/5d0de7ce97f782cbe90fcb6181866421bfa3e8cd)) [@uyarn](https://github.com/uyarn)
 
 ## 0.31.0 `2022-04-14`
 
 ### BREAKING CHANGES
-* FormItem 样式调整，默认渲染 extra 文本节点占位，FormItem 上下 margin 有所调整 [@honkinglin](https://github.com/honkinglin)
-* Popconfirm: 移除 `PopConfirm` 组件导出，请更改为 `Popconfirm` ([#614](https://github.com/Tencent/tdesign-react/issues/614)) ([ca6e4b6](https://github.com/Tencent/tdesign-react/commit/ca6e4b6852469bba35d47ba0811054fc796c1a69)) [@honkinglin](https://github.com/honkinglin)
+
+- FormItem 样式调整，默认渲染 extra 文本节点占位，FormItem 上下 margin 有所调整 [@honkinglin](https://github.com/honkinglin)
+- Popconfirm: 移除 `PopConfirm` 组件导出，请更改为 `Popconfirm` ([#614](https://github.com/Tencent/tdesign-react/issues/614)) ([ca6e4b6](https://github.com/Tencent/tdesign-react/commit/ca6e4b6852469bba35d47ba0811054fc796c1a69)) [@honkinglin](https://github.com/honkinglin)
 
 ### Bug Fixes
 
-* Cascader:
-  * 修复 `filterable` 模式下展示异常 ([92c2776](https://github.com/Tencent/tdesign-react/commit/92c277608778f955108e5a9ff6e231473c2cd039)) [@jsonz1993](https://github.com/jsonz1993)
-  * 修复多选与筛选时文本过长的展示异常 ([6d3f0fc](https://github.com/Tencent/tdesign-react/commit/6d3f0fc82d80b927fff17ca09c24445f19c0881b)) [@jsonz1993](https://github.com/jsonz1993)
-* Popup:
-  * 修复初始化翻转逻辑判断错误 ([#615](https://github.com/Tencent/tdesign-react/issues/615)) ([b7bea93](https://github.com/Tencent/tdesign-react/commit/b7bea93d25e2908973335dc8099c2f85e04d04b0)) [@honkinglin](https://github.com/honkinglin)
-  * 修复嵌套浮层 `click` 时关闭异常 ([f40c1f8](https://github.com/Tencent/tdesign-react/commit/f40c1f8155eeaf54fd7168a47c3be24069baaaad)) [@nia3y](https://github.com/nia3y)
-  * 修复 `trigger` 元素变化后展示异常 ([e8687f2](https://github.com/Tencent/tdesign-react/commit/e8687f2ad9cf63a792ce39eb5fc0aaea62e495ea)) [@Hoofoo-WHU](https://github.com/Hoofoo-WHU)
-* Slider: 修复 `max` 数值过大浏览器崩溃问题 ([#624](https://github.com/Tencent/tdesign-react/issues/624)) ([052b08b](https://github.com/Tencent/tdesign-react/commit/052b08b03e547070903e737650d4e3b6efd14200)) [@honkinglin](https://github.com/honkinglin)
-* Breadcrumb: 修复面包屑初始样式被覆盖问题 ([e156a11](https://github.com/Tencent/tdesign-react/commit/e156a113b274ed1e1ee7e277c03eb5e04913dfc9)) [@yatessss](https://github.com/yatessss)
-* GlobalConfig: 修复 ts 类型问题 ([a2d22ae](https://github.com/Tencent/tdesign-react/commit/a2d22ae061c75ca730d6bcf5959c46e07123636e)) [@uyarn](https://github.com/uyarn)
-* Menu: 修复 `MenuGroup` 嵌套时样式问题 ([17b633a](https://github.com/Tencent/tdesign-react/commit/17b633ac47ab63a27c5001c3166c2feabfdb78e3)) [@ZhaoRB](https://github.com/ZhaoRB)
-* Select: 修复输入事件异常 ([267988d](https://github.com/Tencent/tdesign-react/commit/267988d3e873d5e05894362c0c9624ab3cff5434)) [@uyarn](https://github.com/uyarn)
-* Dialog: 修复 `destroy` 函数未真正销毁组件问题 ([376193d](https://github.com/Tencent/tdesign-react/commit/376193d7b95d569ac1a31d0be66d8a3a89f55cb8)) [@psaren](https://github.com/psaren)
-
+- Cascader:
+  - 修复 `filterable` 模式下展示异常 ([92c2776](https://github.com/Tencent/tdesign-react/commit/92c277608778f955108e5a9ff6e231473c2cd039)) [@jsonz1993](https://github.com/jsonz1993)
+  - 修复多选与筛选时文本过长的展示异常 ([6d3f0fc](https://github.com/Tencent/tdesign-react/commit/6d3f0fc82d80b927fff17ca09c24445f19c0881b)) [@jsonz1993](https://github.com/jsonz1993)
+- Popup:
+  - 修复初始化翻转逻辑判断错误 ([#615](https://github.com/Tencent/tdesign-react/issues/615)) ([b7bea93](https://github.com/Tencent/tdesign-react/commit/b7bea93d25e2908973335dc8099c2f85e04d04b0)) [@honkinglin](https://github.com/honkinglin)
+  - 修复嵌套浮层 `click` 时关闭异常 ([f40c1f8](https://github.com/Tencent/tdesign-react/commit/f40c1f8155eeaf54fd7168a47c3be24069baaaad)) [@nia3y](https://github.com/nia3y)
+  - 修复 `trigger` 元素变化后展示异常 ([e8687f2](https://github.com/Tencent/tdesign-react/commit/e8687f2ad9cf63a792ce39eb5fc0aaea62e495ea)) [@Hoofoo-WHU](https://github.com/Hoofoo-WHU)
+- Slider: 修复 `max` 数值过大浏览器崩溃问题 ([#624](https://github.com/Tencent/tdesign-react/issues/624)) ([052b08b](https://github.com/Tencent/tdesign-react/commit/052b08b03e547070903e737650d4e3b6efd14200)) [@honkinglin](https://github.com/honkinglin)
+- Breadcrumb: 修复面包屑初始样式被覆盖问题 ([e156a11](https://github.com/Tencent/tdesign-react/commit/e156a113b274ed1e1ee7e277c03eb5e04913dfc9)) [@yatessss](https://github.com/yatessss)
+- GlobalConfig: 修复 ts 类型问题 ([a2d22ae](https://github.com/Tencent/tdesign-react/commit/a2d22ae061c75ca730d6bcf5959c46e07123636e)) [@uyarn](https://github.com/uyarn)
+- Menu: 修复 `MenuGroup` 嵌套时样式问题 ([17b633a](https://github.com/Tencent/tdesign-react/commit/17b633ac47ab63a27c5001c3166c2feabfdb78e3)) [@ZhaoRB](https://github.com/ZhaoRB)
+- Select: 修复输入事件异常 ([267988d](https://github.com/Tencent/tdesign-react/commit/267988d3e873d5e05894362c0c9624ab3cff5434)) [@uyarn](https://github.com/uyarn)
+- Dialog: 修复 `destroy` 函数未真正销毁组件问题 ([376193d](https://github.com/Tencent/tdesign-react/commit/376193d7b95d569ac1a31d0be66d8a3a89f55cb8)) [@psaren](https://github.com/psaren)
 
 ### Features
 
-* Form: 新增动态表单能力，可使用 `FormList` 组件管理表单项 ([#602](https://github.com/Tencent/tdesign-react/issues/602)) ([3b82c6d](https://github.com/Tencent/tdesign-react/commit/3b82c6d8403b17ea19dde04f3d1e3234f8eee4ea)) [@honkinglin](https://github.com/honkinglin)
-* Popconfirm: 移除 `PopConfirm` 组件导出，请更改为 `Popconfirm` ([#614](https://github.com/Tencent/tdesign-react/issues/614)) ([ca6e4b6](https://github.com/Tencent/tdesign-react/commit/ca6e4b6852469bba35d47ba0811054fc796c1a69)) [@honkinglin](https://github.com/honkinglin)
-* Popup: 支持 `attach` 函数传入 `triggerNode` ([#616](https://github.com/Tencent/tdesign-react/issues/616)) ([95edef3](https://github.com/Tencent/tdesign-react/commit/95edef347a5b28f6791ac14684d0ae54e9974174)) [@honkinglin](https://github.com/honkinglin)
-
+- Form: 新增动态表单能力，可使用 `FormList` 组件管理表单项 ([#602](https://github.com/Tencent/tdesign-react/issues/602)) ([3b82c6d](https://github.com/Tencent/tdesign-react/commit/3b82c6d8403b17ea19dde04f3d1e3234f8eee4ea)) [@honkinglin](https://github.com/honkinglin)
+- Popconfirm: 移除 `PopConfirm` 组件导出，请更改为 `Popconfirm` ([#614](https://github.com/Tencent/tdesign-react/issues/614)) ([ca6e4b6](https://github.com/Tencent/tdesign-react/commit/ca6e4b6852469bba35d47ba0811054fc796c1a69)) [@honkinglin](https://github.com/honkinglin)
+- Popup: 支持 `attach` 函数传入 `triggerNode` ([#616](https://github.com/Tencent/tdesign-react/issues/616)) ([95edef3](https://github.com/Tencent/tdesign-react/commit/95edef347a5b28f6791ac14684d0ae54e9974174)) [@honkinglin](https://github.com/honkinglin)
 
 ## 0.30.2 `2022-04-08`
 
 ### Bug Fixes
 
-* Cascader: 修复定制数据字段别名 label 不展示问题 ([677f4e2](https://github.com/Tencent/tdesign-react/commit/677f4e2cd7c8a13d503fac485d0d2688ddfd429a)) [@jsonz1993](https://github.com/jsonz1993)
-* Form: 兼容 `FormItem` 单独使用报错问题 ([#588](https://github.com/Tencent/tdesign-react/issues/588)) ([275dd99](https://github.com/Tencent/tdesign-react/commit/275dd999b38adc2f7b8ce1ae156ef8266b935b05)) [@honkinglin](https://github.com/honkinglin)
-* Table:
-  * 修复 `table` 高度问题 ([#593](https://github.com/Tencent/tdesign-react/issues/593)) ([9de72b6](https://github.com/Tencent/tdesign-react/commit/9de72b6d129ac98f0ffb5962885aba78f291e236)) [@honkinglin](https://github.com/honkinglin)
-  * 修复 `table` `className` ts 类型丢失 ([#589](https://github.com/Tencent/tdesign-react/issues/589)) ([6349dba](https://github.com/Tencent/tdesign-react/commit/6349dbac2354d5a74dedbd38383b58abf827fc48)) [@honkinglin](https://github.com/honkinglin)
-* Upload: 修复多图片上传时 `defaultFiles` 造成上传进度错误 ([#586](https://github.com/Tencent/tdesign-react/issues/586)) ([f71499f](https://github.com/Tencent/tdesign-react/commit/f71499f77a59caf127f601eb747c2e8dd2b8c649)), closes [#584](https://github.com/Tencent/tdesign-react/issues/584) [@yaogengzhu](https://github.com/yaogengzhu)
-* Slider: 兼容不传 `value` 场景 ([1ab2a90](https://github.com/Tencent/tdesign-react/commit/1ab2a9054fee90f84ee2946bcd1b3b49799ad83d)) [@andyjxli](https://github.com/andyjxli)
-
+- Cascader: 修复定制数据字段别名 label 不展示问题 ([677f4e2](https://github.com/Tencent/tdesign-react/commit/677f4e2cd7c8a13d503fac485d0d2688ddfd429a)) [@jsonz1993](https://github.com/jsonz1993)
+- Form: 兼容 `FormItem` 单独使用报错问题 ([#588](https://github.com/Tencent/tdesign-react/issues/588)) ([275dd99](https://github.com/Tencent/tdesign-react/commit/275dd999b38adc2f7b8ce1ae156ef8266b935b05)) [@honkinglin](https://github.com/honkinglin)
+- Table:
+  - 修复 `Table` 高度问题 ([#593](https://github.com/Tencent/tdesign-react/issues/593)) ([9de72b6](https://github.com/Tencent/tdesign-react/commit/9de72b6d129ac98f0ffb5962885aba78f291e236)) [@honkinglin](https://github.com/honkinglin)
+  - 修复 `Table` `className` ts 类型丢失 ([#589](https://github.com/Tencent/tdesign-react/issues/589)) ([6349dba](https://github.com/Tencent/tdesign-react/commit/6349dbac2354d5a74dedbd38383b58abf827fc48)) [@honkinglin](https://github.com/honkinglin)
+- Upload: 修复多图片上传时 `defaultFiles` 造成上传进度错误 ([#586](https://github.com/Tencent/tdesign-react/issues/586)) ([f71499f](https://github.com/Tencent/tdesign-react/commit/f71499f77a59caf127f601eb747c2e8dd2b8c649)), closes [#584](https://github.com/Tencent/tdesign-react/issues/584) [@yaogengzhu](https://github.com/yaogengzhu)
+- Slider: 兼容不传 `value` 场景 ([1ab2a90](https://github.com/Tencent/tdesign-react/commit/1ab2a9054fee90f84ee2946bcd1b3b49799ad83d)) [@andyjxli](https://github.com/andyjxli)
 
 ### Features
 
-* Breadcrumb: 增加自定义 `children` 时对 `separator` 的支持 ([1ffcadb](https://github.com/Tencent/tdesign-react/commit/1ffcadb921d3779c0b3031e97ec8fbc8dd38b758)) [@LittlehorseXie](https://github.com/LittlehorseXie)
-* Popconfirm: 调整组件导出命名 ([#585](https://github.com/Tencent/tdesign-react/issues/585)) ([e24816d](https://github.com/Tencent/tdesign-react/commit/e24816d558c1fdda906b770bb379ca64a171bf50)) [@honkinglin](https://github.com/honkinglin)
-
+- Breadcrumb: 增加自定义 `children` 时对 `separator` 的支持 ([1ffcadb](https://github.com/Tencent/tdesign-react/commit/1ffcadb921d3779c0b3031e97ec8fbc8dd38b758)) [@LittlehorseXie](https://github.com/LittlehorseXie)
+- Popconfirm: 调整组件导出命名 ([#585](https://github.com/Tencent/tdesign-react/issues/585)) ([e24816d](https://github.com/Tencent/tdesign-react/commit/e24816d558c1fdda906b770bb379ca64a171bf50)) [@honkinglin](https://github.com/honkinglin)
 
 ## 0.30.1 `2022-04-01`
 
 ### Bug Fixes
 
-* Pagination: 修复输入框宽度自适应问题 ([b6ba28b](https://github.com/Tencent/tdesign-react/commit/b6ba28b2c4415297318b5d839589faf92a055b40)) [@uyarn](https://github.com/uyarn)
-* Datepicker: 修复区间时间选择时，月份/年份选择面板样式异常的问题，([#489](https://github.com/Tencent/tdesign-react/issues/489)) [@honkinglin](https://github.com/honkinglin)
-
+- Pagination: 修复输入框宽度自适应问题 ([b6ba28b](https://github.com/Tencent/tdesign-react/commit/b6ba28b2c4415297318b5d839589faf92a055b40)) [@uyarn](https://github.com/uyarn)
+- Datepicker: 修复区间时间选择时，月份/年份选择面板样式异常的问题，([#489](https://github.com/Tencent/tdesign-react/issues/489)) [@honkinglin](https://github.com/honkinglin)
 
 ### Features
 
-* Tabs: 优化组件内部逻辑 ([#521](https://github.com/Tencent/tdesign-react/pull/521)) [@LeeJim](https://github.com/LeeJim)
-
+- Tabs: 优化组件内部逻辑 ([#521](https://github.com/Tencent/tdesign-react/pull/521)) [@LeeJim](https://github.com/LeeJim)
 
 ## 0.30.0 `2022-03-31`
 
-
 ### BREAKING CHANGES
 
-* SelectInput: 之前只设置 `borderless` 就能达到自动适应宽度效果，之后需要同时设置 `autowidth` [@carolin913](https://github.com/carolin913)
-* FormItem: `label` 为空时不再渲染宽度，如需与有 `label` 的 `FormItem` 对齐需要手动控制 `FormItem` 样式 ([#552](https://github.com/Tencent/tdesign-react/issues/552)) ([a3a0376](https://github.com/Tencent/tdesign-react/commit/a3a03769254dcdf48ef7568894d65ee9e39b9640)) [@honkinglin](https://github.com/honkinglin)
+- SelectInput: 之前只设置 `borderless` 就能达到自动适应宽度效果，之后需要同时设置 `autowidth` [@carolin913](https://github.com/carolin913)
+- FormItem: `label` 为空时不再渲染宽度，如需与有 `label` 的 `FormItem` 对齐需要手动控制 `FormItem` 样式 ([#552](https://github.com/Tencent/tdesign-react/issues/552)) ([a3a0376](https://github.com/Tencent/tdesign-react/commit/a3a03769254dcdf48ef7568894d65ee9e39b9640)) [@honkinglin](https://github.com/honkinglin)
 
 ### Bug Fixes
 
-* Addon: 完善 type 类型 ([58b7ea5](https://github.com/Tencent/tdesign-react/commit/58b7ea5588645519e4b3dd7eb07c750c7d82edc2)) [@honkinglin](https://github.com/honkinglin)
-* Cascader: 修复 `multiple` 模式时 `value` `undefined` 崩溃 ([7bb0a88](https://github.com/Tencent/tdesign-react/commit/7bb0a8854a7ac2520072f7d3ff37dfe81c3ff41a)) [@docoder](https://github.com/docoder)
-* InputNumber: 修复不能输入小数点问题 ([802b3e0](https://github.com/Tencent/tdesign-react/commit/802b3e09853c6461d7119bca2c8a116566de1731)) [@docoder](https://github.com/docoder)
-* Loading: 修复在 `normal` 状态下属性失效问题 ([9cec56f](https://github.com/Tencent/tdesign-react/commit/9cec56f685adec17d1bbca831dee14cec09089a4)) [@uyarn](https://github.com/uyarn)
-* Popconfirm: 修复按需加载样式丢失问题 ([3329fa3](https://github.com/Tencent/tdesign-react/commit/3329fa3223d9b72dcddd29129f4d46b73447a01a)) [@xiaosansiji](https://github.com/xiaosansiji)
-* Dialog: 移除多余 `header` `dom` 元素 ([f902841](https://github.com/Tencent/tdesign-react/commit/f90284169d30c19550c4fa1b53f31cf257db0fac)) [@xiaosansiji](https://github.com/xiaosansiji)
-* Select: 修复首次 `focus` 自动搜索问题 ([78bf1ca](https://github.com/Tencent/tdesign-react/commit/78bf1ca4d7066f4702a6a6a33e4d284aad458b8c)) [@uyarn](https://github.com/uyarn)
-* Textarea: 修复 `dialog` 中无法输入中文问题 ([77f11ac](https://github.com/Tencent/tdesign-react/commit/77f11acf8f1c1fc8158d006e45f16e9c7d8fb8dd)) [@carolin913](https://github.com/carolin913)
+- Addon: 完善 type 类型 ([58b7ea5](https://github.com/Tencent/tdesign-react/commit/58b7ea5588645519e4b3dd7eb07c750c7d82edc2)) [@honkinglin](https://github.com/honkinglin)
+- Cascader: 修复 `multiple` 模式时 `value` `undefined` 崩溃 ([7bb0a88](https://github.com/Tencent/tdesign-react/commit/7bb0a8854a7ac2520072f7d3ff37dfe81c3ff41a)) [@docoder](https://github.com/docoder)
+- InputNumber: 修复不能输入小数点问题 ([802b3e0](https://github.com/Tencent/tdesign-react/commit/802b3e09853c6461d7119bca2c8a116566de1731)) [@docoder](https://github.com/docoder)
+- Loading: 修复在 `normal` 状态下属性失效问题 ([9cec56f](https://github.com/Tencent/tdesign-react/commit/9cec56f685adec17d1bbca831dee14cec09089a4)) [@uyarn](https://github.com/uyarn)
+- Popconfirm: 修复按需加载样式丢失问题 ([3329fa3](https://github.com/Tencent/tdesign-react/commit/3329fa3223d9b72dcddd29129f4d46b73447a01a)) [@xiaosansiji](https://github.com/xiaosansiji)
+- Dialog: 移除多余 `header` `dom` 元素 ([f902841](https://github.com/Tencent/tdesign-react/commit/f90284169d30c19550c4fa1b53f31cf257db0fac)) [@xiaosansiji](https://github.com/xiaosansiji)
+- Select: 修复首次 `focus` 自动搜索问题 ([78bf1ca](https://github.com/Tencent/tdesign-react/commit/78bf1ca4d7066f4702a6a6a33e4d284aad458b8c)) [@uyarn](https://github.com/uyarn)
+- Textarea: 修复 `dialog` 中无法输入中文问题 ([77f11ac](https://github.com/Tencent/tdesign-react/commit/77f11acf8f1c1fc8158d006e45f16e9c7d8fb8dd)) [@carolin913](https://github.com/carolin913)
 
 ### Features
 
-* FormItem: 支持自定义嵌套模式 & `label` 为空时不再处理占位对齐问题 ([#552](https://github.com/Tencent/tdesign-react/issues/552)) ([a3a0376](https://github.com/Tencent/tdesign-react/commit/a3a03769254dcdf48ef7568894d65ee9e39b9640)) [@honkinglin](https://github.com/honkinglin)
-* Input: `placeholder` 使用全局定义文案 ([#553](https://github.com/Tencent/tdesign-react/issues/553)) ([91f71cc](https://github.com/Tencent/tdesign-react/commit/91f71cc0a7e1d714ec7b2a8a9b3d38836ec88f6d)) [@xiaosansiji](https://github.com/xiaosansiji)
-* SelectInput: `borderless` 和 `autowidth` 作为独立属性分开 ([b805462](https://github.com/Tencent/tdesign-react/commit/b805462b48d3dc3d9b2d2ffce72f59f43d8a18f0)) [@carolin913](https://github.com/carolin913)
-
+- FormItem: 支持自定义嵌套模式 & `label` 为空时不再处理占位对齐问题 ([#552](https://github.com/Tencent/tdesign-react/issues/552)) ([a3a0376](https://github.com/Tencent/tdesign-react/commit/a3a03769254dcdf48ef7568894d65ee9e39b9640)) [@honkinglin](https://github.com/honkinglin)
+- Input: `placeholder` 使用全局定义文案 ([#553](https://github.com/Tencent/tdesign-react/issues/553)) ([91f71cc](https://github.com/Tencent/tdesign-react/commit/91f71cc0a7e1d714ec7b2a8a9b3d38836ec88f6d)) [@xiaosansiji](https://github.com/xiaosansiji)
+- SelectInput: `borderless` 和 `autowidth` 作为独立属性分开 ([b805462](https://github.com/Tencent/tdesign-react/commit/b805462b48d3dc3d9b2d2ffce72f59f43d8a18f0)) [@carolin913](https://github.com/carolin913)
 
 ## 0.29.0 `2022-03-25`
 
@@ -1210,7 +1314,7 @@ spline: explain
 
 - Select:
   - 修复 select `className` 透传问题 ([5fa9d1c](https://github.com/Tencent/tdesign-react/commit/5fa9d1c7bca7b0d6f6840fe2ee43840798820278)) [@honkinglin](https://github.com/honkinglin)
-  修复 select `overlayClassName` 丢失的问题 ([bfe85b0](https://github.com/Tencent/tdesign-react/commit/bfe85b0aa37f536b9719df7226611b8f5dcea8fb)) [insekkei](https://github.com/insekkei)
+    修复 select `overlayClassName` 丢失的问题 ([bfe85b0](https://github.com/Tencent/tdesign-react/commit/bfe85b0aa37f536b9719df7226611b8f5dcea8fb)) [insekkei](https://github.com/insekkei)
   - Option 子组件配合自定义 keys 使用异常 ([#513](https://github.com/Tencent/tdesign-react/issues/513)) ([9f51f42](https://github.com/Tencent/tdesign-react/commit/9f51f423ed9dab86498b98a649a76b7d4b1deddc)) [@samhou1988](https://github.com/samhou1988)
 - Selectinput:
   - `onclear` 受控非受控逻辑导致卡死 ([28dcde6](https://github.com/Tencent/tdesign-react/commit/28dcde6e8f6e82a666604864abde4537d327122c)) [@carolin913](https://github.com/carolin913)
@@ -1231,7 +1335,6 @@ spline: explain
 - Input: 增加 `inputClass` API，用于透传 class 到 `t-input` 同级 ([#528](https://github.com/Tencent/tdesign-react/pull/528)) [@pengYYYYY](https://github.com/pengYYYYY)
 - Upload: 支持 `modify` method ([82a26da](https://github.com/Tencent/tdesign-react/commit/82a26dacb1de1a4700911307413563f8ec5e9b19)) [@samhou1988](https://github.com/samhou1988)
 - InputNumber: 默认尺寸下输入框宽度调整，修复默认内容展示不全的问题，[issue #623](https://github.com/Tencent/tdesign-vue/issues/623) [@xiaosansiji](https://github.com/xiaosansiji)
-
 
 ## 0.28.0 `2022-03-18`
 

--- a/packages/tdesign-react/CHANGELOG.en-US.md
+++ b/packages/tdesign-react/CHANGELOG.en-US.md
@@ -5,52 +5,64 @@ toc: false
 spline: explain
 ---
 
-## 🌈 1.16.3 `2026-01-04` 
+## 🌈 1.16.3 `2026-01-04`
 
 ### 🐞 Bug Fixes
+
 - `Dialog`: Fixed an issue where the optimization implemented in version `1.16.0` prevented the use of the `esc` key to close nested dialog boxes @RylanBot ([#4030](https://github.com/Tencent/tdesign-react/pull/4030))
 - `Popup`: @RylanBot ([#4057](https://github.com/Tencent/tdesign-react/pull/4057))
-  - Fixed an issue where a refactor in version `1.16.0` caused the popup layer not to appear when the `trigger` element was an SVG or similar type 
+  - Fixed an issue where a refactor in version `1.16.0` caused the popup layer not to appear when the `trigger` element was an SVG or similar type
   - Fixed an issue where a refactor in version `1.16.0` allowed the popup layer to be triggered even when the `trigger` element was set to `disabled`
 
-## 🌈 1.16.2 `2025-12-30` 
+## 🌈 1.16.2 `2025-12-30`
 
 ### 🐞 Bug Fixes
-- `Popup`: 
+
+- `Popup`:
   - Fixed an issue where the popup would unexpectedly close when `'trigger='hover'` was enabled and external elements were dynamically updated, due to the restructuring in version `1.16.0` @RylanBot ([#4046](https://github.com/Tencent/tdesign-react/pull/4046))
   - Fixed an issue where the position of the popup became unstable in certain scenarios after the restructuring in version `1.16.0` @xiaody ([#4046](https://github.com/Tencent/tdesign-react/pull/4046))
   - Improved the optimization for arrow offset when there is not enough space, implemented in version `1.16.0` @RylanBot ([#4042](https://github.com/Tencent/tdesign-react/pull/4042))
-- `Select`: 
+- `Select`:
   - Fixed an issue where the `onClose` callback function of `valueDisplay` would receive `undefined` as a value @RSS1102 ([#4047](https://github.com/Tencent/tdesign-react/pull/4047))
   - Fixed an issue where values that were not included in the `options` list could not be rendered when the `multiple` option was enabled after version `1.15.7` @RylanBot ([#4037](https://github.com/Tencent/tdesign-react/pull/4037))
   - Fixed an issue where, after the `filterable` option was enabled, the highlighted items in the keyboard navigation would not update even when the options changed @RylanBot ([#4037](https://github.com/Tencent/tdesign-react/pull/4037))
 
-## 🌈 1.16.1 `2025-12-22` 
+## 🌈 1.16.1 `2025-12-22`
+
 ### 🐞 Bug Fixes
+
 - `Textarea`: Fixed warning issues caused by using `defaultValue` or `readonly` @RylanBot ([#4019](https://github.com/Tencent/tdesign-react/pull/4019))
 - `Text`: Fixed error issues caused by reading `undefined` @RylanBot ([#4020](https://github.com/Tencent/tdesign-react/pull/4020))
 - `Guide`: Fixed error issues caused by reading `null` in certain scenarios @RylanBot ([#4027](https://github.com/Tencent/tdesign-react/pull/4027))
-- `Popup`: 
+- `Popup`:
   - Fixed error issues in SSR environment caused by refactoring in version `1.16.0` @RylanBot ([#4026](https://github.com/Tencent/tdesign-react/pull/4026))
   - Fixed issue where inner popups could not be closed properly in nested scenarios caused by refactoring in version `1.16.0` @RylanBot ([#4023](https://github.com/Tencent/tdesign-react/pull/4023))
+
 ### 🚧 Others
+
 - Fixed warning caused by non-existent `sourceMap` references in build artifacts of version `1.16.0` @RylanBot ([#4022](https://github.com/Tencent/tdesign-react/pull/4022))
 - `TagInput`: Removed redundant logs introduced in version `1.16.0` @RylanBot ([#4021](https://github.com/Tencent/tdesign-react/pull/4021))
 
-## 🌈 1.16.0 `2025-12-15` 
+## 🌈 1.16.0 `2025-12-15`
+
 ### 🚨 Breaking Changes
+
 - `MessagePlugin`: Removed message container `id='tdesign-message-container--${placement}'`. Businesses that previously relied on this property should note this change ⚠️ @RylanBot ([#3820](https://github.com/Tencent/tdesign-react/pull/3820))
+
 ### 🚀 Features
+
 - Added API `readOnly` to components supporting `readonly`, with the same effect as `readonly`. The original `readonly` will be retained and will be deprecated in future versions. It is recommended to update in time ⚠️ @RylanBot ([#3955](https://github.com/Tencent/tdesign-react/pull/3955))
 - Support `.dark` class name, enriching ways to switch to dark mode @liweijie0812 ([common#2355](https://github.com/Tencent/tdesign-common/pull/2355))
 - `Dialog`: Optimized rendering phase to avoid child element calculation exceptions. Those who previously had complex content rendering in Dialog should note this change ⚠️ @HaixingOoO ([#3705](https://github.com/Tencent/tdesign-react/pull/3705))
 - `Form`: Preserve original HTML effect. When Enter key is pressed on input box, submit event is automatically triggered. If you need to intercept this behavior, you can bind `onEnter={(e)=>e.preventDefault()}` to input box. Those who previously relied on this built-in feature should note this change ⚠️ @RylanBot ([#3943](https://github.com/Tencent/tdesign-react/pull/3943))
 - `MessagePlugin`: Added animation effects for opening and closing @RylanBot ([#3820](https://github.com/Tencent/tdesign-react/pull/3820))
-- `ImageViewer`: 
+- `ImageViewer`:
   - Added default trigger rendering, defaulting to current image as the default trigger, reducing component usage complexity. Refer to related example changes for details @wonkzhang ([#3819](https://github.com/Tencent/tdesign-react/pull/3819))
   - Optimized format processing and compression ratio when downloading cross-domain images @RylanBot ([#3919](https://github.com/Tencent/tdesign-react/pull/3919))
   - Support direct download of same-domain images, avoiding volume increase and animated image failure caused by secondary conversion @RylanBot ([#3919](https://github.com/Tencent/tdesign-react/pull/3919))
+
 ### 🐞 Bug Fixes
+
 - `Textarea`: Corrected initial value corresponding to `status` and class name to `default`, with corresponding adjustments to internal class names. Those who previously covered tips class names should note this change ⚠️ @RylanBot ([#4007](https://github.com/Tencent/tdesign-react/pull/4007))
 - `Avatar`: Fixed style inconsistency with design specifications @liweijie0812 ([common#2364](https://github.com/Tencent/tdesign-common/pull/2364))
 - `ConfigProvider`: Fixed `tag.closeIcon` not working @RylanBot ([#4004](https://github.com/Tencent/tdesign-react/pull/4004))
@@ -62,34 +74,44 @@ spline: explain
   - Fixed issue where subsequent global messages were also bound to that node after custom `attach`
   - Fixed issue where `closeAll` could not close all messages
 - `EnhancedTable`: Fixed issue where header checkbox state was abnormal when child nodes collapsed @liweijie0812 ([#3988](https://github.com/Tencent/tdesign-react/pull/3988))
-- `Table`: 
+- `Table`:
   - Fixed issue where editable cell data was not synchronized after editing in multi-level header scenarios @RylanBot ([#3982](https://github.com/Tencent/tdesign-react/pull/3982))
   - Fixed missing `context.currentData` in filter scenarios for `onChange` @RylanBot ([#3982](https://github.com/Tencent/tdesign-react/pull/3982))
   - Fixed issues such as header misalignment and empty state not being centered due to unstable table width calculation timing @RylanBot ([#3972](https://github.com/Tencent/tdesign-react/pull/3972))
-- `Popup`: 
+- `Popup`:
   - Fixed arrow offset when space is insufficient @RylanBot ([#3980](https://github.com/Tencent/tdesign-react/pull/3980))
   - Set container position to `absolute` uniformly, fixing positioning exceptions in some scenarios @RylanBot ([#3916](https://github.com/Tencent/tdesign-react/pull/3916))
   - Fixed issue where `triggerElement` of string type was not correctly parsed as element selector @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
   - Fixed issue where popup could not appear normally when `children` was a wrapped component that does not support `ref` penetration @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
 - `PopupPlugin`: Fixed `classPrefix` not working @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
 
-## 🌈 1.15.11 `2025-12-15` 
+## 🌈 1.15.11 `2025-12-15`
+
 ### 🚀 Features
+
 - `Textarea`: Support `count` API for custom counting element rendering @RylanBot ([#4003](https://github.com/Tencent/tdesign-react/pull/4003))
+
 ### 🐞 Bug Fixes
+
 - `RadioGroup`: Fixed infinite loop issue in NextJS when `variant="default-filled"` and child components contain dynamic content @tingtingcheng6 ([#3921](https://github.com/Tencent/tdesign-react/pull/3921))
 
-## 🌈 1.15.10 `2025-12-12` 
+## 🌈 1.15.10 `2025-12-12`
+
 ### 🐞 Bug Fixes
+
 - `Drawer`: Fixed callback event incorrect caching issue @uyarn ([#4008](https://github.com/Tencent/tdesign-react/pull/4008))
 
-## 🌈 1.15.9 `2025-11-28` 
+## 🌈 1.15.9 `2025-11-28`
+
 ### 🚀 Features
+
 - `Cascader`: Support displaying non-leaf nodes in `filterable` options when `valueMode` is `all` or `parentFirst` @lifeiFront ([#3964](https://github.com/Tencent/tdesign-react/pull/3964))
 - `Popup`: Added multiple component instance methods: `getOverlay` for getting overlay element, `getOverlayState` for getting overlay hover state, `getPopper` for getting current component popper instance, `update` for updating overlay content @RSS1102 ([#3925](https://github.com/Tencent/tdesign-react/pull/3925))
 - `Select`: Support keyboard operations for options @uyarn ([#3969](https://github.com/Tencent/tdesign-react/pull/3969))
 - `Swiper`: Support `cardScale` API for controlling card scaling ratio @RylanBot ([#3978](https://github.com/Tencent/tdesign-react/pull/3978))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: Fixed `reserveKeyword` not working @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
 - `Description`: Fixed spacing issue with `itemLayout='vertical'` in borderless mode @mikasayw ([common#2321](https://github.com/Tencent/tdesign-common/pull/2321))
 - `Input`: Fixed issue where `autoWidth` failed on initial render in Safari for the component and upstream components such as `Select` @Cat1007 ([common#2336](https://github.com/Tencent/tdesign-common/pull/2336))
@@ -109,23 +131,29 @@ spline: explain
   - Fixed issue where `onValuesChange` was not triggered when calling `setFieldsValue` during initialization
   - Fixed `setFieldValues` failure when `name` is a number or contains numbers in non-dynamic form scenarios
   - Optimized `key` generation, elements not refreshed when updated value is same as current form value
-- `Tree`: 
+- `Tree`:
   - Fixed issue where filtered nodes were unexpectedly disabled @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
   - Fixed issue where `setData` did not automatically trigger UI refresh @RylanBot ([common#2283](https://github.com/Tencent/tdesign-common/pull/2283))
 - `TreeSelect`: @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
   - Fixed issue where parent nodes of filtered nodes could still be selected
   - Fixed issue where input content was not cleared on `blur`
+
 ### 🚧 Others
+
 - `Slider`: Enhanced component generic support for better `value` and `onChange` interaction @RylanBot ([#3962](https://github.com/Tencent/tdesign-react/pull/3962))
 
-## 🌈 1.15.8 `2025-11-04` 
+## 🌈 1.15.8 `2025-11-04`
+
 ### 🚀 Features
+
 - `Popup`: Added `onOverlayClick` event to support content panel click triggering @RSS1102 ([#3927](https://github.com/Tencent/tdesign-react/pull/3927))
 - `CheckboxGroup`: Support `readonly` API @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
 - `Form`: @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
   - Support `readonly` API
   - Support `FormRule.pattern` type as `string`
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where select all function was abnormal in group mode in version `1.15.7` @uyarn ([#3941](https://github.com/Tencent/tdesign-react/pull/3941))
 - `Form`: Fixed issue where nested `FormList` could not use `setFields` to update form @RylanBot ([#3930](https://github.com/Tencent/tdesign-react/pull/3930))
 - `CheckboxGroup`: Fixed issue where options set to `disabled` would have their status changed by `checkAll` @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
@@ -133,7 +161,7 @@ spline: explain
 - `DatePicker`: Fixed issue where popup would close after selecting date without selecting time when both `enableTimePicker` and `needConfirm={false}` were enabled @RylanBot ([#3860](https://github.com/Tencent/tdesign-react/pull/3860))
 - `DateRangePicker`: Fixed issue where manual confirmation was still required when both `enableTimePicker` and `needConfirm={false}` were enabled @achideal ([#3860](https://github.com/Tencent/tdesign-react/pull/3860))
 - `Progress`: Fixed issue where custom `label` was hidden when `theme='plump'` was enabled @RylanBot ([#3931](https://github.com/Tencent/tdesign-react/pull/3931))
-- `RadioGroup`: @RylanBot 
+- `RadioGroup`: @RylanBot
   - Fixed highlight abnormality when child elements were dynamically updated ([#3922](https://github.com/Tencent/tdesign-react/pull/3922))
   - Fixed issue where highlight block did not disappear when `value` was set to empty ([#3944](https://github.com/Tencent/tdesign-react/pull/3944))
 - `Tree`: @RylanBot
@@ -143,10 +171,13 @@ spline: explain
   - Fixed abnormality where row node was set to `active` when clicking `operation` area ([#3889](https://github.com/Tencent/tdesign-react/pull/3889))
 
 ### 🚧 Others
+
 - `Form`: Optimized underlying logic of `getValidateMessage` method @RylanBot ([#3930](https://github.com/Tencent/tdesign-react/pull/3930))
 
-## 🌈 1.15.7 `2025-10-24` 
+## 🌈 1.15.7 `2025-10-24`
+
 ### 🚀 Features
+
 - `Avatar`: Added `Click`, `Hover` and `Contextmenu` and other mouse events to support avatar operation scenarios @NWYLZW ([#2906](https://github.com/Tencent/tdesign-react/pull/2906))
 - `Dialog`: Support `setConfirmLoading` usage @ZWkang ([#2883](https://github.com/Tencent/tdesign-react/pull/2883))
 - `SelectInput`: Support `size` property @HaixingOoO ([#2894](https://github.com/Tencent/tdesign-react/pull/2894))
@@ -158,66 +189,84 @@ spline: explain
 - `TagInput`: Added `borderless` API to support borderless mode @uyarn ([#2878](https://github.com/Tencent/tdesign-react/pull/2878))
 - `TimePicker`: Added `borderless` API to support borderless mode @uyarn ([#2878](https://github.com/Tencent/tdesign-react/pull/2878))
 - `Scroll`: Adjusted Chrome scrollbar style compatibility method after `1.6.0`, not dependent on `autoprefixer` version @loopzhou ([#2890](https://github.com/Tencent/tdesign-react/pull/2890))
+
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: Fixed issue where channel button position did not change when switching preview colors @fennghuang ([#2880](https://github.com/Tencent/tdesign-react/pull/2880))
 - `Form`: Fixed issue where `FormItem` modification did not trigger listening to `FormList`'s `useWatch` @HaixingOoO ([#2904](https://github.com/Tencent/tdesign-react/pull/2904))
-- `Menu`: @uyarn 
+- `Menu`: @uyarn
   - Fixed issue where using `dist` styles caused submenu position offset due to style priority issues ([#2890](https://github.com/Tencent/tdesign-react/pull/2890))
   - Increased `t-popup__menu` style priority to resolve style abnormality caused by consistent priority within dist ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
 - `Pagination`: Fixed issue where entering decimals did not automatically adjust @uyarn ([#2886](https://github.com/Tencent/tdesign-react/pull/2886))
-- `Select`: 
-   - Fixed `creatable` functionality abnormality @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
-   - Fixed `reserveKeyword`配合 `Option Children` usage abnormality @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
-   - Optimized issue where selected style covered disabled style @fython ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
+- `Select`:
+  - Fixed `creatable` functionality abnormality @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
+  - Fixed `reserveKeyword`配合 `Option Children` usage abnormality @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
+  - Optimized issue where selected style covered disabled style @fython ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
 - `Slider`: Fixed issue where `sliderRef.current` could be empty @ZWkang ([#2868](https://github.com/Tencent/tdesign-react/pull/2868))
-- `Table`: 
+- `Table`:
   - Fixed error where data was empty when unloading table @duxphp ([#2900](https://github.com/Tencent/tdesign-react/pull/2900))
   - Fixed abnormality where using fixed columns caused issues in some scenarios after version `1.5.0` @uyarn ([#2889](https://github.com/Tencent/tdesign-react/pull/2889))
 - `TagInput`:
   - Fixed issue where `tagProps` was not passed to collapsed options @uyarn ([#2869](https://github.com/Tencent/tdesign-react/pull/2869))
   - Extended `collapsedItems` deletion functionality @HaixingOoO ([#2881](https://github.com/Tencent/tdesign-react/pull/2881))
 - `TreeSelect`: Fixed issue where `keys` property had to be set through `treeProps` to work @ZWkang ([#2896](https://github.com/Tencent/tdesign-react/pull/2896))
-- `Upload`: 
+- `Upload`:
   - Fixed bug where upload progress could be manually modified @HaixingOoO ([#2901](https://github.com/Tencent/tdesign-react/pull/2901))
   - Fixed style abnormality of image upload in error type @uyarn ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
+
 ### 🚧 Others
+
 - `TagInput`: Added `Size` property related documentation @HaixingOoO ([#2894](https://github.com/Tencent/tdesign-react/pull/2894))
 - `Typography`: Removed redundant `defaultProps` @HaixingOoO ([#2866](https://github.com/Tencent/tdesign-react/pull/2866))
 - `Upload`: Fixed documentation description about OPTIONS method @Summer-Shen ([#2865](https://github.com/Tencent/tdesign-react/pull/2865))
 
-## 🌈 1.15.6 `2025-10-10` 
+## 🌈 1.15.6 `2025-10-10`
+
 ### 🐞 Bug Fixes
+
 - `VirtualScroll`: Fixed component warning issue when using virtual scrolling with child components in async request scenarios @uyarn ([#3876](https://github.com/Tencent/tdesign-react/pull/3876))
 
-## 🌈 1.15.5 `2025-10-05` 
+## 🌈 1.15.5 `2025-10-05`
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: Fixed usage issue in SSR scenarios in version `1.15.2` @Wesley-0808([#3873](https://github.com/Tencent/tdesign-react/pull/3873))
 - `Descriptions`: Fixed spacing issue in borderless mode @liweijie0812 ([#3873](https://github.com/Tencent/tdesign-react/pull/3873))
 
-## 🌈 1.15.4 `2025-10-01` 
+## 🌈 1.15.4 `2025-10-01`
+
 ### 🚀 Features
+
 - `ImageViewer`: Support `trigger` passing image `index` parameter, `trigger`'s `open` method parameters may have type differences with bound element trigger events. If encountering this issue, please change to anonymous function like `()=> open()` @betavs ([#3827](https://github.com/Tencent/tdesign-react/pull/3827))
+
 ### 🐞 Bug Fixes
+
 - `Swiper`: Fixed issue where auto-play failed after clicking navigation bar in mobile environment @uyarn ([#3862](https://github.com/Tencent/tdesign-react/pull/3862))
 - `List`: Removed redundant code introduced in version `1.15.2` that caused initialization lag when virtual scrolling was enabled @RylanBot ([#3863](https://github.com/Tencent/tdesign-react/pull/3863))
 - `Select`: Removed redundant code introduced in version `1.15.2` that caused initialization lag when virtual scrolling was enabled @RylanBot ([#3863](https://github.com/Tencent/tdesign-react/pull/3863))
 
-## 🌈 1.15.3 `2025-09-29` 
+## 🌈 1.15.3 `2025-09-29`
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where `OptionGroup`'s `style` and `className` were ineffective @uyarn ([#3855](https://github.com/Tencent/tdesign-react/pull/3855))
 
-## 🌈 1.15.2 `2025-09-29` 
+## 🌈 1.15.2 `2025-09-29`
+
 ### 🚀 Features
+
 - `Watermark`: Added `layout` API to support generating different layout watermarks, `watermarkText` supports font configuration @Wesley-0808 ([#3817](https://github.com/Tencent/tdesign-react/pull/3817))
 - `Drawer`: Optimized issue where component content was selected during drag resizing @uyarn ([#3844](https://github.com/Tencent/tdesign-react/pull/3844))
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: Fixed issue where entire canvas content was grayscale when multi-line image watermark was configured with grayscale @Wesley-0808 ([#3817](https://github.com/Tencent/tdesign-react/pull/3817))
 - `Slider`: Fixed return value and display abnormality caused by precision issue after setting `step` @uyarn ([#3821](https://github.com/Tencent/tdesign-react/pull/3821))
 - `TagInput`: Fixed issue where `inputValue` in `onBlur` was always empty @RylanBot ([#3841](https://github.com/Tencent/tdesign-react/pull/3841))
 - `Cascader`: Fixed issue where parent node was unexpectedly highlighted when selecting only child node in `single` mode @RylanBot ([#3840](https://github.com/Tencent/tdesign-react/pull/3840))
 - `DateRangePickerPanel`: Fixed issue where clicking panel couldn't sync when `preset` involved cross-year dates @RylanBot ([#3818](https://github.com/Tencent/tdesign-react/pull/3818))
 - `EnhancedTable`: Fixed issue where position was reset when clicking expand after node drag @RylanBot ([#3780](https://github.com/Tencent/tdesign-react/pull/3780))
-- `Table`: @RylanBot 
+- `Table`: @RylanBot
   - Fixed issue where `onSortChange` always returned `undefined` when `multipleSort` was enabled but `sort` or `defaultSort` was not declared ([#3824](https://github.com/Tencent/tdesign-react/pull/3824))
   - Fixed issue where last row content was blocked when virtual scrolling and `firstFullRow`/`lastFullRow` etc. were enabled simultaneously ([#3792](https://github.com/Tencent/tdesign-react/pull/3792))
   - Fixed issue where `fixedRows`/`firstFullRow`/`lastFullRow` couldn't be used in combination under virtual scrolling ([#3792](https://github.com/Tencent/tdesign-react/pull/3792))
@@ -229,36 +278,42 @@ spline: explain
 - `SelectInput`: @RylanBot ([#3838](https://github.com/Tencent/tdesign-react/pull/3838))
   - Fixed issue where `onBlur` was ineffective when custom `popupVisible={false}`
   - Fixed issue where `onBlur` lacked `tagInputValue` parameter when `multiple` was enabled
-- `Select`: 
+- `Select`:
   - Fixed issue where using `keys` to configure `content` as `label` or `value` was ineffective @RylanBot @uyarn ([#3829](https://github.com/Tencent/tdesign-react/pull/3829))
   - Fixed issue where white screen and scrollbar were unexpectedly reset when dynamically switching to virtual scrolling @RylanBot ([#3792](https://github.com/Tencent/tdesign-react/pull/3792)) ([#3836](https://github.com/Tencent/tdesign-react/pull/3836))
   - Fixed issue where display data was out of sync when virtual scrolling was enabled and data was dynamically updated @huangchen1031 ([#3839](https://github.com/Tencent/tdesign-react/pull/3839))
-- `List`: 
+- `List`:
   - Fixed issue where some `ListItem` APIs were ineffective when virtual scrolling was enabled @FlowerBlackG ([#3835](https://github.com/Tencent/tdesign-react/pull/3835))
   - Fixed issue where scrollbar was unexpectedly reset when dynamically switching to virtual scrolling @RylanBot ([#3792](https://github.com/Tencent/tdesign-react/pull/3792)) ([#3836](https://github.com/Tencent/tdesign-react/pull/3836))
 
-## 🌈 1.15.1 `2025-09-12` 
+## 🌈 1.15.1 `2025-09-12`
+
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: Fixed issue where `imageScale` configuration effect was abnormal @uyarn ([#3814](https://github.com/Tencent/tdesign-react/pull/3814))
 
-## 🌈 1.15.0 `2025-09-11` 
+## 🌈 1.15.0 `2025-09-11`
+
 ### 🚀 Features
+
 - `Icon`: @uyarn ([#3802](https://github.com/Tencent/tdesign-react/pull/3802))
-  - `tdesign-icons-react` released version `0.6.0`, added `align-bottom`, `no-result`, `no-result-filled`, `tree-list`, `wifi-no`, `wifi-no-filled`, `logo-stackblitz-filled`, `logo-stackblitz`, `logo-wecom-filled` icons, removed `video-camera-3`, `video-camera-3-filled`, `list` icons. Those who relied on the following icons should note this upgrade ⚠️ 
+  - `tdesign-icons-react` released version `0.6.0`, added `align-bottom`, `no-result`, `no-result-filled`, `tree-list`, `wifi-no`, `wifi-no-filled`, `logo-stackblitz-filled`, `logo-stackblitz`, `logo-wecom-filled` icons, removed `video-camera-3`, `video-camera-3-filled`, `list` icons. Those who relied on the following icons should note this upgrade ⚠️
   - Icon resources used by on-demand loading support variable stroke width feature, configured through `strokeWidth` property
   - Icon resources used by on-demand loading support multi-color fill feature, configured through `strokeColor` and `fillColor` properties
 - `DatePicker`: Support not closing popup when clicking `preset` by overriding `popupProps` @RylanBot ([#3798](https://github.com/Tencent/tdesign-react/pull/3798))
+
 ### 🐞 Bug Fixes
+
 - `Tree`: @RylanBot ([#3756](https://github.com/Tencent/tdesign-react/pull/3756))
   - Corrected node property `date-target` spelling to `data-target`, businesses that used this property before should note this change ⚠️
   - Fixed issue where expand/collapse icon display was abnormal after dragging
 - `MessagePlugin`: Fixed error when `content` was `''`/`undefined`/`null` @RylanBot ([#3778](https://github.com/Tencent/tdesign-react/pull/3778))
-- `Table`: 
+- `Table`:
   - Fixed page flickering issue caused by `Loading` mounting when `<React.StrictMode>` was not enabled @RylanBot ([#3775](https://github.com/Tencent/tdesign-react/pull/3775))
   - Fixed abnormality where `firstFullRow` size was larger than `size='medium'` when `size='small'` ([common2253](https://github.com/Tencent/tdesign-common/pull/2253))
 - `Upload`: Fixed `status` update error in drag mode @RSS1102 ([#3801](https://github.com/Tencent/tdesign-react/pull/3801))
 - `Input`: Fixed issue where `onFocus` and `onBlur` weren't triggered when `readonly` or disabling `allowInput` @RylanBot ([#3800](https://github.com/Tencent/tdesign-react/pull/3800))
-- `Cascader`: 
+- `Cascader`:
   - Fixed issue where `valueDisplay` rendering was abnormal when `multiple` and `valueType='full'` were enabled @RSS1102 ([#3809](https://github.com/Tencent/tdesign-react/pull/3809))
   - Fixed issue where bottom options couldn't be selected caused by new features introduced in version `1.11.0` @RylanBot ([#3772](https://github.com/Tencent/tdesign-react/pull/3772))
 - `Select`: Avoid frequent repeated triggering of `valueDisplay` rendering when dropdown opens and closes @RylanBot ([#3808](https://github.com/Tencent/tdesign-react/pull/3808))
@@ -267,30 +322,42 @@ spline: explain
 - `Drawer`: Fixed infinite loop issue caused by using `ref` in React 19 environment @RylanBot ([#3799](https://github.com/Tencent/tdesign-react/pull/3799))
 - `Popup`: Fixed issue where moving out of Trigger element was abnormal when `delay` was set to 0 @HaixingOoO ([#3806](https://github.com/Tencent/tdesign-react/pull/3806))
 - `Tooltip`: Fixed incomplete type issue with `delay` API @HaixingOoO ([#3806](https://github.com/Tencent/tdesign-react/pull/3806))
+
 ### 🚧 Others
+
 - `react-render`: Fixed issue where warning about needing to import related modules still appeared after introducing `react-19-adapter` @HaixingOoO ([#3790](https://github.com/Tencent/tdesign-react/pull/3790))
 
-## 🌈 1.14.5 `2025-08-26` 
+## 🌈 1.14.5 `2025-08-26`
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: Improved watermark component compatibility in SSR scenarios @uyarn ([#3765](https://github.com/Tencent/tdesign-react/pull/3765))
 
-## 🌈 1.14.3 `2025-08-26` 
+## 🌈 1.14.3 `2025-08-26`
+
 ### 🐞 Bug Fixes
+
 - `Pagination`: Fixed issue where jump icon didn't reset to correct state @phalera ([#3758](https://github.com/Tencent/tdesign-react/pull/3758))
 - `Watermark`: @uyarn ([#3760](https://github.com/Tencent/tdesign-react/pull/3760))
   - Fixed issue where default text color lacked transparency in version `1.14.0`
   - Fixed issue where version `1.14.0` was incompatible with SSR scenarios
 
-## 🌈 1.14.2 `2025-08-22` 
+## 🌈 1.14.2 `2025-08-22`
+
 ### 🐞 Bug Fixes
+
 - `Dialog`: Fixed issue where `draggable` disable failed due to new features introduced in version `1.14.0` @RylanBot ([#3753](https://github.com/Tencent/tdesign-react/pull/3753))
 
-## 🌈 1.14.1 `2025-08-22` 
+## 🌈 1.14.1 `2025-08-22`
+
 ### 🐞 Bug Fixes
+
 - `Steps`: Fixed issue where icons were repeatedly rendered when `theme` was not `default` caused by version `1.13.2` @RSS1102 ([#3748](https://github.com/Tencent/tdesign-react/pull/3748))
 
-## 🌈 1.14.0 `2025-08-21` 
+## 🌈 1.14.0 `2025-08-21`
+
 ### 🚀 Features
+
 - `Tabs`: Moved `remove` event from delete icon to outer container to ensure replace icon functionality works normally. Those who overrode delete icon styles should note this change ⚠️ @RSS1102 ([#3736](https://github.com/Tencent/tdesign-react/pull/3736))
 - `Card`: Added `headerClassName`, `headerStyle`, `bodyClassName`, `bodyStyle`, `footerClassName`, `footerStyle` for easy customization of card component parts @lifeiFront ([#3737](https://github.com/Tencent/tdesign-react/pull/3737))
 - `Form`: `rules` support configuring nested fields for validation @uyarn ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
@@ -304,32 +371,36 @@ spline: explain
 - `ImageViewer`: Support `draggable` property to take effect on mobile @RylanBot ([#3723](https://github.com/Tencent/tdesign-react/pull/3723))
 - `Slider`: Support dragging on mobile @RylanBot ([#3723](https://github.com/Tencent/tdesign-react/pull/3723))
 - `Statistic`: Changed `color` property type to string to support any [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) supported color values @RSS1102 ([#3706](https://github.com/Tencent/tdesign-react/pull/3706))
+
 ### 🐞 Bug Fixes
+
 - `Tree`: @RylanBot
-  - Fixed issue where `draggable` was still effective in `disabled` state. Businesses that relied on this error should note this change ⚠️ ([#3740](https://github.com/Tencent/tdesign-react/pull/3740)) 
+  - Fixed issue where `draggable` was still effective in `disabled` state. Businesses that relied on this error should note this change ⚠️ ([#3740](https://github.com/Tencent/tdesign-react/pull/3740))
   - Fixed issue where parent node `disabled` state wasn't associated when `checkStrictly` was false by default ([#3739](https://github.com/Tencent/tdesign-react/pull/3739))
   - Fixed issue where `node` was null in drag-related event callbacks ([#3728](https://github.com/Tencent/tdesign-react/pull/3728))
 - `Form`: @uyarn
-    - Fixed issue where nested form data construction was affected by outer `FormList` ([#3715](https://github.com/Tencent/tdesign-react/pull/3715))
-    - Fixed issue where inner form validation result fields were affected by outer form in nested forms ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
+  - Fixed issue where nested form data construction was affected by outer `FormList` ([#3715](https://github.com/Tencent/tdesign-react/pull/3715))
+  - Fixed issue where inner form validation result fields were affected by outer form in nested forms ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
 - `FormList`: Fixed issue where new data couldn't be added when manually setting initial values with `setFields` instead of using `initialData` caused by fix introduced in `1.13.2` @RylanBot ([#3730](https://github.com/Tencent/tdesign-react/pull/3730))
 - `Input`: Fixed issue where cursor position wasn't preserved when clicking icon to toggle content visibility in password input @RylanBot ([#3726](https://github.com/Tencent/tdesign-react/pull/3726))
 - `Table`: @RylanBot ([#3733](https://github.com/Tencent/tdesign-react/pull/3733))
-    - Fixed white screen issue when dynamically updating data with virtual scrolling enabled  
-    - Fixed issue where header and table content width didn't sync when virtual scrolling was enabled
-    - Fixed issue where scrollbar was unexpectedly reset to first row position when virtual scrolling was enabled
-    - Fixed issue where column dragging was ineffective when `dragSort='row-handler-col'` ([#3734](https://github.com/Tencent/tdesign-react/pull/3734))
-    - Fixed abnormality where `firstFullRow` size was larger than `size='medium'` when `size='small'` ([common#2253](https://github.com/Tencent/tdesign-common/pull/2253))
+  - Fixed white screen issue when dynamically updating data with virtual scrolling enabled
+  - Fixed issue where header and table content width didn't sync when virtual scrolling was enabled
+  - Fixed issue where scrollbar was unexpectedly reset to first row position when virtual scrolling was enabled
+  - Fixed issue where column dragging was ineffective when `dragSort='row-handler-col'` ([#3734](https://github.com/Tencent/tdesign-react/pull/3734))
+  - Fixed abnormality where `firstFullRow` size was larger than `size='medium'` when `size='small'` ([common#2253](https://github.com/Tencent/tdesign-common/pull/2253))
 - `Watermark`: Fixed issue where text watermark content was not obvious in dark mode @HaixingOoO @liweijie0812 ([#3692](https://github.com/Tencent/tdesign-react/pull/3692))
 - `DatePicker`: Optimized panel content display effect when selecting same panel year in year selection mode @uyarn ([#3744](https://github.com/Tencent/tdesign-react/pull/3744))
 
-## 🌈 1.13.2 `2025-08-01` 
+## 🌈 1.13.2 `2025-08-01`
+
 ### 🐞 Bug Fixes
-- `DatePicker`: 
+
+- `DatePicker`:
   - Fixed week and quarter mode tag deletion abnormality in multi-select scenarios @betavs ([#3664](https://github.com/Tencent/tdesign-react/pull/3664))
   - Fixed issue where `placeholder` didn't disappear normally in multi-select mode @RylanBot ([#3666](https://github.com/Tencent/tdesign-react/pull/3666))
 - `EnhancedTable`: @RylanBot
-  - Fixed issue where `data` update failed in async scenarios caused by fix introduced in `1.13.0` version ([#3690](https://github.com/Tencent/tdesign-react/pull/3690)) 
+  - Fixed issue where `data` update failed in async scenarios caused by fix introduced in `1.13.0` version ([#3690](https://github.com/Tencent/tdesign-react/pull/3690))
   - Fixed issue where unique key didn't exist when dynamically initializing `columns` using `tree` API ([#3669](https://github.com/Tencent/tdesign-react/pull/3669))
   - Fixed issue where leaf node judgment condition was too broad, causing corresponding style not to render normally @RylanBot ([#3681](https://github.com/Tencent/tdesign-react/pull/3681))
 - `SelectInput`: Fixed some bugs caused by setting `display` when getting scrollbar in `useOverlayInnerStyle` @HaixingOoO ([#3677](https://github.com/Tencent/tdesign-react/pull/3677))
@@ -345,19 +416,25 @@ spline: explain
 - `Form`: Fixed issue where old data was filled back when adding new data after deleting data in dynamic form @RylanBot ([#3684](https://github.com/Tencent/tdesign-react/pull/3684))
 
 ## 🌈 1.13.1 `2025-07-11`
+
 ### 🐞 Bug Fixes
+
 - `QRCode`: Fixed `canvas` QR code Safari style compatibility issue @lifeiFront ([common#2207](https://github.com/Tencent/tdesign-common/pull/2207))
 
-## 🌈 1.13.0 `2025-07-10` 
+## 🌈 1.13.0 `2025-07-10`
+
 ### 🚀 Features
+
 - `React19`: Added adapter compatible with React 19 usage. Please refer to usage documentation for detailed instructions when using in React 19 @HaixingOoO @uyarn([#3640](https://github.com/Tencent/tdesign-react/pull/3640))
 - `QRCode`: Added `QRCode` component @lifeiFront @wonkzhang ([#3612](https://github.com/Tencent/tdesign-react/pull/3612))
 - `Alert`: Added `closeBtn` API to maintain consistency with other components, `close` will be deprecated in future versions, please adjust to use `closeBtn` as soon as possible ⚠️ @ngyyuusora ([#3625](https://github.com/Tencent/tdesign-react/pull/3625))
 - `Form`: Added feature to reset form content when reopening Form @alisdonwang ([#3613](https://github.com/Tencent/tdesign-react/pull/3613))
 - `ImageViewer`: Support zooming images with two fingers when using on mobile @RylanBot ([#3629](https://github.com/Tencent/tdesign-react/pull/3629))
 - `locale`: Support proper display of singular/plural scenarios in built-in multilingual English version @YunYouJun ([#3639](https://github.com/Tencent/tdesign-react/pull/3639))
+
 ### 🐞 Bug Fixes
-- `ColorPicker`: 
+
+- `ColorPicker`:
   - Fixed issue where color board didn't sync update when clicking gradient point @RylanBot ([#3624](https://github.com/Tencent/tdesign-react/pull/3624))
   - Fixed issue where input box content wasn't reset in invalid character input and multiple clearing scenarios @uyarn ([#3653](https://github.com/Tencent/tdesign-react/pull/3653))
 - `Dropdown`: Fixed error issue caused by abnormal dropdown menu node retrieval in some scenarios @uyarn ([#3657](https://github.com/Tencent/tdesign-react/pull/3657))
@@ -367,17 +444,21 @@ spline: explain
 - `Popup`: Fixed arrow position offset caused by `arrow` modifier from popper.js introduced in `1.11.2` @RylanBot ([#3652](https://github.com/Tencent/tdesign-react/pull/3652))
 - `Loading`: Fixed icon position error issue on iPad WeChat @Nero978([#3655](https://github.com/Tencent/tdesign-react/pull/3655))
 - `Menu`: Fixed issue where `expandMutex` easily failed when nested submenus existed @RylanBot ([#3621](https://github.com/Tencent/tdesign-react/pull/3621))
-- `Table`: 
+- `Table`:
   - Fixed issue where sticky function didn't follow height changes @huangchen1031 ([#3620](https://github.com/Tencent/tdesign-react/pull/3620))
   - Fixed error when `columns` changed dynamically when `showHeader` was `false` @RylanBot ([#3637](https://github.com/Tencent/tdesign-react/pull/3637))
 - `EnhancedTable`: Fixed issue where `tree.defaultExpandAll` was ineffective @RylanBot ([#3638](https://github.com/Tencent/tdesign-react/pull/3638))
 - `Textarea`: Fixed jittering issue when wrapping after exceeding maximum height @RSS1102 ([#3631](https://github.com/Tencent/tdesign-react/pull/3631))
 
-## 🌈 1.12.3 `2025-06-13` 
+## 🌈 1.12.3 `2025-06-13`
+
 ### 🚀 Features
+
 - `Form`: Added `requiredMarkPosition` API to define required symbol position @Wesley-0808 ([#3586](https://github.com/Tencent/tdesign-react/pull/3586))
 - `ConfigProvider`: `FormConfig` in global configuration added `requiredMaskPosition` configuration for globally configuring required symbol position @Wesley-0808 ([#3586](https://github.com/Tencent/tdesign-react/pull/3586))
+
 ### 🐞 Bug Fixes
+
 - `Drawer`: Fixed missing `null` declaration in `cancelBtn` and `confirmBtn` types @RSS1102 ([#3602](https://github.com/Tencent/tdesign-react/pull/3602))
 - `ImageViewer`: Fixed size abnormality of error images in small window image viewer @RylanBot([#3607](https://github.com/Tencent/tdesign-react/pull/3607))
 - `Menu`: Issue where `delay` property in `popupProps` was ineffective in `SubMenu` @RylanBot ([#3599](https://github.com/Tencent/tdesign-react/pull/3599))
@@ -388,38 +469,48 @@ spline: explain
 - `Tabs`: Fixed issue where first `TabPanel` was always rendered first when lazy loading was enabled @HaixingOoO ([#3614](https://github.com/Tencent/tdesign-react/pull/3614))
 - `TreeSelect`: Fixed issue where `label` API couldn't be used normally @RylanBot ([#3603](https://github.com/Tencent/tdesign-react/pull/3603))
 
-## 🌈 1.12.2 `2025-05-30` 
+## 🌈 1.12.2 `2025-05-30`
+
 ### 🚀 Features
+
 - `Cascader`: Added support for using `option` method to customize dropdown option content @huangchen1031 ([#3565](https://github.com/Tencent/tdesign-react/pull/3565))
 - `MenuGroup`: Added support for using `className` and `style` @wang-ky ([#3568](https://github.com/Tencent/tdesign-react/pull/3568))
 - `InputNumber`: `decimalPlaces` added `enableRound` parameter to control whether to enable rounding @RylanBot ([#3564](https://github.com/Tencent/tdesign-react/pull/3564))
 - `TagInput`: Optimized mouse cursor display as move cursor when draggable @liweijie0812 ([#3552](https://github.com/Tencent/tdesign-react/pull/3552))
+
 ### 🐞 Bug Fixes
+
 - `Card`: Fixed issue where `content` prop was ineffective @RylanBot ([#3553](https://github.com/Tencent/tdesign-react/pull/3553))
-- `Cascader`: 
-     - Fixed display abnormality when options had overly long text in small sizes @Shabi-x([#3551](https://github.com/Tencent/tdesign-react/pull/3551))
-     - Fixed issue where `displayValue` didn't change when async updating `options` after initialization @huangchen1031 ([#3549](https://github.com/Tencent/tdesign-react/pull/3549))
+- `Cascader`:
+  - Fixed display abnormality when options had overly long text in small sizes @Shabi-x([#3551](https://github.com/Tencent/tdesign-react/pull/3551))
+  - Fixed issue where `displayValue` didn't change when async updating `options` after initialization @huangchen1031 ([#3549](https://github.com/Tencent/tdesign-react/pull/3549))
 - `DatePicker`: Fixed `onFocus` event timing issue @l123wx ([#3578](https://github.com/Tencent/tdesign-react/pull/3578))
 - `Drawer`: Optimized input cursor error caused by `TNode` re-rendering @betavs ([#3544](https://github.com/Tencent/tdesign-react/pull/3544))
--  `Form`:
-    - Fixed issue where setting same value through `setFields` in `onValuesChange` continued to trigger `onValuesChange` causing `re-render` @HaixingOoO ([#3304](https://github.com/Tencent/tdesign-react/pull/3304))
-    - Fixed `reset` value initialization error after deleting `field` in `FormList` @l123wx ([#3557](https://github.com/Tencent/tdesign-react/pull/3557))
-    - Compatible with scenarios of using `FormItem` alone before version `1.11.7` @uyarn ([#3588](https://github.com/Tencent/tdesign-react/pull/3588))
+- `Form`:
+  - Fixed issue where setting same value through `setFields` in `onValuesChange` continued to trigger `onValuesChange` causing `re-render` @HaixingOoO ([#3304](https://github.com/Tencent/tdesign-react/pull/3304))
+  - Fixed `reset` value initialization error after deleting `field` in `FormList` @l123wx ([#3557](https://github.com/Tencent/tdesign-react/pull/3557))
+  - Compatible with scenarios of using `FormItem` alone before version `1.11.7` @uyarn ([#3588](https://github.com/Tencent/tdesign-react/pull/3588))
 - `Guide`: Optimized issue where component didn't recalculate position when screen size changed @HaixingOoO ([#3543](https://github.com/Tencent/tdesign-react/pull/3543))
 - `List`: Fixed issue where getting child node `props` failed when child nodes were empty @RSS1102 ([#3570](https://github.com/Tencent/tdesign-react/pull/3570))
 - `Popconfirm`: Fixed issue where `confirmBtn` property children was ineffective @huangchen1031 ([#3556](https://github.com/Tencent/tdesign-react/pull/3556))
 - `Slider`: Fixed issue where last `label` width was insufficient and automatically wrapped @l123wx([#3581](https://github.com/Tencent/tdesign-react/pull/3581))
 - `Textarea`: Fixed issue where Chinese input was interrupted @betavs ([#3544](https://github.com/Tencent/tdesign-react/pull/3544))
 - `TreeSelect`: Fixed issue where selected values were deleted when clicking already selected value in single-select mode @HaixingOoO ([#3573](https://github.com/Tencent/tdesign-react/pull/3573))
+
 ### 🚧 Others
+
 - `Dialog`: Optimized component initialization rendering time @RylanBot ([#3561](https://github.com/Tencent/tdesign-react/pull/3561))
 
-## 🌈 1.12.1 `2025-05-07` 
+## 🌈 1.12.1 `2025-05-07`
+
 ### 🐞 Bug Fixes
+
 - Fixed compatibility issue with React 18 and below in version 1.12.0 @uyarn ([#3545](https://github.com/Tencent/tdesign-react/pull/3545))
 
-## 🌈 1.12.0 `2025-04-28` 
+## 🌈 1.12.0 `2025-04-28`
+
 ### 🚀 Features
+
 - `React`: Comprehensively upgraded related dependencies, compatible with usage in React19 @HaixingOoO ([#3438](https://github.com/Tencent/tdesign-react/pull/3438))
 - `ColorPicker`: @RylanBot ([#3503](https://github.com/Tencent/tdesign-react/pull/3503)) Businesses using gradient mode should note this change ⚠️
   - Automatically switch between single color and gradient modes based on color values from "trigger/recent colors/preset colors"
@@ -428,81 +519,109 @@ spline: explain
   - Added `enableMultipleGradient` API, enabled by default
 - `Drawer`: Added `lazy` property for lazy loading scenarios, `forceRender` has been declared deprecated and will be removed in future versions @RSS1102 ([#3527](https://github.com/Tencent/tdesign-react/pull/3527))
 - `Dialog`: Added `lazy` property for lazy loading scenarios, `forceRender` has been declared deprecated and will be removed in future versions @RSS1102 ([#3515](https://github.com/Tencent/tdesign-react/pull/3515))
+
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: @RylanBot ([#3503](https://github.com/Tencent/tdesign-react/pull/3503))
   - Fixed issue where gradient points couldn't normally update color and position
   - Fixed return value formatting abnormality when transparency channel was enabled
 
-## 🌈 1.11.8 `2025-04-28` 
+## 🌈 1.11.8 `2025-04-28`
+
 ### 🚀 Features
+
 - `ConfigProvider`: Support global context configuration acting on Message related plugins @lifeiFront ([#3513](https://github.com/Tencent/tdesign-react/pull/3513))
 - `Icon`: Added `logo-miniprogram` Mini Program, `logo-cnb` Cloud Native Build, `seal` Seal, `quote` Quote and other icons @taowensheng1997 @uyarn ([#3517](https://github.com/Tencent/tdesign-react/pull/3517))
 - `Upload`: `image-flow` mode supports progress and custom error text @ngyyuusora ([#3525](https://github.com/Tencent/tdesign-react/pull/3525))
 - `Select`: Multi-select removing options through panel added `onRemove` callback @QuentinHsu ([#3526](https://github.com/Tencent/tdesign-react/pull/3526))
+
 ### 🐞 Bug Fixes
+
 - `InputNumber`: Optimized boundary issues of number input box @Sight-wcg([#3519](https://github.com/Tencent/tdesign-react/pull/3519))
 - `Select`:
-    - Fixed cursor abnormality and missing complete `option` information in child component callback functions after version `1.11.2` @HaixingOoO @uyarn ([#3520](https://github.com/Tencent/tdesign-react/pull/3520))  ([#3529](https://github.com/Tencent/tdesign-react/pull/3529))
-    - Optimized multi-select tag removal related events to different `trigger`, adjusted different trigger scenarios to `clear`, `remove-tag` and `uncheck`, fixed select all option `trigger` error @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
-    - Fixed issue where `change` event was triggered when clicking selected option again in single-select mode @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
-    - Fixed issue where `change` event couldn't be triggered when pressing `backspace` in multi-select mode @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - Fixed cursor abnormality and missing complete `option` information in child component callback functions after version `1.11.2` @HaixingOoO @uyarn ([#3520](https://github.com/Tencent/tdesign-react/pull/3520)) ([#3529](https://github.com/Tencent/tdesign-react/pull/3529))
+  - Optimized multi-select tag removal related events to different `trigger`, adjusted different trigger scenarios to `clear`, `remove-tag` and `uncheck`, fixed select all option `trigger` error @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - Fixed issue where `change` event was triggered when clicking selected option again in single-select mode @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - Fixed issue where `change` event couldn't be triggered when pressing `backspace` in multi-select mode @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
 
-## 🌈 1.11.7 `2025-04-18` 
+## 🌈 1.11.7 `2025-04-18`
+
 ### 🚀 Features
+
 - `ConfigProvider`: Added `isContextEffectPlugin` API, disabled by default. When enabled, global configuration will affect function calls of `Dialog`, `Loading`, `Drawer`, `Notification` and `Popup` components @lifeiFront ([#3488](https://github.com/Tencent/tdesign-react/pull/3488)) ([#3504](https://github.com/Tencent/tdesign-react/pull/3504))
 - `Tree`: `checkProps` parameter supports function passing, supporting different `checkProps` settings for different nodes @phalera ([#3501](https://github.com/Tencent/tdesign-react/pull/3501))
 - `Cascader`: Added `onClear` event callback @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
 - `DatePicker`: Added `onClear` event callback @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
 - `TimePicker`: Added `onClear` event callback @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
-- `ColorPicker`: 
-    - Added `clearable` API @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
-    - Added `onClear` event callback @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+- `ColorPicker`:
+  - Added `clearable` API @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+  - Added `onClear` event callback @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: Ensure corresponding `onVisibleChange` callback when external component actively closes Popup @RylanBot ([#3510](https://github.com/Tencent/tdesign-react/pull/3510))
 - `Drawer`: Added `DrawerPlugin` to support function calls, refer to examples for specific usage @Wesley-0808 ([#3381](https://github.com/Tencent/tdesign-react/pull/3381))
 - `InputNumber`: Fixed issue where component wasn't controlled by value property @RSS1102 ([#3499](https://github.com/Tencent/tdesign-react/pull/3499))
 - `ImageViewer`:
-     - Fixed display abnormality when `step` had precision @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
-     - Fixed type error where parameters in `imageScale` were required @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
+  - Fixed display abnormality when `step` had precision @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
+  - Fixed type error where parameters in `imageScale` were required @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
 - `Slider`: Fixed issue where size wasn't limited when using `theme` as `col` input box mode when input box was enabled @RSS1102 ([#3500](https://github.com/Tencent/tdesign-react/pull/3500))
 - `Tabs`: Optimized issue where sliding buttons were ineffective when tab `label` was too long @wonkzhang ([common#2108](https://github.com/Tencent/tdesign-common/pull/2108))
 
-## 🌈 1.11.6 `2025-04-11` 
+## 🌈 1.11.6 `2025-04-11`
+
 ### 🚀 Features
+
 - `Breadcrumb`: Added related APIs `ellipsis`, `maxItems`, `itemsAfterCollapse`, `itemsBeforeCollapse` for collapse scenarios, refer to examples for specific usage @moecasts ([#3487](https://github.com/Tencent/tdesign-react/pull/3487))
+
 ### 🐞 Bug Fixes
+
 - `RadioGroup`: Optimized switching highlight effect issue @RylanBot ([#3446](https://github.com/Tencent/tdesign-react/pull/3446))
 - `Tag`: Fixed issue where `style` priority was lower than `color`, causing scenarios where tag styles couldn't be forcefully overridden @uyarn ([#3492](https://github.com/Tencent/tdesign-react/pull/3492))
 - `ColorPicker`: Fixed effect abnormality when switching between single color and gradient @RylanBot ([#3493](https://github.com/Tencent/tdesign-react/pull/3493))
 - `Table`: Fixed right-side drag adjustment abnormality in adjustable column width table @uyarn ([#3496](https://github.com/Tencent/tdesign-react/pull/3496))
 - `Swiper`: Optimized default container height to avoid navigator position abnormality @uyarn ([#3490](https://github.com/Tencent/tdesign-react/pull/3490))
+
 ### 📝 Documentation
+
 - `Swiper`: Optimized component jump sandbox demo missing example styles @uyarn ([#3490](https://github.com/Tencent/tdesign-react/pull/3490))
+
 ### 🚧 Others
+
 - Version `1.12.0` will fully support React 19 usage. For React 19 related usage scenarios, you can upgrade to version `1.12.0-alpha.3` for trial
 
-## 🌈 1.11.4 `2025-04-03` 
+## 🌈 1.11.4 `2025-04-03`
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where empty `options` caused error leading to white screen @2ue ([#3484](https://github.com/Tencent/tdesign-react/pull/3484))
 - `Tree`: Fixed issue where clicking and expand logic was still triggered when icon was false @uyarn ([#3485](https://github.com/Tencent/tdesign-react/pull/3485))
 
-## 🌈 1.11.3 `2025-04-01` 
+## 🌈 1.11.3 `2025-04-01`
+
 ### 🚀 Features
+
 - `ConfigProvider`: `Pagination` added `Jumper` configuration for customizing jump part styles @RylanBot ([#3421](https://github.com/Tencent/tdesign-react/pull/3421))
+
 ### 🐞 Bug Fixes
+
 - `Textarea`: Fixed `TextArea` `autofocus` bug and `autosize` ineffective in `Dialog` @HaixingOoO ([#3471](https://github.com/Tencent/tdesign-react/pull/3471))
 - `lib`: Fixed `lib` artifact redundant style issue causing abnormality in `next.js` usage and missing version number in version `1.11.2` @uyarn ([#3474](https://github.com/Tencent/tdesign-react/pull/3474))
 - `Table`: Fixed pagination state calculation error in controlled method @huangchen1031 ([#3473](https://github.com/Tencent/tdesign-react/pull/3473))
 
-## 🌈 1.11.2 `2025-03-28` 
+## 🌈 1.11.2 `2025-03-28`
+
 ### 🚀 Features
+
 - `ImageViewer`: Added `onDownload` API for customizing preview image download callback functionality @lifeiFront ([#3408](https://github.com/Tencent/tdesign-react/pull/3408))
 - `ConfigProvider`: `Input` added `clearTrigger` configuration for globally configuring show close button when there's value in global mode @RylanBot ([#3412](https://github.com/Tencent/tdesign-react/pull/3412))
 - `Descriptions`: Added `tableLayout` property @liweijie0812 ([#3434](https://github.com/Tencent/tdesign-react/pull/3434))
 - `Message`: When closing message instance, remove it from global message list to avoid potential memory leak risks @wonkzhang ([#3413](https://github.com/Tencent/tdesign-react/pull/3413))
 - `Select`: Group selector added support for filtering functionality @huangchen1031 ([#3430](https://github.com/Tencent/tdesign-react/pull/3430))
 - `Tabs`: Added `lazy` API to support configuring lazy loading functionality @HaixingOoO ([#3426](https://github.com/Tencent/tdesign-react/pull/3426))
+
 ### 🐞 Bug Fixes
+
 - `ConfigProvider`: Fixed issue where secondary configuration affected non-`Context` range @uyarn ([#3441](https://github.com/Tencent/tdesign-react/pull/3441))
 - `Dialog`: Added class names to cancel and confirm buttons for easy customization @RSS1102 ([#3417](https://github.com/Tencent/tdesign-react/pull/3417))
 - `Drawer`: Fixed issue where width might be incorrect when getting during drag resizing @wonkzhang ([#3420](https://github.com/Tencent/tdesign-react/pull/3420))
@@ -514,27 +633,39 @@ spline: explain
   - Fixed style abnormality of selectable table in Firefox browser @uyarn ([common#2093](https://github.com/Tencent/tdesign-common/pull/2093))
 - `Tooltip`: Fixed `mouse` position calculation error in `TooltipLite` under `React 16` @moecasts ([#3465](https://github.com/Tencent/tdesign-react/pull/3465))
 - `Tree`: Fixed issue where component reported error after removing nodes in some scenarios @2ue ([#3463](https://github.com/Tencent/tdesign-react/pull/3463))
+
 ### 📝 Documentation
+
 - `Card`: Fixed documentation content text error @betavs ([#3448](https://github.com/Tencent/tdesign-react/pull/3448))
 
-## 🌈 1.11.1 `2025-02-28` 
+## 🌈 1.11.1 `2025-02-28`
+
 ### 🚀 Features
+
 - `Layout`: Child component `Content` added `content` API @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
+
 ### 🐞 Bug Fixes
+
 - `reactRender`: fix `React19` `reactRender` error @HaixingOoO ([#3380](https://github.com/Tencent/tdesign-react/pull/3380))
 - `Table`: Fixed footer rendering issue under virtual scrolling @huangchen1031 ([#3383](https://github.com/Tencent/tdesign-react/pull/3383))
 - `fix`: Fixed `1.11.0` cjs artifact abnormality @uyarn ([#3392](https://github.com/Tencent/tdesign-react/pull/3392))
+
 ### 📝 Documentation
+
 - `ConfigProvider`: Added `globalConfig` API documentation @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
 
-## 🌈 1.11.0 `2025-02-20` 
+## 🌈 1.11.0 `2025-02-20`
+
 ### 🚀 Features
+
 - `Cascader`: Added support for automatically scrolling to first selected item node when opening menu @uyarn ([#3357](https://github.com/Tencent/tdesign-react/pull/3357))
 - `DatePicker`: Adjusted component disabled date `before` and `after` parameter logic, now disables dates before `before` definition and after `after` definition. Those who used related APIs before should note this change ⚠️ @lifeiFront ([#3362](https://github.com/Tencent/tdesign-react/pull/3362))
 - `List`: Added `scroll` API to support enabling virtual scrolling for large data volumes @HaixingOoO ([#3363](https://github.com/Tencent/tdesign-react/pull/3363))
 - `Menu`: Menu added collapse and expand animation effects @hd10180 ([#3342](https://github.com/Tencent/tdesign-react/pull/3342))
 - `TagInput`: Added `maxRows` API for setting maximum display rows @Shabi-x ([#3293](https://github.com/Tencent/tdesign-react/pull/3293))
+
 ### 🐞 Bug Fixes
+
 - `Card`: Fixed warning issues in React 19 @HaixingOoO ([#3369](https://github.com/Tencent/tdesign-react/pull/3369))
 - `Cascader`: Fixed multi-select dynamic loading usage abnormality @uyarn ([#3376](https://github.com/Tencent/tdesign-react/pull/3376))
 - `CheckboxGroup`: Fixed issue where `onChange` `context` parameter lacked `option` @HaixingOoO ([#3349](https://github.com/Tencent/tdesign-react/pull/3349))
@@ -545,17 +676,23 @@ spline: explain
 - `Table`: Fixed issue where Table footer wasn't displayed when switching tabs with `Tabs` @wonkzhang ([#3370](https://github.com/Tencent/tdesign-react/pull/3370))
 - `Textarea`: Fixed issue where cursor didn't follow content end when using `autofocus` API and `value` had value @HaixingOoO ([#3358](https://github.com/Tencent/tdesign-react/pull/3358))
 - `Transfer`: Fixed `TransferItem` ineffective issue @HaixingOoO ([#3339](https://github.com/Tencent/tdesign-react/pull/3339))
+
 ### 🚧 Others
+
 - Adjusted component dependency `lodash` to `lodash-es` @zhangpaopao0609 ([#3345](https://github.com/Tencent/tdesign-react/pull/3345))
 
-## 🌈 1.10.5 `2025-01-16` 
+## 🌈 1.10.5 `2025-01-16`
+
 ### 🚀 Features
+
 - `RadioGroup`: Added `theme` API to determine child component styles when using options @HaixingOoO ([#3303](https://github.com/Tencent/tdesign-react/pull/3303))
 - `Upload`: Added `imageProps` API for passing through `Image` component related properties in image upload scenarios @HaixingOoO ([#3317](https://github.com/Tencent/tdesign-react/pull/3317))
 - `AutoComplete`: Added `empty` API to support customizing empty node content @liweijie0812 ([#3319](https://github.com/Tencent/tdesign-react/pull/3319))
 - `Drawer`: `sizeDraggable` added support for `SizeDragLimit` type functionality implementation @huangchen1031 ([#3323](https://github.com/Tencent/tdesign-react/pull/3323))
 - `Icon`: Added `logo-alipay`, `logo-behance-filled` and other icons, modified `logo-wecom` icon, removed unreasonable `logo-wecom-filled` icon @uyarn ([#3326](https://github.com/Tencent/tdesign-react/pull/3326))
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where all options values in `onChange` callback `context` didn't contain complete option content @uyarn ([#3305](https://github.com/Tencent/tdesign-react/pull/3305))
 - `DateRangePicker`: Logic judgment error when start and end values both existed @betavs ([#3301](https://github.com/Tencent/tdesign-react/pull/3301))
 - `Notification`: Fixed rendering node abnormality caused by using `attach` attribute configuration @centuryPark ([#3306](https://github.com/Tencent/tdesign-react/pull/3306))
@@ -564,18 +701,26 @@ spline: explain
 - `Statistic`: Fixed precision error during value animation when `decimalPlaces=0` @huangchen1031 ([#3327](https://github.com/Tencent/tdesign-react/pull/3327))
 - `ImageViewer`: Fixed flickering when clicking overlay to close when `closeOnOverlay` was enabled @huangchen1031
 
-## 🌈 1.10.4 `2024-12-25` 
+## 🌈 1.10.4 `2024-12-25`
+
 ### 🚀 Features
+
 - `Tree`: Support `onScroll` API for handling scroll event callbacks @HaixingOoO ([#3295](https://github.com/Tencent/tdesign-react/pull/3295))
 - `TooltipLite`: Optimized to completely follow mouse position in `mouse` mode, more consistent with API description @moecasts ([#3267](https://github.com/Tencent/tdesign-react/pull/3267))
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where select all default return value was wrong @uyarn ([#3298](https://github.com/Tencent/tdesign-react/pull/3298))
 - `Upload`: Optimized style issues of some size upload component image display @huangchen1031 ([#3290](https://github.com/Tencent/tdesign-react/pull/3290))
+
 ### 📝 Documentation
+
 - `Stackblitz`: Adjusted `Stackblitz` example startup method and fixed issues where some examples couldn't use `stackblitz` or `codesandbox` to run @uyarn ([#3297](https://github.com/Tencent/tdesign-react/pull/3297))
 
 ## 🌈 1.10.2 `2024-12-19`
+
 ### 🚀 Features
+
 - `Alert`: No longer display `expand more/collapse` button when `maxLine >= message` array length @miownag ([#3281](https://github.com/Tencent/tdesign-react/pull/3281))
 - `ConfigProvider`: `attach` property supports configuring `drawer` component, supports globally configuring `drawer` mount position @HaixingOoO ([#3272](https://github.com/Tencent/tdesign-react/pull/3272))
 - `DatePicker`: Multi-select mode supports week selection and year selection scenarios @HaixingOoO @uyarn ([#3264](https://github.com/Tencent/tdesign-react/pull/3264))
@@ -585,7 +730,9 @@ spline: explain
 - `DatePicker`: Support `label` API @liweijie0812 ([#3276](https://github.com/Tencent/tdesign-react/pull/3276))
 - `TimePicker`: Support `label` API @liweijie0812 ([#3276](https://github.com/Tencent/tdesign-react/pull/3276))
 - `RangeInput`: Support `label` API @liweijie0812 ([#3276](https://github.com/Tencent/tdesign-react/pull/3276))
+
 ### 🐞 Bug Fixes
+
 - `DateRangePicker`: Fixed display abnormality in cross-year scenarios @huangchen1031 ([#3275](https://github.com/Tencent/tdesign-react/pull/3275))
 - `Menu`: Optimized menu item click event binding issue to avoid boundary trigger abnormality @huangchen1031 ([#3241](https://github.com/Tencent/tdesign-react/pull/3241))
 - `ImageViewer`: Fixed issue where `onClose` was triggered every time `visable` changed when uncontrolled @HaixingOoO ([#3244](https://github.com/Tencent/tdesign-react/pull/3244))
@@ -595,16 +742,22 @@ spline: explain
 - `Select`: Fixed display abnormality and callback parameter missing when `valueType` was `object` and select all was selected @uyarn ([#3287](https://github.com/Tencent/tdesign-react/pull/3287))
 - `SelectInput`: Fixed vertical alignment issue caused by rendering node when there was no `label` @huangchen1031 ([#3278](https://github.com/Tencent/tdesign-react/pull/3278))
 - `TextArea`: Optimized height calculation logic under `autosize` during `TextArea` initialization @HaixingOoO ([#3286](https://github.com/Tencent/tdesign-react/pull/3286))
+
 ### 🚧 Others
+
 - `Alert`: Optimized test case code types and added tests for `className`, `style` @RSS1102 ([#3284](https://github.com/Tencent/tdesign-react/pull/3284))
 
-## 🌈 1.10.1 `2024-11-28` 
+## 🌈 1.10.1 `2024-11-28`
+
 ### 🚀 Features
+
 - `DatePicker`: Added `multiple` API to support date picker multi-select functionality, refer to examples for specific usage @HaixingOoO ([#3199](https://github.com/Tencent/tdesign-react/pull/3199))
 - `DatePicker`: Added `disableTime` API to more conveniently set disabled time parts @HaixingOoO ([#3226](https://github.com/Tencent/tdesign-react/pull/3226))
 - `Dialog`: Added `beforeClose` and `beforeOpen` APIs to execute more callback operations when opening and closing popup @Wesley-0808 ([#3203](https://github.com/Tencent/tdesign-react/pull/3203))
 - `Drawer`: Added `beforeClose` and `beforeOpen` APIs to execute more callback operations when opening and closing drawer @Wesley-0808 ([#3203](https://github.com/Tencent/tdesign-react/pull/3203))
+
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: Fixed issue where some copy in `colorMode` didn't support internationalization @l123wx ([#3221](https://github.com/Tencent/tdesign-react/pull/3221))
 - `Form`: Fixed issue where `setFieldsValue` and `setFields` didn't trigger `onValuesChange` @uyarn ([#3232](https://github.com/Tencent/tdesign-react/pull/3232))
 - `Notification`: Modified `NotificationPlugin` `offset` property default value to better match conventional habits @huangchen1031 ([#3231](https://github.com/Tencent/tdesign-react/pull/3231))
@@ -615,13 +768,19 @@ spline: explain
   - Fixed filterable table handling `null` type abnormality @2ue ([#3197](https://github.com/Tencent/tdesign-react/pull/3197))
   - Fixed rendering abnormality when cell was number 0 and ellipsis was enabled @uyarn ([#3233](https://github.com/Tencent/tdesign-react/pull/3233))
 - `Tree`: Fixed `scrollTo` method scroll abnormal behavior @uyarn ([#3235](https://github.com/Tencent/tdesign-react/pull/3235))
+
 ### 📝 Documentation
+
 - `Dialog`: Fixed code example error @RSS1102 ([#3229](https://github.com/Tencent/tdesign-react/pull/3229))
+
 ### 🚧 Others
+
 - `TextArea`: Optimized `TextArea` event types @HaixingOoO ([#3211](https://github.com/Tencent/tdesign-react/pull/3211))
 
-## 🌈 1.10.0 `2024-11-15` 
+## 🌈 1.10.0 `2024-11-15`
+
 ### 🚀 Features
+
 - `Select`: `collapsedItems` method parameter `collapsedSelectedItems` expanded to `options`. Those using `collapsedItems` should note this change ⚠️ @RSS1102 ([#3185](https://github.com/Tencent/tdesign-react/pull/3185))
 - `Icon`: @uyarn ([#3194](https://github.com/Tencent/tdesign-react/pull/3194))
   - Icon library released version `0.4.0`, added 907 new icons
@@ -632,27 +791,37 @@ spline: explain
 - `Menu`: Added `tooltipProps` API acting on nodes appearing when first-level menu is collapsed and focused @uyarn ([#3201](https://github.com/Tencent/tdesign-react/pull/3201))
 - `Switch`: Added `before-change` API @centuryPark ([#3167](https://github.com/Tencent/tdesign-react/pull/3167))
 - `Form`: Added `getValidateMessage` instance method @moecasts ([#3180](https://github.com/Tencent/tdesign-react/pull/3180))
+
 ### 🐞 Bug Fixes
+
 - `TagInput`: Fixed issue where selected options could still be deleted by Backspace key in `readonly` mode @RSS1102 ([#3172](https://github.com/Tencent/tdesign-react/pull/3172))
 - `Form`: Fixed issue where `FormItem` had abnormality when `name` attribute was set outside `Form` in version `1.9.3` @l123wx ([#3183](https://github.com/Tencent/tdesign-react/pull/3183))
 - `Select`: Fixed callback parameter type error when clicking select all button when valueType was object @l123wx ([#3193](https://github.com/Tencent/tdesign-react/pull/3193))
 - `Table`: Fixed issue where child nodes weren't displayed normally when dynamically setting `expandTreeNode` @uyarn ([#3202](https://github.com/Tencent/tdesign-react/pull/3202))
 - `Tree`: Fixed dynamic `expandAll` functionality abnormality @uyarn ([#3204](https://github.com/Tencent/tdesign-react/pull/3204))
 - `Drawer`: Fixed issue where `confirmBtn` and `closeBtn` content couldn't be customized @RSS1102 ([#3191](https://github.com/Tencent/tdesign-react/pull/3191))
+
 ### 📝 Documentation
+
 - `Icon`: Optimized icon search functionality to support Chinese and English icon search @uyarn ([#3194](https://github.com/Tencent/tdesign-react/pull/3194))
 - `Popup`: Added `popperOption` usage example @HaixingOoO ([#3200](https://github.com/Tencent/tdesign-react/pull/3200))
 
-## 🌈 1.9.3 `2024-10-31` 
+## 🌈 1.9.3 `2024-10-31`
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed `onClose` callback issue under `valueDisplay` @uyarn ([#3154](https://github.com/Tencent/tdesign-react/pull/3154))
 - `Typography`: Fixed `Typography` `Ellipsis` functionality issue under Chinese @HaixingOoO ([#3158](https://github.com/Tencent/tdesign-react/pull/3158))
 - `Form`: Fixed `FormList` or `FormItem` data `getFieldsValue` issue @HaixingOoO ([#3149](https://github.com/Tencent/tdesign-react/pull/3149))
 
-## 🌈 1.9.2 `2024-10-17` 
+## 🌈 1.9.2 `2024-10-17`
+
 ### 🚀 Features
+
 - `Form`: Added `setStatus` method to set form item status @moecasts ([#3120](https://github.com/Tencent/tdesign-react/pull/3120))
+
 ### 🐞 Bug Fixes
+
 - `Grid`: Fixed `align-items` style issue in some cases @uyarn ([#3139](https://github.com/Tencent/tdesign-react/pull/3139))
 - `Table`: Fixed fixed column alignment issue under virtual scrolling @haizw ([#3133](https://github.com/Tencent/tdesign-react/pull/3133))
 - `ColorPicker`: Fixed transparent channel abnormality under some scenarios @uyarn ([#3140](https://github.com/Tencent/tdesign-react/pull/3140))
@@ -665,12 +834,16 @@ spline: explain
 - `List`: Fixed scroll-to load abnormality when data was empty @uyarn ([#3156](https://github.com/Tencent/tdesign-react/pull/3156))
 - `Calendar`: Fixed issue where cell click event wasn't triggered in cell mode @uyarn ([#3157](https://github.com/Tencent/tdesign-react/pull/3157))
 
-## 🌈 1.9.1 `2024-09-26` 
+## 🌈 1.9.1 `2024-09-26`
+
 ### 🚀 Features
+
 - `Upload`: Added `isBatchUpload` API @uyarn ([#3097](https://github.com/Tencent/tdesign-react/pull/3097))
 - `Calendar`: Added `fillWithZero` API to support controlling whether to fill month and day with zero @Leeeahind ([#3103](https://github.com/Tencent/tdesign-react/pull/3103))
 - `Tree`: Added `expandOnClick` API to control whether clicking node expands @uyarn ([#3104](https://github.com/Tencent/tdesign-react/pull/3104))
+
 ### 🐞 Bug Fixes
+
 - `Grid`: Fixed align-items style issue in some cases @uyarn ([#3118](https://github.com/Tencent/tdesign-react/pull/3118))
 - `Upload`: Fixed status abnormality in drag upload scenario @uyarn ([#3124](https://github.com/Tencent/tdesign-react/pull/3124))
 - `Menu`: Fixed issue where `popupProps` couldn't be passed through to `SubMenu` @uyarn ([#3127](https://github.com/Tencent/tdesign-react/pull/3127))
@@ -682,8 +855,10 @@ spline: explain
 - `ColorPicker`: Fixed issue where recently used colors couldn't be deleted @uyarn ([#3142](https://github.com/Tencent/tdesign-react/pull/3142))
 - `Tree`: Fixed issue where index calculation was abnormal when nodes were deleted @uyarn ([#3143](https://github.com/Tencent/tdesign-react/pull/3143))
 
-## 🌈 1.9.0 `2024-09-12` 
+## 🌈 1.9.0 `2024-09-12`
+
 ### 🚀 Features
+
 - `AutoComplete`: Added `popupProps` API @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
 - `Select`: Added `popupProps` API @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
 - `DatePicker`: Added `popupProps` API @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
@@ -714,7 +889,9 @@ spline: explain
 - `Form`: Added `status` API for `FormList` @uyarn ([#3082](https://github.com/Tencent/tdesign-react/pull/3082))
 - `List`: Added `loading` and `asyncLoading` states @uyarn ([#3083](https://github.com/Tencent/tdesign-react/pull/3083))
 - `ColorPicker`: Added `show-primary-color-preview` API @uyarn ([#3085](https://github.com/Tencent/tdesign-react/pull/3085))
+
 ### 🐞 Bug Fixes
+
 - `AutoComplete`: Fixed display abnormality when options were empty @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
 - `Select`: Fixed display abnormality when options were empty @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
 - `DatePicker`: Fixed display abnormality when options were empty @uyarn ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
@@ -743,12 +920,16 @@ spline: explain
 - `List`: Fixed virtual scrolling abnormality @uyarn ([#3083](https://github.com/Tencent/tdesign-react/pull/3083))
 - `ColorPicker`: Fixed primary color preview display abnormality @uyarn ([#3085](https://github.com/Tencent/tdesign-react/pull/3085))
 
-## 🌈 1.8.1 `2024-08-23` 
+## 🌈 1.8.1 `2024-08-23`
+
 ### 🚀 Features
+
 - `Dialog`: Added `header` and `footer` slots for easy content customization @uyarn ([#3049](https://github.com/Tencent/tdesign-react/pull/3049))
 - `Swiper`: Added `type` and `animation` effects for rich switching effects @Leeeahind ([#3055](https://github.com/Tencent/tdesign-react/pull/3055))
 - `Table`: Added `onRowMouseUp`, `onRowMouseDown`, `onRowMouseEnter`, `onRowMouseLeave` events @uyarn ([#3057](https://github.com/Tencent/tdesign-react/pull/3057))
+
 ### 🐞 Bug Fixes
+
 - `Drawer`: Fixed height inheritance issue @uyarn ([#3058](https://github.com/Tencent/tdesign-react/pull/3058))
 - `Image`: Fixed issue where events couldn't be triggered after multiple fast clicks @uyarn ([#3059](https://github.com/Tencent/tdesign-react/pull/3059))
 - `Affix`: Fixed container calculation issue @uyarn ([#3060](https://github.com/Tencent/tdesign-react/pull/3060))
@@ -760,8 +941,10 @@ spline: explain
 - `Tree`: Fixed node deletion causing abnormal scroll position @uyarn ([#3070](https://github.com/Tencent/tdesign-react/pull/3070))
 - `TagInput`: Fixed tag deletion event abnormality @uyarn ([#3071](https://github.com/Tencent/tdesign-react/pull/3071))
 
-## 🌈 1.8.0 `2024-08-22` 
+## 🌈 1.8.0 `2024-08-22`
+
 ### 🚀 Features
+
 - `Typography`: Added `Typography` component @insekkei ([#3020](https://github.com/Tencent/tdesign-react/pull/3020))
 - `Input`: Added `align` API @uyarn ([#3025](https://github.com/Tencent/tdesign-react/pull/3025))
 - `Select`: Added `panelBottomContent` API for customizing bottom content of popup panel @uyarn ([#3033](https://github.com/Tencent/tdesign-react/pull/3033))
@@ -778,7 +961,9 @@ spline: explain
 - `Calendar`: Added `cellAppend` and `cell` APIs to support customizing cell content @Leeeahind ([#3050](https://github.com/Tencent/tdesign-react/pull/3050))
 - `Tree`: Added `onRowMouseUp`, `onRowMouseDown`, `onRowMouseEnter`, `onRowMouseLeave` events @uyarn ([#3057](https://github.com/Tencent/tdesign-react/pull/3057))
 - `List`: Added `onRowMouseUp`, `onRowMouseDown`, `onRowMouseEnter`, `onRowContentMouseEnter`, `onRowContentMouseLeave`, `onRowMouseLeave` events @uyarn ([#3057](https://github.com/Tencent/tdesign-react/pull/3057))
+
 ### 🐞 Bug Fixes
+
 - `Grid`: Fixed `align-items` style issue in some cases @uyarn ([#3028](https://github.com/Tencent/tdesign-react/pull/3028))
 - `InputNumber`: Fixed style issue when `size` was `large` @uyarn ([#3038](https://github.com/Tencent/tdesign-react/pull/3038))
 - `Table`: Fixed virtual scrolling data change triggering abnormality @uyarn ([#3062](https://github.com/Tencent/tdesign-react/pull/3062))
@@ -794,8 +979,10 @@ spline: explain
 - `Tree`: Fixed virtual scrolling data change triggering abnormality @uyarn ([#3062](https://github.com/Tencent/tdesign-react/pull/3062))
 - `List`: Fixed scroll-to load abnormality when data was empty @uyarn ([#3035](https://github.com/Tencent/tdesign-react/pull/3035))
 
-## 🌈 1.7.9 `2024-08-07` 
+## 🌈 1.7.9 `2024-08-07`
+
 ### 🐞 Bug Fixes
+
 - `InputNumber`: Fixed issue where large numbers couldn't be input normally @uyarn ([#2991](https://github.com/Tencent/tdesign-react/pull/2991))
 - `Table`: Fixed selectable table style issue @uyarn ([#2992](https://github.com/Tencent/tdesign-react/pull/2992))
 - `TreeSelect`: Fixed issue where enter couldn't submit when filter was enabled @uyarn ([#2995](https://github.com/Tencent/tdesign-react/pull/2995))
@@ -803,8 +990,10 @@ spline: explain
 - `DatePicker`: Fixed year panel invalid date style issue @uyarn ([#2999](https://github.com/Tencent/tdesign-react/pull/2999))
 - `Form`: Fixed form validation abnormality when `disabled` was true @uyarn ([#3000](https://github.com/Tencent/tdesign-react/pull/3000))
 
-## 🌈 1.7.8 `2024-08-01` 
+## 🌈 1.7.8 `2024-08-01`
+
 ### 🐞 Bug Fixes
+
 - `Table`: Fixed issue where event callback missing `selectData` parameter @uyarn ([#2983](https://github.com/Tencent/tdesign-react/pull/2983))
 - `Select`: Fixed issue where focus couldn't be obtained by clicking selected option in multi-select mode @uyarn ([#2984](https://github.com/Tencent/tdesign-react/pull/2984))
 - `TreeSelect`: Fixed issue where selected options text color was abnormal in filter mode @uyarn ([#2986](https://github.com/Tencent/tdesign-react/pull/2986))
@@ -813,11 +1002,15 @@ spline: explain
 - `Tree`: Fixed line-through style abnormality for disabled nodes @uyarn ([#2989](https://github.com/Tencent/tdesign-react/pull/2989))
 - `Form`: Fixed form validation trigger abnormality @uyarn ([#2990](https://github.com/Tencent/tdesign-react/pull/2990))
 
-## 🌈 1.7.7 `2024-07-18` 
+## 🌈 1.7.7 `2024-07-18`
+
 ### 🚀 Features
+
 - `Table`: Added `title` and `col` configuration for customizing column group content and column configuration @uyarn ([#2964](https://github.com/Tencent/tdesign-react/pull/2964))
 - `Form`: Added `resetType` API to control reset behavior @uyarn ([#2967](https://github.com/Tencent/tdesign-react/pull/2967))
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: Fixed panel height adaptation issue when time picker was enabled @uyarn ([#2968](https://github.com/Tencent/tdesign-react/pull/2968))
 - `Form`: Fixed form validation trigger abnormality @uyarn ([#2970](https://github.com/Tencent/tdesign-react/pull/2970))
 - `Select`: Fixed multi-select dropdown collapse display abnormality @uyarn ([#2972](https://github.com/Tencent/tdesign-react/pull/2972))
@@ -829,22 +1022,30 @@ spline: explain
 - `Textarea`: Fixed issue where clear button couldn't be clicked in readonly mode @uyarn ([#2981](https://github.com/Tencent/tdesign-react/pull/2981))
 - `TagInput`: Fixed tag deletion event abnormality @uyarn ([#2982](https://github.com/Tencent/tdesign-react/pull/2982))
 
-## 🌈 1.7.6 `2024-06-27` 
+## 🌈 1.7.6 `2024-06-27`
+
 ### 🚀 Features
+
 - `Calendar`: Added `fillWithZero` API to support controlling whether to fill month and day with zero @Leeeahind ([#2939](https://github.com/Tencent/tdesign-react/pull/2939))
 - `Upload`: Added `useCache` API to support controlling whether to use cache for temporary images @uyarn ([#2941](https://github.com/Tencent/tdesign-react/pull/2941))
+
 ### 🐞 Bug Fixes
+
 - `Form`: Fixed `resetType` configuration ineffective issue @uyarn ([#2953](https://github.com/Tencent/tdesign-react/pull/2953))
 - `InputNumber`: Fixed large number input abnormality @uyarn ([#2954](https://github.com/Tencent/tdesign-react/pull/2954))
 - `Table`: Fixed column configuration functionality abnormality @uyarn ([#2955](https://github.com/Tencent/tdesign-react/pull/2955))
 - `Tree`: Fixed node filtering abnormality when `keys.children` was configured @uyarn ([#2956](https://github.com/Tencent/tdesign-react/pull/2956))
 - `TagInput`: Fixed tag dragging abnormality @uyarn ([#2958](https://github.com/Tencent/tdesign-react/pull/2958))
-- `DatePicker`: Fixed panel height adaptation issue when time picker was enabled @uyarn ([#2961](详细的](https://github.com/Tencent/tdesign-react/pull/2961))...
+- `DatePicker`: Fixed panel height adaptation issue when time picker was enabled @uyarn ([#2961](<详细的](https://github.com/Tencent/tdesign-react/pull/2961)>)...
 
-## 🌈 1.7.0 `2024-04-25` 
+## 🌈 1.7.0 `2024-04-25`
+
 ### 🚀 Features
+
 - `Typography`: Added `Typography` typography component @insekkei ([#2821](https://github.com/Tencent/tdesign-react/pull/2821))
+
 ### 🐞 Bug Fixes
+
 - `Table`: When executing data retrieval and updates in `effect` asynchrony, it might cause some bugs @HaixingOoO ([#2848](https://github.com/Tencent/tdesign-react/pull/2848))
 - `DatePicker`: Fixed abnormality where month selection jumped to initial state in date picker @uyarn ([#2854](https://github.com/Tencent/tdesign-react/pull/2854))
 - `Form`: `useWatch` in certain cases, different `name` caused view issues @HaixingOoO ([#2853](https://github.com/Tencent/tdesign-react/pull/2853))
@@ -852,76 +1053,99 @@ spline: explain
 - `Dropdown`: Fixed issue where overlay was still displayed when option length was empty @uyarn ([#2860](https://github.com/Tencent/tdesign-react/pull/2860))
 - `Dropdown`: Optimized `Dropdown` `children` pass-through `disabled` @HaixingOoO ([#2862](https://github.com/Tencent/tdesign-react/pull/2862))
 - `SelectInput`: Fixed issue where uncontrolled property `defaultPopupVisible` did not work @uyarn ([#2861](https://github.com/Tencent/tdesign-react/pull/2861))
-- `Style`: Fixed issue where some node prefixes could not be uniformly replaced @ZWkang  @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
+- `Style`: Fixed issue where some node prefixes could not be uniformly replaced @ZWkang @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
 - `Upload`: Fixed `method` enum value `options` error @summer-shen @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
 
-## 🌈 1.6.0 `2024-04-11` 
+## 🌈 1.6.0 `2024-04-11`
+
 ### 🚀 Features
+
 - `Portal`: `Portal` added lazy loading `forceRender`, default is `lazy` mode, optimized performance, compatible with `SSR` rendering, potentially has breaking impact on `Dialog` and `Drawer` components ⚠️ @HaixingOoO ([#2826](https://github.com/Tencent/tdesign-react/pull/2826))
+
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: Fixed issue where `imageReferrerpolicy` did not affect top thumbnail @uyarn ([#2815](https://github.com/Tencent/tdesign-react/pull/2815))
 - `Descriptions`: Fixed issue where `props` lacked `className` and `style` properties @HaixingOoO ([#2818](https://github.com/Tencent/tdesign-react/pull/2818))
 - `Layout`: Fixed page layout jump when adding `Aside` @HaixingOoO ([#2824](https://github.com/Tencent/tdesign-react/pull/2824))
 - `Input`: Fixed issue where event bubbling was not prevented in `React16` version @HaixingOoO ([#2833](https://github.com/Tencent/tdesign-react/pull/2833))
 - `DatePicker`: Fixed issue where Date type and week selector were abnormal after version `1.5.3` @uyarn ([#2841](https://github.com/Tencent/tdesign-react/pull/2841))
-- `Guide`:  
-     - Optimized usage in `SSR` @HaixingOoO ([#2842](https://github.com/Tencent/tdesign-react/pull/2842))
-     - Fixed component initialization rendering position abnormality in SSR scenario @uyarn ([#2832](https://github.com/Tencent/tdesign-react/pull/2832))
+- `Guide`:
+  - Optimized usage in `SSR` @HaixingOoO ([#2842](https://github.com/Tencent/tdesign-react/pull/2842))
+  - Fixed component initialization rendering position abnormality in SSR scenario @uyarn ([#2832](https://github.com/Tencent/tdesign-react/pull/2832))
 - `Scroll`: Fixed style abnormality of `Table`, `Select` and some components with scrollbars caused by Chrome 121 version supporting scroll width @loopzhou ([common#1765](https://github.com/Tencent/tdesign-vue/pull/1765)) @uyarn ([#2843](https://github.com/Tencent/tdesign-react/pull/2843))
 - `Locale`: Optimized language pack for some `DatePicker` modes @uyarn ([#2843](https://github.com/Tencent/tdesign-react/pull/2843))
 - `Tree`: Fixed issue where `draggable` property lost responsiveness after initialization @Liao-js ([#2838](https://github.com/Tencent/tdesign-react/pull/2838))
 - `Style`: Supported packaging styles through `less` main entry @NWYLZW @uyarn ([common#1757](https://github.com/Tencent/tdesign-common/pull/1757)) ([common#1766](https://github.com/Tencent/tdesign-common/pull/1766))
 
+## 🌈 1.5.5 `2024-03-28`
 
-## 🌈 1.5.5 `2024-03-28` 
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: Fixed issue where `imageReferrerpolicy` did not affect top thumbnail @uyarn ([#2815](https://github.com/Tencent/tdesign-react/pull/2815))
 
-## 🌈 1.5.4 `2024-03-28` 
+## 🌈 1.5.4 `2024-03-28`
+
 ### 🚀 Features
-- `ImageViewer`: Added `imageReferrerpolicy` API to support scenarios needing Referrerpolicy configuration配合 with Image component @uyarn ([#2813](https://github.com/Tencent/tdesign-react/pull/2813))
+
+- `ImageViewer`: Added `imageReferrerpolicy` API to support scenarios needing Referrerpolicy configuration 配合 with Image component @uyarn ([#2813](https://github.com/Tencent/tdesign-react/pull/2813))
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue where `onRemove` event was not triggered normally @Ali-ovo ([#2802](https://github.com/Tencent/tdesign-react/pull/2802))
 - `Skeleton`: Fixed issue where `children` was required type @uyarn ([#2805](https://github.com/Tencent/tdesign-react/pull/2805))
 - `Tabs`: Provided `action` area default style @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
-- `Locale`: Fixed English language pack abnormality for `image` and `imageViewer` @uyarn  @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
+- `Locale`: Fixed English language pack abnormality for `image` and `imageViewer` @uyarn @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
 - `Image`: `referrerpolicy` parameter was incorrectly passed to outer `div`, actual target should be native `image` tag @NWYLZW ([#2811](https://github.com/Tencent/tdesign-react/pull/2811))
 
-## 🌈 1.5.3 `2024-03-14` 
+## 🌈 1.5.3 `2024-03-14`
+
 ### 🚀 Features
+
 - `BreadcrumbItem`: Support `onClick` event @HaixingOoO ([#2795](https://github.com/Tencent/tdesign-react/pull/2795))
-- `Tag`: Component added `color` API to support custom colors @maoyiluo  @uyarn ([#2799](https://github.com/Tencent/tdesign-react/pull/2799))
+- `Tag`: Component added `color` API to support custom colors @maoyiluo @uyarn ([#2799](https://github.com/Tencent/tdesign-react/pull/2799))
+
 ### 🐞 Bug Fixes
+
 - `FormList`: Fixed issue where multiple components were stuck @HaixingOoO ([#2788](https://github.com/Tencent/tdesign-react/pull/2788))
 - `DatePicker`: Fixed calculation error when `format` and `valueType` were inconsistent @uyarn ([#2798](https://github.com/Tencent/tdesign-react/pull/2798))
+
 ### 🚧 Others
+
 - `Portal`: Added Portal test cases @HaixingOoO ([#2791](https://github.com/Tencent/tdesign-react/pull/2791))
 - `List`: Improved List test cases @HaixingOoO ([#2792](https://github.com/Tencent/tdesign-react/pull/2792))
 - `Alert`: Improved Alert tests, optimized code @HaixingOoO ([#2793](https://github.com/Tencent/tdesign-react/pull/2793))
 
-## 🌈 1.5.2 `2024-02-29` 
+## 🌈 1.5.2 `2024-02-29`
+
 ### 🚀 Features
+
 - `Cascader`: Added `valueDisplay` and `label` API support @HaixingOoO ([#2736](https://github.com/Tencent/tdesign-react/pull/2736))
 - `Descriptions`: Component supports nesting @HaixingOoO ([#2777](https://github.com/Tencent/tdesign-react/pull/2777))
 - `Tabs`: Adjusted activated `Tab` underline and `TabHeader` border hierarchy relationship @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
+
 ### 🐞 Bug Fixes
+
 - `Grid`: Size calculation error, width compatibility abnormality @NWYLZW ([#2738](https://github.com/Tencent/tdesign-react/pull/2738))
 - `Cascader`: Fixed issue where `clearable` clicking clear button triggered `onChange` three times @HaixingOoO ([#2736](https://github.com/Tencent/tdesign-react/pull/2736))
 - `Dialog`: Fixed `useDialogPosition` rendering multiple binding events @HaixingOoO ([#2749](https://github.com/Tencent/tdesign-react/pull/2749))
 - `Guide`: Fixed custom content functionality failure @zhangpaopao0609 ([#2752](https://github.com/Tencent/tdesign-react/pull/2752))
 - `Tree`: Fixed issue where expand icon did not change normally after setting `keys.children` @uyarn ([#2746](https://github.com/Tencent/tdesign-react/pull/2746))
 - `Tree`: Fixed `Tree` custom label `setData` rendering issue @HaixingOoO ([#2776](https://github.com/Tencent/tdesign-react/pull/2776))
-- `Tree`: Fixed issue where `TreeItem` `checkbox` was compressed when setting `Tree` width, and `label` ellipsis failure @HaixingOoO  @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
-- `Select`: @uyarn 
-    - Fixed scroll behavior abnormality after selecting options via scroll loading ([#2779](https://github.com/Tencent/tdesign-react/pull/2779))
-    - Fixed virtual scrolling functionality abnormality when using `size` API ([#2756](https://github.com/Tencent/tdesign-react/pull/2756))
+- `Tree`: Fixed issue where `TreeItem` `checkbox` was compressed when setting `Tree` width, and `label` ellipsis failure @HaixingOoO @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
+- `Select`: @uyarn
+  - Fixed scroll behavior abnormality after selecting options via scroll loading ([#2779](https://github.com/Tencent/tdesign-react/pull/2779))
+  - Fixed virtual scrolling functionality abnormality when using `size` API ([#2756](https://github.com/Tencent/tdesign-react/pull/2756))
 
-## 🌈 1.5.1 `2024-01-25` 
+## 🌈 1.5.1 `2024-01-25`
+
 ### 🚀 Features
+
 - `Popup`: Support using `Plugin` method @HaixingOoO ([#2717](https://github.com/Tencent/tdesign-react/pull/2717))
 - `Transfer`: Support `direction` API @uyarn ([#2727](https://github.com/Tencent/tdesign-react/pull/2727))
 - `Tabs`: Added `action` API to support customizing right area @uyarn ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
+
 ### 🐞 Bug Fixes
+
 - `Pagination`: `Jump to` adjusted to uppercase to maintain consistency @wangyewei ([#2716](https://github.com/Tencent/tdesign-react/pull/2716))
 - `Table`: Fixed issue where `Form` form in `Modal` using `shouldUpdate`卸载 could sometimes not find form methods @duxphp ([#2675](https://github.com/Tencent/tdesign-react/pull/2675))
 - `Table`: Column width adjustment and row expansion scenarios, fixed issue where row expansion reset column width adjustment results @chaishi ([#2722](https://github.com/Tencent/tdesign-react/pull/2722))
@@ -935,39 +1159,50 @@ spline: explain
 - `Menu`: Fixed `collapsed` `scroll` style @Except10n ([#2718](https://github.com/Tencent/tdesign-react/pull/2718))
 - `Cascader`: Fixed style abnormality in `Safari` when option list was long @uyarn ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
 
-## 🌈 1.5.0 `2024-01-11` 
+## 🌈 1.5.0 `2024-01-11`
+
 ### 🚨 Breaking Changes
+
 - `Dialog`: This version fixed incorrect mounting of `className`. Now `className` will only be mounted to upper container element Context of `Dialog`. If you need to directly modify `Dialog` body styles, you can switch to using `dialogClassName` for modification.
+
 ### 🚀 Features
+
 - `Descriptions`: Added `Descriptions` description component @HaixingOoO ([#2706](https://github.com/Tencent/tdesign-react/pull/2706))
 - `Dialog`: Added `dialogClassName` for handling internal dialog node styles. It is recommended that users who previously modified dialog body styles through `className` switch to using `dialogClassName` @NWYLZW ([#2639](https://github.com/Tencent/tdesign-react/pull/2639))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: Fixed Cascader `trigger=hover` after filtering, selection operation abnormal bug @HaixingOoO ([#2702](https://github.com/Tencent/tdesign-react/pull/2702))
 - `Upload`: Fixed Upload `uploadFilePercent` type undefined @betavs ([#2703](https://github.com/Tencent/tdesign-react/pull/2703))
 - `Dialog`: Fixed multiple node mounting errors of Dialog `className`, `className` will only be mounted to ctx element @NWYLZW ([#2639](https://github.com/Tencent/tdesign-react/pull/2639))
 - `TreeSelect`: Fixed `suffixIcon` error and added related examples @Ali-ovo ([#2692](https://github.com/Tencent/tdesign-react/pull/2692))
 
-## 🌈 1.4.3 `2024-01-02` 
+## 🌈 1.4.3 `2024-01-02`
+
 ### 🐞 Bug Fixes
+
 - `AutoComplete`: Fixed issue where pressing Enter when `ActiveIndex=-1` had no match caused error @Ali-ovo ([#2300](https://github.com/Tencent/tdesign-react/pull/2300))
 - `Cascader`: Fixed `1.4.2` Cascader single-select filter selection defect @HaixingOoO ([#2700](https://github.com/Tencent/tdesign-react/pull/2700))
 
+## 🌈 1.4.2 `2023-12-28`
 
-## 🌈 1.4.2 `2023-12-28` 
 ### 🚀 Features
+
 - `Card`: Added `LoadingProps` property @HaixingOoO ([#2677](https://github.com/Tencent/tdesign-react/pull/2677))
-- `DatePicker`: `DateRangePicker` added `cancelRangeSelectLimit` to support not limiting RangePicker selection前后 range @uyarn ([#2684](https://github.com/Tencent/tdesign-react/pull/2684))
+- `DatePicker`: `DateRangePicker` added `cancelRangeSelectLimit` to support not limiting RangePicker selection 前后 range @uyarn ([#2684](https://github.com/Tencent/tdesign-react/pull/2684))
 - `Space`: No longer render a child element when elements are empty @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
 - `Upload`: @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
   - Added support for using `uploadPastedFiles` to paste and upload files
   - File input type upload component, added class name `t-upload--theme-file-input`
   - Added support for `uploadPastedFiles`, indicating allow paste upload files
   - Added `cancelUploadButton` and `uploadButton`, supporting custom upload and cancel upload buttons
-  - Added `imageViewerProps`, passing all properties of image preview component 
+  - Added `imageViewerProps`, passing all properties of image preview component
   - Added `showImageFileName`, for controlling whether to display image name
   - Supported passing non-array form as default value
   - Supported `fileListDisplay=null` to hide file list; and added more complete `fileListDisplay` parameter for customizing UI
+
 ### 🐞 Bug Fixes
+
 - `Table`: When asynchronously getting latest tree structure data, prioritize using `window.requestAnimationFrame` function to prevent screen flicker @lazybonee ([#2668](https://github.com/Tencent/tdesign-react/pull/2668))
 - `Table`: Fixed issue where filter icon could not highlight when filter value was `0/false` @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
 - `Cascader`: Fixed abnormal bug when performing selection and clearing content after component filtering @HaixingOoO ([#2674](https://github.com/Tencent/tdesign-react/pull/2674))
@@ -979,16 +1214,20 @@ spline: explain
 - `Upload`: @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
   - Fixed issue where upload progress could not be updated during manual upload
   - Fixed `uploadFilePercent` parameter type issue
-    
-## 🌈 1.4.1 `2023-12-14` 
+
+## 🌈 1.4.1 `2023-12-14`
+
 ### 🚀 Features
+
 - `Radio`: Support selecting options with Space key @liweijie0812 ([#2638](https://github.com/Tencent/tdesign-react/pull/2638))
 - `Dropdown`: Removed special styling handling for left items @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
+
 ### 🐞 Bug Fixes
+
 - `AutoComplete`: Fixed error issues when matching some special characters @ZWkang ([#2631](https://github.com/Tencent/tdesign-react/pull/2631))
-- `DatePicker`: 
+- `DatePicker`:
   - Fixed flickering issue when clicking clear button on date @HaixingOoO ([#2641](https://github.com/Tencent/tdesign-react/pull/2641))
-  - Fixed issue where suffix icon color changed after date selection was disabled @HaixingOoO  @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
+  - Fixed issue where suffix icon color changed after date selection was disabled @HaixingOoO @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
   - Fixed issue where clicking component edge when disabled could still show `Panel` @Zz-ZzzZ ([#2653](https://github.com/Tencent/tdesign-react/pull/2653))
 - `Dropdown`: Fixed issue where disabled dropdown menu could be clicked @betavs ([#2648](https://github.com/Tencent/tdesign-react/pull/2648))
 - `DropdownItem`: Fixed missing `Divider` type @uyarn ([#2649](https://github.com/Tencent/tdesign-react/pull/2649))
@@ -997,38 +1236,46 @@ spline: explain
 - `SelectInput`: Fixed popup content width calculation issue @HaixingOoO ([#2647](https://github.com/Tencent/tdesign-react/pull/2647))
 - `ImageViewer`: Added default zoom ratio for image preview and option to trigger close event on ESC key press @HaixingOoO ([#2652](https://github.com/Tencent/tdesign-react/pull/2652))
 - `Table`: @chaishi
-    - Fixed issue where tree nodes in `EnhancedTable` could not expand properly ([#2661](https://github.com/Tencent/tdesign-react/pull/2661))
-    - Fixed issue where tree nodes could not expand in virtual scrolling scenario ([#2659](https://github.com/Tencent/tdesign-react/pull/2659))
+  - Fixed issue where tree nodes in `EnhancedTable` could not expand properly ([#2661](https://github.com/Tencent/tdesign-react/pull/2661))
+  - Fixed issue where tree nodes could not expand in virtual scrolling scenario ([#2659](https://github.com/Tencent/tdesign-react/pull/2659))
 
 ## 🌈 1.4.0 `2023-11-30`
+
 ### 🚀 Features
+
 - `Space`: Added support for component spacing rendering in legacy browsers @chaishi ([#2602](https://github.com/Tencent/tdesign-react/pull/2602))
 - `Statistic`: Added statistical value component @HaixingOoO ([#2596](https://github.com/Tencent/tdesign-react/pull/2596))
+
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: Fixed issue where adjusting transparency was ineffective when `format` was `hex` with `enableAlpha` @uyarn ([#2628](https://github.com/Tencent/tdesign-react/pull/2628))
 - `ColorPicker`: Fixed issue where slider button color above color picker didn't change @HaixingOoO ([#2615](https://github.com/Tencent/tdesign-react/pull/2615))
 - `Table`: Fixed `lazyLoad` lazy loading effect @chaishi ([#2605](https://github.com/Tencent/tdesign-react/pull/2605))
-- `Tree`: 
-    - Fixed style abnormality caused by incorrect `open class` state control logic for tree component nodes @NWYLZW ([#2611](https://github.com/Tencent/tdesign-react/pull/2611))
-    - `key` and `index` in API for scrolling to specific node should be optional @uyarn ([#2626](https://github.com/Tencent/tdesign-react/pull/2626))
+- `Tree`:
+  - Fixed style abnormality caused by incorrect `open class` state control logic for tree component nodes @NWYLZW ([#2611](https://github.com/Tencent/tdesign-react/pull/2611))
+  - `key` and `index` in API for scrolling to specific node should be optional @uyarn ([#2626](https://github.com/Tencent/tdesign-react/pull/2626))
 - `Drawer`: Fixed issue where when `mode` was `push`, the pushed content area was the drawer node's parent node @HaixingOoO ([#2614](https://github.com/Tencent/tdesign-react/pull/2614))
 - `Radio`: Fixed issue where form `disabled` was not effective on `Radio` @li-jia-nan ([#2397](https://github.com/Tencent/tdesign-react/pull/2397))
 - `Pagination`: Fixed issue where `current` value became 0 when `total` was 0 and `pageSize` changed @betavs ([#2624](https://github.com/Tencent/tdesign-react/pull/2624))
 - `Image`: Fixed issue where images didn't trigger native events in SSR mode @HaixingOoO ([#2616](https://github.com/Tencent/tdesign-react/pull/2616))
 
-## 🌈 1.3.1 `2023-11-15` 
+## 🌈 1.3.1 `2023-11-15`
+
 ### 🚀 Features
+
 - `Upload`: In drag-and-drop upload scenario, trigger `drop` event even when file type is incorrect @chaishi ([#2591](https://github.com/Tencent/tdesign-react/pull/2591))
+
 ### 🐞 Bug Fixes
-- `Tree`: 
-    - Fixed issue where `onClick` event could be triggered without adding `activable` parameter @HaixingOoO ([#2568](https://github.com/Tencent/tdesign-react/pull/2568))
-    - Fixed issue where linkage between editable components in editable table was not effective @HaixingOoO ([#2572](https://github.com/Tencent/tdesign-react/pull/2572))
-- `Notification`: 
-    - Fixed issue where popping two `Notification`s consecutively, only one was actually displayed the first time @HaixingOoO ([#2595](https://github.com/Tencent/tdesign-react/pull/2595))
-    - Fixed warning when using `flushSync` in `useEffect`, now using loop `setTimeout` to handle @HaixingOoO ([#2597](https://github.com/Tencent/tdesign-react/pull/2597))
-- `Dialog`: 
-    - Fixed issue where cursor jumped to end when typing in middle of `Input` component introduced in `Dialog` @HaixingOoO ([#2485](https://github.com/Tencent/tdesign-react/pull/2485))
-    - Fixed issue where dialog header title display affected cancel button position @HaixingOoO ([#2593](https://github.com/Tencent/tdesign-react/pull/2593))
+
+- `Tree`:
+  - Fixed issue where `onClick` event could be triggered without adding `activable` parameter @HaixingOoO ([#2568](https://github.com/Tencent/tdesign-react/pull/2568))
+  - Fixed issue where linkage between editable components in editable table was not effective @HaixingOoO ([#2572](https://github.com/Tencent/tdesign-react/pull/2572))
+- `Notification`:
+  - Fixed issue where popping two `Notification`s consecutively, only one was actually displayed the first time @HaixingOoO ([#2595](https://github.com/Tencent/tdesign-react/pull/2595))
+  - Fixed warning when using `flushSync` in `useEffect`, now using loop `setTimeout` to handle @HaixingOoO ([#2597](https://github.com/Tencent/tdesign-react/pull/2597))
+- `Dialog`:
+  - Fixed issue where cursor jumped to end when typing in middle of `Input` component introduced in `Dialog` @HaixingOoO ([#2485](https://github.com/Tencent/tdesign-react/pull/2485))
+  - Fixed issue where dialog header title display affected cancel button position @HaixingOoO ([#2593](https://github.com/Tencent/tdesign-react/pull/2593))
 - `Popup`: Fixed missing type issue for `PopupRef` @Ricinix ([#2577](https://github.com/Tencent/tdesign-react/pull/2577))
 - `Tabs`: Fixed issue where clicking activated tab repeatedly still triggered `onChange` event @HaixingOoO ([#2588](https://github.com/Tencent/tdesign-react/pull/2588))
 - `Radio`: Display Radio.Button according to corresponding variant @NWYLZW ([#2589](https://github.com/Tencent/tdesign-react/pull/2589))
@@ -1038,13 +1285,17 @@ spline: explain
 - `DatePicker`: Fixed issue where `PaginationMini` was not updated causing abnormal switching behavior @Ricinix ([#2587](https://github.com/Tencent/tdesign-react/pull/2587))
 - `Form`: Fixed infinite loop caused by setFields triggering onValuesChange @honkinglin ([#2570](https://github.com/Tencent/tdesign-react/pull/2570))
 
-## 🌈 1.3.0 `2023-10-19` 
+## 🌈 1.3.0 `2023-10-19`
+
 ### 🚀 Features
+
 - `TimelineItem`: Added click event @Zzongke ([#2545](https://github.com/Tencent/tdesign-react/pull/2545))
 - `Tag`: @chaishi ([#2524](https://github.com/Tencent/tdesign-react/pull/2524))
-    - Support multiple style tag configurations
-    - Support use of tag group `CheckTagGroup`, see example documentation for details
+  - Support multiple style tag configurations
+  - Support use of tag group `CheckTagGroup`, see example documentation for details
+
 ### 🐞 Bug Fixes
+
 - `locale`: Added missing it_IT, ru_RU, zh_TW locales @Zzongke ([#2542](https://github.com/Tencent/tdesign-react/pull/2542))
 - `Cascader`: Issue with `source` in `change` event @betavs ([#2544](https://github.com/Tencent/tdesign-react/pull/2544))
 - `Tree`: Fixed display result of filtered nodes when `allowFoldNodeOnFilter` is true @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
@@ -1052,261 +1303,349 @@ spline: explain
 - `TreeSelect`: Adjusted interaction behavior after filtering options to maintain consistency with other implementation frameworks @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
 - `Rate`: Fixed issue where multiple texts displayed when mouse moved quickly @Jon-Millent ([#2551](https://github.com/Tencent/tdesign-react/pull/2551))
 
-## 🌈 1.2.6 `2023-09-28` 
+## 🌈 1.2.6 `2023-09-28`
+
 ### 🚀 Features
+
 - `Table`: Optimized rendering count @chaishi ([#2514](https://github.com/Tencent/tdesign-react/pull/2514))
 - `Card`: `title` uses `div` instead of `span` to better conform to specifications in custom scenarios @uyarn ([#2517](https://github.com/Tencent/tdesign-react/pull/2517))
 - `Tree`: Support scrolling to specific position by matching single value with key, refer to example code for specific usage @uyarn ([#2519](https://github.com/Tencent/tdesign-react/pull/2519))
+
 ### 🐞 Bug Fixes
+
 - `Form`: Fixed formList nested data retrieval exception @honkinglin ([#2529](https://github.com/Tencent/tdesign-react/pull/2529))
 - `Table`: Fixed `rowspanAndColspan` rendering issue when data switched @chaishi ([#2514](https://github.com/Tencent/tdesign-react/pull/2514))
 - `Cascader`: hover on parent node without child node data didn't update child nodes @betavs ([#2528](https://github.com/Tencent/tdesign-react/pull/2528))
 - `DatePicker`: Fixed month switching failure issue @honkinglin ([#2531](https://github.com/Tencent/tdesign-react/pull/2531))
 - `Dropdown`: Fixed issue where `Dropdown` disabled API was ineffective @uyarn ([#2532](https://github.com/Tencent/tdesign-react/pull/2532))
 
-## 🌈 1.2.5 `2023-09-14` 
+## 🌈 1.2.5 `2023-09-14`
+
 ### 🚀 Features
+
 - `Steps`: Global configuration added custom completed icon for steps @Zzongke ([#2491](https://github.com/Tencent/tdesign-react/pull/2491))
 - `Table`: Filterable table, `onFilterChange` event added parameter `trigger: 'filter-change' | 'confirm' | 'reset' | 'clear'` to indicate source of filter condition change @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
 - `Form`: trigger added `submit` option @honkinglin ([#2507](https://github.com/Tencent/tdesign-react/pull/2507))
 - `ImageViewer`: `onIndexChange` event added `trigger` enum value `current` @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Image`: @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
-    - Added `fallback` for fallback image, displayed when original image fails to load
-    - Added support for `src` type as `File`, supporting image preview through `File`
+  - Added `fallback` for fallback image, displayed when original image fails to load
+  - Added support for `src` type as `File`, supporting image preview through `File`
 - `Upload`: File list supports displaying thumbnails @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Tree`: @uyarn ([#2509](https://github.com/Tencent/tdesign-react/pull/2509))
-    - Support scrolling to specific node by `key` in virtual scrolling scenario
-    - Support running `scrollTo` operation when below `threshold` in virtual scrolling scenario
+  - Support scrolling to specific node by `key` in virtual scrolling scenario
+  - Support running `scrollTo` operation when below `threshold` in virtual scrolling scenario
+
 ### 🐞 Bug Fixes
+
 - `ConfigProvider`: Fixed issue where language switching was ineffective @uyarn ([#2501](https://github.com/Tencent/tdesign-react/pull/2501))
 - `Table`:
-    - Filterable table, fixed issue where `resetValue` couldn't reset to specified `resetValue` when clearing filter @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
-    - Tree structure table, fixed issue where expandedTreeNodes.sync and expanded-tree-nodes-change were ineffective when using expandTreeNodeOnClick @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
-    - Cell in edit mode, incorrect handling of chained colKey during save, couldn't overwrite original value @Empire-suy ([#2493](https://github.com/Tencent/tdesign-react/pull/2493))
-    - Editable table, fixed issue where validation affected each other when multiple editable tables existed @chaishi ([#2498](https://github.com/Tencent/tdesign-react/pull/2498))
+  - Filterable table, fixed issue where `resetValue` couldn't reset to specified `resetValue` when clearing filter @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
+  - Tree structure table, fixed issue where expandedTreeNodes.sync and expanded-tree-nodes-change were ineffective when using expandTreeNodeOnClick @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
+  - Cell in edit mode, incorrect handling of chained colKey during save, couldn't overwrite original value @Empire-suy ([#2493](https://github.com/Tencent/tdesign-react/pull/2493))
+  - Editable table, fixed issue where validation affected each other when multiple editable tables existed @chaishi ([#2498](https://github.com/Tencent/tdesign-react/pull/2498))
 - `TagInput`: Fixed size issue of collapsed display options @uyarn ([#2503](https://github.com/Tencent/tdesign-react/pull/2503))
 - `Tabs`: Fixed issue where panel content was lost when using list to pass props and destroyOnHide was false @lzy2014love ([#2500](https://github.com/Tencent/tdesign-react/pull/2500))
 - `Menu`: Fixed issue where menuitem passing onClick didn't trigger when menu `expandType` was in default mode @Zzongke ([#2502](https://github.com/Tencent/tdesign-react/pull/2502))
 - `ImageViewer`: Fixed issue where preview popup couldn't be opened directly through `visible` @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Tree`: Fixed abnormality where some `TreeNodeModel` operations failed after version `1.2.0` @uyarn ([#2509](https://github.com/Tencent/tdesign-react/pull/2509))
 
-## 🌈 1.2.4 `2023-08-31` 
+## 🌈 1.2.4 `2023-08-31`
+
 ### 🚀 Features
+
 - `Table`: Tree structure, when `expandedTreeNodes` is not set, automatically collapse all expanded nodes when data changes (if you want to keep expanded nodes, please use property `expandedTreeNodes` to control @chaishi ([#2470](https://github.com/Tencent/tdesign-react/pull/2470))
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: Modified watermark node without affecting watermark display @tingtingcheng6 ([#2459](https://github.com/Tencent/tdesign-react/pull/2459))
 - `Table`: @chaishi ([#2470](https://github.com/Tencent/tdesign-react/pull/2470))
-    - Drag sorting + local data pagination scenario, fixed incorrect event parameters `currentIndex/targetIndex/current/target` etc.
-    - Drag sorting + local data pagination scenario, fixed issue where automatically jumped to first page after drag and drop sorting in paginated data after second page
-    - Supported drag sorting scenario with uncontrolled pagination
+  - Drag sorting + local data pagination scenario, fixed incorrect event parameters `currentIndex/targetIndex/current/target` etc.
+  - Drag sorting + local data pagination scenario, fixed issue where automatically jumped to first page after drag and drop sorting in paginated data after second page
+  - Supported drag sorting scenario with uncontrolled pagination
 - `Slider`: Fixed issue where `label` position was incorrect when initial value was 0 @Zzongke ([#2477](https://github.com/Tencent/tdesign-react/pull/2477))
-- `Tree`: Support `store.children` calling getChildren method @uyarn ([#2480](https://github.com/Tencent/tdesign-react/pull/2480)) 
+- `Tree`: Support `store.children` calling getChildren method @uyarn ([#2480](https://github.com/Tencent/tdesign-react/pull/2480))
 
-## 🌈 1.2.3 `2023-08-24` 
+## 🌈 1.2.3 `2023-08-24`
+
 ### 🐞 Bug Fixes
+
 - `Table`: Fixed usePrevious error @honkinglin ([#2464](https://github.com/Tencent/tdesign-react/pull/2464))
-- `ImageViewer`: Fixed import file path error @honkinglin ([#2465](https://github.com/Tencent/tdesign-react/pull/2465)) 
+- `ImageViewer`: Fixed import file path error @honkinglin ([#2465](https://github.com/Tencent/tdesign-react/pull/2465))
 
-## 🌈 1.2.2 `2023-08-24` 
+## 🌈 1.2.2 `2023-08-24`
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
-    - Tree structure, added component instance method `removeChildren` for removing child nodes
-    - Tree structure, support freely controlling expanded nodes through property `expandedTreeNodes.sync`, non-required property
+  - Tree structure, added component instance method `removeChildren` for removing child nodes
+  - Tree structure, support freely controlling expanded nodes through property `expandedTreeNodes.sync`, non-required property
 - `Tree`: Added `scrollTo` method to support scrolling to specified node in virtual scrolling scenario @uyarn ([#2460](https://github.com/Tencent/tdesign-react/pull/2460))
+
 ### 🐞 Bug Fixes
+
 - `TagInput`: Fixed issue where input got stuck when typing Chinese @Zzongke ([#2438](https://github.com/Tencent/tdesign-react/pull/2438))
 - `Table`:
-    - Click row expand/click row select, fixed issue where `expandOnRowClick` and `selectOnRowClick` couldn't independently control row click execution interaction @chaishi ([#2452](https://github.com/Tencent/tdesign-react/pull/2452))
-    - Tree structure, fixed component instance method expand all `expandAll` issue @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
-- `Form`: Fixed FormList component using form setFieldsValue, reset exception @nickcdon ([#2406](https://github.com/Tencent/tdesign-react/pull/2406)) 
+  - Click row expand/click row select, fixed issue where `expandOnRowClick` and `selectOnRowClick` couldn't independently control row click execution interaction @chaishi ([#2452](https://github.com/Tencent/tdesign-react/pull/2452))
+  - Tree structure, fixed component instance method expand all `expandAll` issue @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
+- `Form`: Fixed FormList component using form setFieldsValue, reset exception @nickcdon ([#2406](https://github.com/Tencent/tdesign-react/pull/2406))
 
-## 🌈 1.2.1 `2023-08-16` 
+## 🌈 1.2.1 `2023-08-16`
+
 ### 🚀 Features
+
 - `Anchor`: Added `getCurrentAnchor` to support custom highlight anchor @ontheroad1992 ([#2436](https://github.com/Tencent/tdesign-react/pull/2436))
 - `MenuItem`: `onClick` event added `value` return value @dexterBo ([#2441](https://github.com/Tencent/tdesign-react/pull/2441))
 - `FormItem`: Added `valueFormat` function to support data formatting @honkinglin ([#2445](https://github.com/Tencent/tdesign-react/pull/2445))
+
 ### 🐞 Bug Fixes
+
 - `Dialog`: Fixed flickering issue @linjunc ([#2435](https://github.com/Tencent/tdesign-react/pull/2435))
 - `Select`: @uyarn ([#2446](https://github.com/Tencent/tdesign-react/pull/2446))
-    - Fixed issue of losing `title` in multi-select
-    - Don't execute internal filtering when remote search is enabled
+  - Fixed issue of losing `title` in multi-select
+  - Don't execute internal filtering when remote search is enabled
 - `Popconfirm`: Invalid `className` and `style` Props @betavs ([#2420](https://github.com/Tencent/tdesign-react/pull/2420))
-- `DatePicker`: Fixed unnecessary rendering caused by hovering cell @j10ccc ([#2440](https://github.com/Tencent/tdesign-react/pull/2440)) 
+- `DatePicker`: Fixed unnecessary rendering caused by hovering cell @j10ccc ([#2440](https://github.com/Tencent/tdesign-react/pull/2440))
 
-## 🌈 1.2.0 `2023-08-10` 
+## 🌈 1.2.0 `2023-08-10`
+
 ### 🚨 Breaking Changes
+
 - `Icon`: @uyarn ([#2429](https://github.com/Tencent/tdesign-react/pull/2429))
-    - Added 960 icons
-    - Adjusted icon naming: `photo` to `camera`, `books` to `bookmark`, `stop-cirle-1` to `stop-circle-stroke`
-    - Removed `money-circle` icon, please check icon page for details
+  - Added 960 icons
+  - Adjusted icon naming: `photo` to `camera`, `books` to `bookmark`, `stop-cirle-1` to `stop-circle-stroke`
+  - Removed `money-circle` icon, please check icon page for details
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2402](https://github.com/Tencent/tdesign-react/pull/2402))
-    - Added `lazyLoad` for lazy loading entire table
-    - Editable cell, added `edit.keepEditMode` to keep cell always in edit mode
-    - Filterable table, support passing `attrs/style/classNames` properties, styles, class names etc. to custom components
-    - Filterable table, when current `filterValue` is not set for default filter value, no longer pass undefined to filter component, some components' default values must be array, not allowed to be undefined
+  - Added `lazyLoad` for lazy loading entire table
+  - Editable cell, added `edit.keepEditMode` to keep cell always in edit mode
+  - Filterable table, support passing `attrs/style/classNames` properties, styles, class names etc. to custom components
+  - Filterable table, when current `filterValue` is not set for default filter value, no longer pass undefined to filter component, some components' default values must be array, not allowed to be undefined
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: Error when passed value is not in options @peng-yin ([#2414](https://github.com/Tencent/tdesign-react/pull/2414))
 - `Menu`: Fixed issue where same `MenuItem` triggered `onChange` multiple times @leezng ([#2424](https://github.com/Tencent/tdesign-react/pull/2424))
 - `Drawer`: Drawer component couldn't display normally when `visible` default was `true` @peng-yin ([#2415](https://github.com/Tencent/tdesign-react/pull/2415))
 - `Table`: @chaishi ([#2402](https://github.com/Tencent/tdesign-react/pull/2402))
-    - Virtual scrolling scenario, fixed issue where header width and content width were inconsistent
-    - Virtual scrolling scenario, fixed issue where default scrollbar length (position) was inconsistent after scrolling
+  - Virtual scrolling scenario, fixed issue where header width and content width were inconsistent
+  - Virtual scrolling scenario, fixed issue where default scrollbar length (position) was inconsistent after scrolling
 
 ## 🌈 1.1.17 `2023-07-28`
+
 ### 🐞 Bug Fixes
+
 - `Tabs`: Fixed js error when list passed empty array @zhenglianghan ([#2393](https://github.com/Tencent/tdesign-react/pull/2393))
 - `ListItemMeta`: Fixed `description` passing custom elements @qijizh ([#2396](https://github.com/Tencent/tdesign-react/pull/2396))
 - `Tree`: Fixed interaction abnormality where nodes rolled back in some scenarios when virtual scrolling was enabled @uyarn ([#2399](https://github.com/Tencent/tdesign-react/pull/2399))
 - `Tree`: Fixed issue where operations based on `level` property couldn't work properly after version `1.1.15` @uyarn ([#2399](https://github.com/Tencent/tdesign-react/pull/2399))
 
 ## 🌈 1.1.16 `2023-07-26`
+
 ### 🚀 Features
+
 - `TimePicker`: @uyarn ([#2388](https://github.com/Tencent/tdesign-react/pull/2388))
-    - `disableTime` callback added millisecond parameter
-    - Optimized experience when scrolling to unavailable options when displaying unavailable time options
+  - `disableTime` callback added millisecond parameter
+  - Optimized experience when scrolling to unavailable options when displaying unavailable time options
 - `Dropdown`: Added `panelTopContent` and `panelBottomContent` to support scenarios needing additional top and bottom nodes @uyarn ([#2387](https://github.com/Tencent/tdesign-react/pull/2387))
+
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - Editable table scenario, support setting `colKey` value as chained property, such as: `a.b.c` @chaishi ([#2381](https://github.com/Tencent/tdesign-react/pull/2381))
-    - Tree structure table, fixed error when values in `selectedRowKeys` didn't exist in data @chaishi ([#2385](https://github.com/Tencent/tdesign-react/pull/2385))
+  - Editable table scenario, support setting `colKey` value as chained property, such as: `a.b.c` @chaishi ([#2381](https://github.com/Tencent/tdesign-react/pull/2381))
+  - Tree structure table, fixed error when values in `selectedRowKeys` didn't exist in data @chaishi ([#2385](https://github.com/Tencent/tdesign-react/pull/2385))
 - `Guide`: Fixed functionality of hiding component when setting `step1` to `-1` @uyarn ([#2389](https://github.com/Tencent/tdesign-react/pull/2389))
 
-## 🌈 1.1.15 `2023-07-19` 
-### 🚀 Features
-- `DatePicker`: Optimized resetting default selected area after closing popup @honkinglin ([#2371](https://github.com/Tencent/tdesign-react/pull/2371))
-### 🐞 Bug Fixes
-- `Dialog`: Fixed issue where `theme=danger` was ineffective @chaishi ([#2365](https://github.com/Tencent/tdesign-react/pull/2365))
-- `Popconfirm`: When `confirmBtn/cancelBtn` value type was `Object`, not passed through @imp2002 ([#2361](https://github.com/Tencent/tdesign-react/pull/2361)) 
+## 🌈 1.1.15 `2023-07-19`
 
-## 🌈 1.1.14 `2023-07-12` 
 ### 🚀 Features
+
+- `DatePicker`: Optimized resetting default selected area after closing popup @honkinglin ([#2371](https://github.com/Tencent/tdesign-react/pull/2371))
+
+### 🐞 Bug Fixes
+
+- `Dialog`: Fixed issue where `theme=danger` was ineffective @chaishi ([#2365](https://github.com/Tencent/tdesign-react/pull/2365))
+- `Popconfirm`: When `confirmBtn/cancelBtn` value type was `Object`, not passed through @imp2002 ([#2361](https://github.com/Tencent/tdesign-react/pull/2361))
+
+## 🌈 1.1.14 `2023-07-12`
+
+### 🚀 Features
+
 - `Tree`: Support virtual scrolling @uyarn ([#2359](https://github.com/Tencent/tdesign-react/pull/2359))
 - `Table`: Tree structure, added row level class names for business to set different level styles @chaishi ([#2354](https://github.com/Tencent/tdesign-react/pull/2354))
 - `Radio`: Optimized option group wrapping scenario @ontheroad1992 ([#2358](https://github.com/Tencent/tdesign-react/pull/2358))
 - `Upload`: @chaishi ([#2353](https://github.com/Tencent/tdesign-react/pull/2353))
-    - Added component instance method `uploadFilePercent` for updating file upload progress
-    - `theme=image`, support using `fileListDisplay` to customize UI content
-    - `theme=image`, support clicking name to open new window to access image
-    - Drag-and-drop upload scenario, support `accept` file type restriction
+  - Added component instance method `uploadFilePercent` for updating file upload progress
+  - `theme=image`, support using `fileListDisplay` to customize UI content
+  - `theme=image`, support clicking name to open new window to access image
+  - Drag-and-drop upload scenario, support `accept` file type restriction
+
 ### 🐞 Bug Fixes
+
 - `Upload`: Custom upload method, fixed issue where uploaded file wasn't correctly returned after upload success or failure @chaishi ([#2353](https://github.com/Tencent/tdesign-react/pull/2353))
 
-## 🌈 1.1.13 `2023-07-05` 
+## 🌈 1.1.13 `2023-07-05`
+
 ### 🐞 Bug Fixes
+
 - `Tag`: Fixed rendering abnormality when `children` was number `0` @HelKyle ([#2335](https://github.com/Tencent/tdesign-react/pull/2335))
 - `Input`: Fixed style issue of `limitNumber` part in `disabled` state @uyarn ([#2338](https://github.com/Tencent/tdesign-react/pull/2338))
 - `TagInput`: Fixed style issue of prefix icon @uyarn ([#2342](https://github.com/Tencent/tdesign-react/pull/2342))
 - `SelectInput`: Fixed issue where input content wasn't cleared on blur @uyarn ([#2342](https://github.com/Tencent/tdesign-react/pull/2342))
 
-## 🌈 1.1.12 `2023-06-29` 
+## 🌈 1.1.12 `2023-06-29`
+
 ### 🚀 Features
+
 - `Site`: Support English site @uyarn ([#2316](https://github.com/Tencent/tdesign-react/pull/2316))
+
 ### 🐞 Bug Fixes
+
 - `Slider`: Fixed issue where number input `theme` was fixed to `column` @Ali-ovo ([#2289](https://github.com/Tencent/tdesign-react/pull/2289))
 - `Table`: Column width adjustment and custom columns coexistence scenario, fixed issue where table total width couldn't be restored to smaller when table column count became smaller through custom column configuration @chaishi ([#2325](https://github.com/Tencent/tdesign-react/pull/2325))
 
-## 🌈 1.1.11 `2023-06-20` 
-### 🐞 Bug Fixes
-- `Table`: @chaishi ([#2297](https://github.com/Tencent/tdesign-react/pull/2297))
-    - Draggable column width scenario, fixed issue where `resizable=false` was ineffective, default value is false
-    - Local data sorting scenario, fixed issue where canceling sort caused empty list when fetching data asynchronously
-    - Fixed header misalignment in fixed table + fixed column + virtual scrolling scenario
-    - Editable cell/editable row scenario, fixed issue where data always validated previous value, adjusted to validate latest input value
-    - Fixed missing example code for local data sorting, multi-field sorting scenario
-- `ColorPicker`: @uyarn ([#2301](https://github.com/Tencent/tdesign-react/pull/2301))
-    - Support empty string as initial value when initializing as gradient mode
-    - Fixed type issues with `recentColors` and other fields
-    - Fixed issue where internal dropdown options didn't pass through `popupProps`
+## 🌈 1.1.11 `2023-06-20`
 
-## 🌈 1.1.10 `2023-06-13` 
-### 🚀 Features
-- `Menu`:
-    - `Submenu` added `popupProps` property to allow passing settings to underlying Popup popup @xiaosansiji ([#2284](https://github.com/Tencent/tdesign-react/pull/2284))
-    - Popup menu refactored using Popup @xiaosansiji ([#2274](https://github.com/Tencent/tdesign-react/pull/2274))
 ### 🐞 Bug Fixes
+
+- `Table`: @chaishi ([#2297](https://github.com/Tencent/tdesign-react/pull/2297))
+  - Draggable column width scenario, fixed issue where `resizable=false` was ineffective, default value is false
+  - Local data sorting scenario, fixed issue where canceling sort caused empty list when fetching data asynchronously
+  - Fixed header misalignment in fixed table + fixed column + virtual scrolling scenario
+  - Editable cell/editable row scenario, fixed issue where data always validated previous value, adjusted to validate latest input value
+  - Fixed missing example code for local data sorting, multi-field sorting scenario
+- `ColorPicker`: @uyarn ([#2301](https://github.com/Tencent/tdesign-react/pull/2301))
+  - Support empty string as initial value when initializing as gradient mode
+  - Fixed type issues with `recentColors` and other fields
+  - Fixed issue where internal dropdown options didn't pass through `popupProps`
+
+## 🌈 1.1.10 `2023-06-13`
+
+### 🚀 Features
+
+- `Menu`:
+  - `Submenu` added `popupProps` property to allow passing settings to underlying Popup popup @xiaosansiji ([#2284](https://github.com/Tencent/tdesign-react/pull/2284))
+  - Popup menu refactored using Popup @xiaosansiji ([#2274](https://github.com/Tencent/tdesign-react/pull/2274))
+
+### 🐞 Bug Fixes
+
 - `InputNumber`: When initial value is `undefined`/`null` and `decimalPlaces` exists, no longer perform decimal correction @chaishi ([#2273](https://github.com/Tencent/tdesign-react/pull/2273))
 - `Select`: Fixed issue with `onBlur` method callback parameters @Ali-ovo ([#2281](https://github.com/Tencent/tdesign-react/pull/2281))
 
-## 🌈 1.1.9 `2023-06-06` 
+## 🌈 1.1.9 `2023-06-06`
+
 ### 🚀 Features
+
 - `DatePicker`: Support `onConfirm` event @honkinglin ([#2260](https://github.com/Tencent/tdesign-react/pull/2260))
 - `Menu`: Optimized side navigation menu `Tooltip` display when collapsed @xiaosansiji ([#2263](https://github.com/Tencent/tdesign-react/pull/2263))
 - `Swiper`: navigation type supports `dots` `dots-bar` @carolin913 ([#2246](https://github.com/Tencent/tdesign-react/pull/2246))
 - `Table`: Added `onColumnResizeChange` event @honkinglin ([#2262](https://github.com/Tencent/tdesign-react/pull/2262))
+
 ### 🐞 Bug Fixes
+
 - `TreeSelect`: Fixed issue where `keys` property wasn't passed through to `Tree` @uyarn ([#2267](https://github.com/Tencent/tdesign-react/pull/2267))
 - `InputNumber`: Fixed issue where some decimal numbers couldn't be input @chaishi ([#2264](https://github.com/Tencent/tdesign-react/pull/2264))
 - `ImageViewer`: Fixed touchpad zoom operation abnormality @honkinglin ([#2265](https://github.com/Tencent/tdesign-react/pull/2265))
 - `TreeSelect`: Fixed display issue when `label` is `reactNode` @Ali-ovo ([#2258](https://github.com/Tencent/tdesign-react/pull/2258))
 
-## 🌈 1.1.8 `2023-05-25` 
+## 🌈 1.1.8 `2023-05-25`
+
 ### 🚀 Features
+
 - `TimePicker`: Don't allow clicking confirm button when no value is selected @uyarn ([#2240](https://github.com/Tencent/tdesign-react/pull/2240))
+
 ### 🐞 Bug Fixes
+
 - `Form`: Fixed `FormList` data passing issue @honkinglin ([#2239](https://github.com/Tencent/tdesign-react/pull/2239))
 
-## 🌈 1.1.7 `2023-05-19` 
+## 🌈 1.1.7 `2023-05-19`
+
 ### 🐞 Bug Fixes
+
 - `Tooltip`: Fixed arrow offset issue @uyarn ([#1347](https://github.com/Tencent/tdesign-common/pull/1347))
 
-## 🌈 1.1.6 `2023-05-18` 
+## 🌈 1.1.6 `2023-05-18`
+
 ### 🚀 Features
+
 - `TreeSelect`: Support `panelConent` API @ArthurYung ([#2182](https://github.com/Tencent/tdesign-react/pull/2182))
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed issue of creating options with duplicate labels @uyarn ([#2221](https://github.com/Tencent/tdesign-react/pull/2221))
 - `Skeleton`: Fixed issue where extra theme row was rendered when using `rowCol` @uyarn ([#2223](https://github.com/Tencent/tdesign-react/pull/2223))
 - `Form`:
-    - Fixed error when using `useWatch` in async rendering @honkinglin ([#2220](https://github.com/Tencent/tdesign-react/pull/2220))
-    - Fixed `FormList` initial value assignment failure issue @honkinglin ([#2222](https://github.com/Tencent/tdesign-react/pull/2222))
+  - Fixed error when using `useWatch` in async rendering @honkinglin ([#2220](https://github.com/Tencent/tdesign-react/pull/2220))
+  - Fixed `FormList` initial value assignment failure issue @honkinglin ([#2222](https://github.com/Tencent/tdesign-react/pull/2222))
 
-## 🌈 1.1.5 `2023-05-10` 
+## 🌈 1.1.5 `2023-05-10`
+
 ### 🚀 Features
+
 - `Cascader`: Support `suffix`, `suffixIcon` @honkinglin ([#2200](https://github.com/Tencent/tdesign-react/pull/2200))
+
 ### 🐞 Bug Fixes
+
 - `SelectInput`: Fixed issue where `loading` was hidden in `disabled` state @honkinglin ([#2196](https://github.com/Tencent/tdesign-react/pull/2196))
 - `Image`: Fixed issue where component didn't support `ref` @li-jia-nan ([#2198](https://github.com/Tencent/tdesign-react/pull/2198))
 - `BackTop`: Support `ref` pass-through @li-jia-nan ([#2202](https://github.com/Tencent/tdesign-react/pull/2202))
 
-## 🌈 1.1.4 `2023-04-27` 
+## 🌈 1.1.4 `2023-04-27`
+
 ### 🚀 Features
+
 - `Select`: Support `panelTopContent` for scenarios needing scrolling dropdown like virtual scrolling, see examples for usage @uyarn ([#2184](https://github.com/Tencent/tdesign-react/pull/2184))
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: Fixed panel close abnormality on second click @honkinglin ([#2183](https://github.com/Tencent/tdesign-react/pull/2183))
 - `Table`: Fixed `useResizeObserver` ssr error @chaishi ([#2175](https://github.com/Tencent/tdesign-react/pull/2175))
 
-## 🌈 1.1.3 `2023-04-21` 
+## 🌈 1.1.3 `2023-04-21`
+
 ### 🚀 Features
+
 - `DatePicker`: Support `onPresetClick` event @honkinglin ([#2165](https://github.com/Tencent/tdesign-react/pull/2165))
 - `Switch`: `onChange` supports returning `event` parameter @carolin913 ([#2162](https://github.com/Tencent/tdesign-react/pull/2162))
 - `Collapse`: `onChange` supports returning `event` parameter @carolin913 ([#2162](https://github.com/Tencent/tdesign-react/pull/2162))
+
 ### 🐞 Bug Fixes
-- `Form`: 
-    - Fixed active reset not triggering `onReset` logic @honkinglin ([#2150](https://github.com/Tencent/tdesign-react/pull/2150))
-    - Fixed `onValuesChange` event return parameter issue @honkinglin ([#2169](https://github.com/Tencent/tdesign-react/pull/2169))
+
+- `Form`:
+  - Fixed active reset not triggering `onReset` logic @honkinglin ([#2150](https://github.com/Tencent/tdesign-react/pull/2150))
+  - Fixed `onValuesChange` event return parameter issue @honkinglin ([#2169](https://github.com/Tencent/tdesign-react/pull/2169))
 - `Select`: Fixed issue where `size` property was ineffective in multi-select mode @uyarn ([#2163](https://github.com/Tencent/tdesign-react/pull/2163))
 - `Collapse`:
-    - Fixed `Radio` disable judgment @duanbaosheng ([#2161](https://github.com/Tencent/tdesign-react/pull/2161))
-    - Fixed controlled issue when `value` has default value @moecasts ([#2152](https://github.com/Tencent/tdesign-react/pull/2152))
+  - Fixed `Radio` disable judgment @duanbaosheng ([#2161](https://github.com/Tencent/tdesign-react/pull/2161))
+  - Fixed controlled issue when `value` has default value @moecasts ([#2152](https://github.com/Tencent/tdesign-react/pull/2152))
 - `Icon`: Fixed issue where manifest unified entry exported esm module but documentation wasn't updated in time @Layouwen ([#2160](https://github.com/Tencent/tdesign-react/pull/2160))
 
-## 🌈 1.1.2 `2023-04-13` 
+## 🌈 1.1.2 `2023-04-13`
+
 ### 🚀 Features
+
 - `DatePicker`: Optimized week selector highlight judgment logic performance @honkinglin ([#2136](https://github.com/Tencent/tdesign-react/pull/2136))
+
 ### 🐞 Bug Fixes
-- `Dialog`: 
-    - Fixed issue where setting style width was ineffective @honkinglin ([#2132](https://github.com/Tencent/tdesign-react/pull/2132))
-    - Fixed footer rendering null issue @honkinglin ([#2131](https://github.com/Tencent/tdesign-react/pull/2131))
+
+- `Dialog`:
+  - Fixed issue where setting style width was ineffective @honkinglin ([#2132](https://github.com/Tencent/tdesign-react/pull/2132))
+  - Fixed footer rendering null issue @honkinglin ([#2131](https://github.com/Tencent/tdesign-react/pull/2131))
 - `Select`: Fixed multi-select group display style abnormality @uyarn ([#2138](https://github.com/Tencent/tdesign-react/pull/2138))
-- `Popup`: 
-    - Fixed issue where scrollTop decimal under windows caused scroll bottom judgment failure @honkinglin ([#2142](https://github.com/Tencent/tdesign-react/pull/2142))
-    - Fixed critical point initial positioning issue @honkinglin ([#2134](https://github.com/Tencent/tdesign-react/pull/2134))
+- `Popup`:
+  - Fixed issue where scrollTop decimal under windows caused scroll bottom judgment failure @honkinglin ([#2142](https://github.com/Tencent/tdesign-react/pull/2142))
+  - Fixed critical point initial positioning issue @honkinglin ([#2134](https://github.com/Tencent/tdesign-react/pull/2134))
 - `ColorPicker`: Fixed issue where saturation and slider couldn't be dragged in Frame @insekkei ([#2140](https://github.com/Tencent/tdesign-react/pull/2140))
 
-## 🌈 1.1.1 `2023-04-06` 
+## 🌈 1.1.1 `2023-04-06`
+
 ### 🚀 Features
+
 - `StickyTool`: Added `sticky-tool` component @ZekunWu ([#2065](https://github.com/Tencent/tdesign-react/pull/2065))
+
 ### 🐞 Bug Fixes
+
 - `TagInput`: Fixed issue where deleting keywords when filtering based on `TagInput` components would delete selected values @2513483494 ([#2113](https://github.com/Tencent/tdesign-react/pull/2113))
 - `InputNumber`: Fixed functionality abnormality when inputting decimals ending in 0 @uyarn ([#2127](https://github.com/Tencent/tdesign-react/pull/2127))
 - `Tree`: Fixed component data property not controlled issue @PBK-B ([#2119](https://github.com/Tencent/tdesign-react/pull/2119))
@@ -1314,19 +1653,23 @@ spline: explain
 - `TreeSelect`: Fixed issue where couldn't expand after filtering @honkinglin ([#2128](https://github.com/Tencent/tdesign-react/pull/2128))
 - `Popup`: Fixed right-click showing popup triggering browser default event @honkinglin ([#2120](https://github.com/Tencent/tdesign-react/pull/2120))
 
-## 🌈 1.1.0 `2023-03-30` 
+## 🌈 1.1.0 `2023-03-30`
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2089](https://github.com/Tencent/tdesign-react/pull/2089))
-    - Support using `filterIcon` to display different filter icons for different columns
-    - Support horizontal scrolling to fixed columns
+  - Support using `filterIcon` to display different filter icons for different columns
+  - Support horizontal scrolling to fixed columns
 - `Button`: Support disabled state not triggering href jump logic @honkinglin ([#2095](https://github.com/Tencent/tdesign-react/pull/2095))
 - `BackTop`: Added BackTop component @meiqi502 ([#2037](https://github.com/Tencent/tdesign-react/pull/2037))
 - `Form`: submit supports returning data @honkinglin ([#2096](https://github.com/Tencent/tdesign-react/pull/2096))
+
 ### 🐞 Bug Fixes
+
 - `Table`: @chaishi ([#2089](https://github.com/Tencent/tdesign-react/pull/2089))
-    - Fixed document is not undefined issue in SSR environment
-    - Fixed issue where column order couldn't be dragged and swapped in column display control scenario
-    - Single row selection, fixed `allowUncheck: false` ineffective issue
+  - Fixed document is not undefined issue in SSR environment
+  - Fixed issue where column order couldn't be dragged and swapped in column display control scenario
+  - Single row selection, fixed `allowUncheck: false` ineffective issue
 - `Dialog`: Fixed Dialog onOpen event timing issue @honkinglin ([#2090](https://github.com/Tencent/tdesign-react/pull/2090))
 - `DatePicker`: Fixed functionality abnormality when `format` is 12-hour system @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
 - `Alert`: Fixed center and font size issues when close button is text @Wen1kang @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
@@ -1334,75 +1677,95 @@ spline: explain
 - `Notification`: Fixed instance retrieval issue @honkinglin ([#2103](https://github.com/Tencent/tdesign-react/pull/2103))
 - `Radio`: Fixed ts type issue @honkinglin ([#2102](https://github.com/Tencent/tdesign-react/pull/2102))
 
-## 🌈 1.0.5 `2023-03-23` 
+## 🌈 1.0.5 `2023-03-23`
+
 ### 🚀 Features
+
 - `TimePicker`: Added `size` API for controlling time input box size @uyarn ([#2081](https://github.com/Tencent/tdesign-react/pull/2081))
+
 ### 🐞 Bug Fixes
+
 - `Form`: Fixed `FormList` initial data retrieval issue @honkinglin ([#2067](https://github.com/Tencent/tdesign-react/pull/2067))
 - `Watermark`: Fixed document undefined issue in NextJS @carolin913 ([#2073](https://github.com/Tencent/tdesign-react/pull/2073))
 - `ColorPicker`: @insekkei ([#2074](https://github.com/Tencent/tdesign-react/pull/2074))
-    - Fixed issue where HEX color values couldn't be manually input
-    - Fixed issue where recently used colors couldn't be deleted
+  - Fixed issue where HEX color values couldn't be manually input
+  - Fixed issue where recently used colors couldn't be deleted
 - `Dialog`: Fixed `onCloseBtnClick` event ineffective issue @ArthurYung ([#2080](https://github.com/Tencent/tdesign-react/pull/2080))
 - `BreadCrumb`: Fixed issue where Icon couldn't be configured through options property @uyarn ([#2081](https://github.com/Tencent/tdesign-react/pull/2081))
 
-## 🌈 1.0.4 `2023-03-16` 
+## 🌈 1.0.4 `2023-03-16`
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
-    - Updated the resizing behavior so that when there is no overflow, resizing affects the current and adjacent columns, and when horizontal scrolling exists, it affects only the current column and the total width.
-    - Editable cell(row) functionality, support real-time validation when data changes in edit mode, `col.edit.validateTrigger`
-    - Only when fixed columns exist will class names `.t-table__content--scrollable-to-left` and `.t-table__content--scrollable-to-right` appear
-    - Drag functionality, support disabling fixed columns from being dragged to adjust order
+  - Updated the resizing behavior so that when there is no overflow, resizing affects the current and adjacent columns, and when horizontal scrolling exists, it affects only the current column and the total width.
+  - Editable cell(row) functionality, support real-time validation when data changes in edit mode, `col.edit.validateTrigger`
+  - Only when fixed columns exist will class names `.t-table__content--scrollable-to-left` and `.t-table__content--scrollable-to-right` appear
+  - Drag functionality, support disabling fixed columns from being dragged to adjust order
 - `Upload`: `theme=file-input` when file is empty, don't show clear button on hover @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
 - `InputNumber`: Support thousand separator paste @uyarn ([#2058](https://github.com/Tencent/tdesign-react/pull/2058))
 - `DatePicker`: Support `size` property @honkinglin ([#2055](https://github.com/Tencent/tdesign-react/pull/2055))
+
 ### 🐞 Bug Fixes
+
 - `Form`: Fixed reset default value data type error @honkinglin ([#2046](https://github.com/Tencent/tdesign-react/pull/2046))
 - `TimelineItem`: Fixed export type @southorange0929 ([#2053](https://github.com/Tencent/tdesign-react/pull/2053))
 - `Table`: @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
-    - Fixed table width jitter issue
-    - Column width adjustment functionality, fixed Dialog column width adjustment issue
-    - Editable cell, fixed issue where dropdown selection type components `abortEditOnEvent` didn't include `onChange` but still triggered exit edit mode when data changed
+  - Fixed table width jitter issue
+  - Column width adjustment functionality, fixed Dialog column width adjustment issue
+  - Editable cell, fixed issue where dropdown selection type components `abortEditOnEvent` didn't include `onChange` but still triggered exit edit mode when data changed
 - `Table`: Fixed lazy-load reset bug @MrWeilian ([#2041](https://github.com/Tencent/tdesign-react/pull/2041))
 - `ColorPicker`: Fixed issue where input box couldn't be input @insekkei ([#2061](https://github.com/Tencent/tdesign-react/pull/2061))
 - `Affix`: Fixed fixed judgment issue @lio-mengxiang ([#2048](https://github.com/Tencent/tdesign-react/pull/2048))
 
-## 🌈 1.0.3 `2023-03-09` 
+## 🌈 1.0.3 `2023-03-09`
+
 ### 🚀 Features
+
 - `Message`: Don't auto-close on mouse hover @HelKyle ([#2036](https://github.com/Tencent/tdesign-react/pull/2036))
 - `DatePicker`: Support `defaultTime` @honkinglin ([#2038](https://github.com/Tencent/tdesign-react/pull/2038))
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: Fixed issue where current month was displayed when month was 0 @honkinglin ([#2032](https://github.com/Tencent/tdesign-react/pull/2032))
 - `Upload`: Fixed `upload.method` ineffective issue @i-tengfei ([#2034](https://github.com/Tencent/tdesign-react/pull/2034))
 - `Select`: Fixed selection error when multi-select select all initial value was empty @uyarn ([#2042](https://github.com/Tencent/tdesign-react/pull/2042))
 - `Dialog`: Fixed dialog vertical center issue @KMethod ([#2043](https://github.com/Tencent/tdesign-react/pull/2043))
 
-## 🌈 1.0.2 `2023-03-01` 
+## 🌈 1.0.2 `2023-03-01`
+
 ### 🚀 Features
+
 - `Image`: Image component supports special format addresses `.avif` and `.webp` @chaishi ([#2021](https://github.com/Tencent/tdesign-react/pull/2021))
 - `ConfigProvider`: Added `Image` global configuration `globalConfig.image.replaceImageSrc` for unified image address replacement @chaishi ([#2021](https://github.com/Tencent/tdesign-react/pull/2021))
 - `List`: `listItemMeta` supports `className`, `style` properties @honkinglin ([#2005](https://github.com/Tencent/tdesign-react/pull/2005))
+
 ### 🐞 Bug Fixes
+
 - `Form`: @honkinglin ([#2014](https://github.com/Tencent/tdesign-react/pull/2014))
-    - Fixed validation information using wrong cache
-    - Removed `FormItem` redundant event notification logic
+  - Fixed validation information using wrong cache
+  - Removed `FormItem` redundant event notification logic
 - `Drawer`: Fixed page scrollbar appearance after drag @honkinglin ([#2012](https://github.com/Tencent/tdesign-react/pull/2012))
 - `Input`: Fixed async rendering width calculation issue @honkinglin ([#2010](https://github.com/Tencent/tdesign-react/pull/2010))
 - `Textarea`: Adjusted limit display position, fixed style issue when coexisting with tips @duanbaosheng ([#2015](https://github.com/Tencent/tdesign-react/pull/2015))
 - `Checkbox`: Fixed ts type issue @NWYLZW ([#2023](https://github.com/Tencent/tdesign-react/pull/2023))
 
-## 🌈 1.0.1 `2023-02-21` 
+## 🌈 1.0.1 `2023-02-21`
+
 ### 🚀 Features
+
 - `Popup`: Added `onScrollToBottom` event @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
 - `Select`: @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
-    - Support virtual scrolling usage
-    - Support `autofocus`, `suffix`, `suffixIcon` and other APIs, `onSearch` added callback parameters
-    - Option child component supports custom `title` API
+  - Support virtual scrolling usage
+  - Support `autofocus`, `suffix`, `suffixIcon` and other APIs, `onSearch` added callback parameters
+  - Option child component supports custom `title` API
 - `Icon`: Inject styles when loading to avoid errors in next environment @uyarn ([#1990](https://github.com/Tencent/tdesign-react/pull/1990))
 - `Avatar`: Component internal image uses Image component rendering, support passing `imageProps` to Image component @chaishi ([#1993](https://github.com/Tencent/tdesign-react/pull/1993))
 - `DialogPlugin`: Support custom `visbile` @moecasts ([#1998](https://github.com/Tencent/tdesign-react/pull/1998))
 - `Tabs`: Support drag capability @duanbaosheng ([#1979](https://github.com/Tencent/tdesign-react/pull/1979))
+
 ### 🐞 Bug Fixes
+
 - `Select`: Fixed `onInputchange` trigger timing issue @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
 - `Radio`: Fixed `disabled` default value issue @honkinglin ([#1977](https://github.com/Tencent/tdesign-react/pull/1977))
 - `Table`: Ensure editable cells maintain edit state @moecasts ([#1988](https://github.com/Tencent/tdesign-react/pull/1988))
@@ -1415,12 +1778,17 @@ spline: explain
 - `Drawer`: Fixed scrollbar detection issue @honkinglin ([#2001](https://github.com/Tencent/tdesign-react/pull/2001))
 - `Dialog`: Fixed scrollbar detection issue @honkinglin ([#2001](https://github.com/Tencent/tdesign-react/pull/2001))
 
-## 🌈 1.0.0 `2023-02-13` 
+## 🌈 1.0.0 `2023-02-13`
+
 ### 🚀 Features
+
 - `Dropdown`: Submenu layer structure adjustment, added one layer `t-dropdown__submenu-wrapper` @uyarn ([#1964](https://github.com/Tencent/tdesign-react/pull/1964))
+
 ### 🐞 Bug Fixes
+
 - `Tree`: Fixed issue where `onExpand` wasn't triggered when using setItem to set node expanded @genyuMPj ([#1956](https://github.com/Tencent/tdesign-react/pull/1956))
 - `Dropdown`: Fixed position abnormality issue for multi-layer long menus @uyarn ([#1964](https://github.com/Tencent/tdesign-react/pull/1964))
 
 ## 🌈 0.x `2021-03-26 - 2023-02-08`
+
 Go to [GitHub](https://github.com/Tencent/tdesign-react/blob/develop/packages/tdesign-react/CHANGELOG-0.x.md) to view `0.x` changelog

--- a/packages/tdesign-react/CHANGELOG.md
+++ b/packages/tdesign-react/CHANGELOG.md
@@ -5,54 +5,64 @@ toc: false
 spline: explain
 ---
 
-## 🌈 1.16.3 `2026-01-04` 
+## 🌈 1.16.3 `2026-01-04`
 
 ### 🐞 Bug Fixes
+
 - `Dialog`: 修复 `1.16.0` 的优化导致无法使用 `esc` 键关闭嵌套对话框的问题 @RylanBot ([#4030](https://github.com/Tencent/tdesign-react/pull/4030))
 - `Popup`: @RylanBot ([#4057](https://github.com/Tencent/tdesign-react/pull/4057))
-  - 修复 `1.16.0` 版本的重构导致 `trigger` 为 SVG 等元素时弹出层无法出现的问题 
+  - 修复 `1.16.0` 版本的重构导致 `trigger` 为 SVG 等元素时弹出层无法出现的问题
   - 修复 `1.16.0` 版本的重构导致 `trigger` 被 `disabled` 依旧能触发弹出层的问题
 
-
-## 🌈 1.16.2 `2025-12-30` 
+## 🌈 1.16.2 `2025-12-30`
 
 ### 🐞 Bug Fixes
-- `Popup`: 
+
+- `Popup`:
   - 修复 `1.16.0` 版本的重构导致开启 `'trigger='hover'` 且外部元素动态更新时，弹窗意外被关闭的问题 @RylanBot ([#4046](https://github.com/Tencent/tdesign-react/pull/4046))
   - 修复 `1.16.0` 版本的重构导致弹窗在某些场景下位置不稳定的问题 @xiaody ([#4046](https://github.com/Tencent/tdesign-react/pull/4046))
   - 完善 `1.16.0` 版本中关于空间不足时箭头偏移的优化方案 @RylanBot ([#4042](https://github.com/Tencent/tdesign-react/pull/4042))
-- `Select`: 
+- `Select`:
   - 修复 `valueDisplay` 的 `onClose` 回调函数读取到 `undefined` 的问题 @RSS1102 ([#4047](https://github.com/Tencent/tdesign-react/pull/4047))
   - 修复 `1.15.7` 版本后，开启 `multiple` 时，不在 `options` 里的 `value` 无法渲染的问题 @RylanBot ([#4037](https://github.com/Tencent/tdesign-react/pull/4037))
   - 修复开启 `filterable` 后，选项变化但键盘导航高亮项未更新的问题 @RylanBot ([#4037](https://github.com/Tencent/tdesign-react/pull/4037))
 
+## 🌈 1.16.1 `2025-12-22`
 
-## 🌈 1.16.1 `2025-12-22` 
 ### 🐞 Bug Fixes
+
 - `Textarea`: 修复使用 `defaultValue` 或 `readonly` 产生的警告问题 @RylanBot ([#4019](https://github.com/Tencent/tdesign-react/pull/4019))
 - `Text`: 修复读取到 `undefined` 产生的报错问题 @RylanBot ([#4020](https://github.com/Tencent/tdesign-react/pull/4020))
 - `Guide`: 修复在某些场景下可能读取到 `null` 而产生的报错问题 @RylanBot ([#4027](https://github.com/Tencent/tdesign-react/pull/4027))
-- `Popup`: 
+- `Popup`:
   - 修复 `1.16.0` 版本的重构导致 `SSR` 环境下产生的报错问题 @RylanBot ([#4026](https://github.com/Tencent/tdesign-react/pull/4026))
   - 修复 `1.16.0` 版本的重构导致嵌套场景下，内层弹窗无法正常关闭的问题 @RylanBot ([#4023](https://github.com/Tencent/tdesign-react/pull/4023))
+
 ### 🚧 Others
+
 - 修复 `1.16.0` 版本打包产物中有不存在的 `sourceMap` 引用而产生的警告 @RylanBot ([#4022](https://github.com/Tencent/tdesign-react/pull/4022))
 - `TagInput`: 移除 `1.16.0` 版本引入的多余日志 @RylanBot ([#4021](https://github.com/Tencent/tdesign-react/pull/4021))
 
-## 🌈 1.16.0 `2025-12-15` 
+## 🌈 1.16.0 `2025-12-15`
+
 ### 🚨 Breaking Changes
+
 - `MessagePlugin`: 移除消息容器的 `id='tdesign-message-container--${placement}'`，之前依赖该属性的业务注意此变更 ⚠️ @RylanBot ([#3820](https://github.com/Tencent/tdesign-react/pull/3820))
+
 ### 🚀 Features
-- 支持 `readonly`  的组件新增 API  `readOnly`，与 `readonly` 效果一致。原有的 `readonly` 会被保留，未来版本将废弃，建议及时更换 ⚠️ @RylanBot ([#3955](https://github.com/Tencent/tdesign-react/pull/3955))
+
+- 支持 `readonly` 的组件新增 API `readOnly`，与 `readonly` 效果一致。原有的 `readonly` 会被保留，未来版本将废弃，建议及时更换 ⚠️ @RylanBot ([#3955](https://github.com/Tencent/tdesign-react/pull/3955))
 - 支持 `.dark` 类名，丰富切换深色模式的方式 @liweijie0812 ([common#2355](https://github.com/Tencent/tdesign-common/pull/2355))
 - `Dialog`: 优化渲染阶段，避免子元素计算异常的问题，此前有在 Dialog 内进行复杂内容渲染的请注意此变更 ⚠️ @HaixingOoO ([#3705](https://github.com/Tencent/tdesign-react/pull/3705))
 - `Form`: 保留原始 HTML 效果，当输入框按下 Enter 键自动触发 submit 事件，如果需要拦截该行为，可以给输入框绑定 `onEnter={(e)=>e.preventDefault()}`，此前有依赖此内置特性请注意此变更 ⚠️ @RylanBot ([#3943](https://github.com/Tencent/tdesign-react/pull/3943))
 - `MessagePlugin`: 新增开启和关闭时的动画效果 @RylanBot ([#3820](https://github.com/Tencent/tdesign-react/pull/3820))
-- `ImageViewer`: 
+- `ImageViewer`:
   - 新增默认 trigger 渲染 ，默认为当前使用的图片作为默认 trigger，降低组件的使用复杂度，具体参考相关示例改动 @wonkzhang ([#3819](https://github.com/Tencent/tdesign-react/pull/3819))
   - 优化下载跨域图片时的格式处理和压缩比例 @RylanBot ([#3919](https://github.com/Tencent/tdesign-react/pull/3919))
   - 支持直接下载同域图片，避免二次转换导致体积增大和动图失效等问题 @RylanBot ([#3919](https://github.com/Tencent/tdesign-react/pull/3919))
+
 ### 🐞 Bug Fixes
+
 - `Textarea`: 更正 `status` 对应的初始值与 class 名为 `default`，内部 class 进行了相应调整，之前有覆盖 tips 类名请注意此变更 ⚠️ @RylanBot ([#4007](https://github.com/Tencent/tdesign-react/pull/4007))
 - `Avatar`: 修复样式与设计稿不一致的问题 @liweijie0812 ([common#2364](https://github.com/Tencent/tdesign-common/pull/2364))
 - `ConfigProvider`: 修复 `tag.closeIcon` 不生效的问题 @RylanBot ([#4004](https://github.com/Tencent/tdesign-react/pull/4004))
@@ -64,78 +74,94 @@ spline: explain
   - 修复自定义 `attach` 后，后续其它全局消息也被绑定到该节点中的异常
   - 修复 `closeAll` 无法关闭所有消息的异常
 - `EnhancedTable`: 修复子节点收缩时，表头全选状态异常的问题 @liweijie0812 ([#3988](https://github.com/Tencent/tdesign-react/pull/3988))
-- `Table`: 
+- `Table`:
   - 修复多级表头场景下，`editable` 单元格编辑后数据没有同步的问题 @RylanBot ([#3982](https://github.com/Tencent/tdesign-react/pull/3982))
   - 修复 `onChange` 的 `context.currentData` 在过滤场景下缺失的问题 @RylanBot ([#3982](https://github.com/Tencent/tdesign-react/pull/3982))
   - 修复由于表格宽度计算时机不稳定，导致表头无法对齐、空状态不居中等问题 @RylanBot ([#3972](https://github.com/Tencent/tdesign-react/pull/3972))
-- `Popup`: 
+- `Popup`:
   - 修复空间不足时，箭头偏移的问题 @RylanBot ([#3980](https://github.com/Tencent/tdesign-react/pull/3980))
   - 将容器的位置统一设为 `absolute`，修复部分场景下定位异常的问题 @RylanBot ([#3916](https://github.com/Tencent/tdesign-react/pull/3916))
   - 修复 `triggerElement` 类型为字符串时未正确作为元素选择器解析的问题 @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
   - 修复 `children` 为不支持 `ref` 穿透的封装组件时，弹窗无法正常出现的问题 @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
 - `PopupPlugin`: 修复 `classPrefix` 不生效的问题 @RylanBot ([#3940](https://github.com/Tencent/tdesign-react/pull/3940))
 
-## 🌈 1.15.11 `2025-12-15` 
+## 🌈 1.15.11 `2025-12-15`
+
 ### 🚀 Features
+
 - `Textarea`: 支持 `count` API，用于自定义计数元素的渲染 @RylanBot ([#4003](https://github.com/Tencent/tdesign-react/pull/4003))
+
 ### 🐞 Bug Fixes
+
 - `RadioGroup`: 修复 NextJS 中，`variant="default-filled` 时，子组件含动态内容时导致无限循环的问题 @tingtingcheng6 ([#3921](https://github.com/Tencent/tdesign-react/pull/3921))
 
-## 🌈 1.15.10 `2025-12-12` 
+## 🌈 1.15.10 `2025-12-12`
+
 ### 🐞 Bug Fixes
+
 - `Drawer`: 修复回调事件错误缓存的问题 @uyarn ([#4008](https://github.com/Tencent/tdesign-react/pull/3921))
 
-## 🌈 1.15.9 `2025-11-28` 
+## 🌈 1.15.9 `2025-11-28`
+
 ### 🚀 Features
+
 - `Cascader`: 支持当 `valueMode` 为 `all` 或者 `parentFirst` 时，在 `filterable` 选项中显示非叶子节点 @lifeiFront ([#3964](https://github.com/Tencent/tdesign-react/pull/3964))
-- `Popup`:  新增多个组件实例方法，`getOverlay` 用于获取浮层元素，`getOverlayState` 用于获取浮层悬浮状态，`getPopper` 用于获取当前组件 popper 实例，`update` 用于更新浮层内容 @RSS1102 ([#3925](https://github.com/Tencent/tdesign-react/pull/3925))
+- `Popup`: 新增多个组件实例方法，`getOverlay` 用于获取浮层元素，`getOverlayState` 用于获取浮层悬浮状态，`getPopper` 用于获取当前组件 popper 实例，`update` 用于更新浮层内容 @RSS1102 ([#3925](https://github.com/Tencent/tdesign-react/pull/3925))
 - `Select`: 支持通过键盘进行选项操作 @uyarn ([#3969](https://github.com/Tencent/tdesign-react/pull/3969))
 - `Swiper`: 支持 `cardScale` API，用于控制卡片的缩放比例 @RylanBot ([#3978](https://github.com/Tencent/tdesign-react/pull/3978))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: 修复 `reserveKeyword` 不生效的问题 @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
 - `Description`: 修复无边框模式下 `itemLayout='vertical'` 的间距问题 @mikasayw ([common#2321](https://github.com/Tencent/tdesign-common/pull/2321))
 - `Input`: 修正组件及上层 `Select` 等组件在 Safari 中初次渲染 `autoWidth` 失效的问题 @Cat1007 ([common#2336](https://github.com/Tencent/tdesign-common/pull/2336))
 - `Table`: 表格内容未渲染时，设置 `dragSort` 相关拖动事件报错的问题 @lifeiFront ([#3958](https://github.com/Tencent/tdesign-react/pull/3958))
-- `Title`: 添加兜底机制，避免错误使用 `level` 导致页面直接白屏的问题  @RylanBot ([#3975](https://github.com/Tencent/tdesign-react/pull/3975))
+- `Title`: 添加兜底机制，避免错误使用 `level` 导致页面直接白屏的问题 @RylanBot ([#3975](https://github.com/Tencent/tdesign-react/pull/3975))
 - `Select`: 修复使用 `backspace` 键删除标签时，没有触发 `onRemove` 的问题 @RylanBot ([#3961](https://github.com/Tencent/tdesign-react/pull/3961))
 - `Slider`: 修复浮点误差导致的滑块位置异常问题 @RylanBot ([#3947](https://github.com/Tencent/tdesign-react/pull/3947))
 - `Swiper`: 修复受控模式下 `current` 初始化错误的问题 @HaixingOoO ([#3959](https://github.com/Tencent/tdesign-react/pull/3959))
 - `Upload`: 修复不支持文件数组上传的问题 @GATING ([common#2078](https://github.com/Tencent/tdesign-common/pull/2078))
-- `Calendar`:  @shumuuu ([#3938](https://github.com/Tencent/tdesign-react/pull/3938))
+- `Calendar`: @shumuuu ([#3938](https://github.com/Tencent/tdesign-react/pull/3938))
   - 修复当 `range` 为同一年内时，终止月份之后的月份选项没有正常禁用的问题
   - 修复年份选项错误地使用了月份选项禁用范围判定逻辑的问题
-- `Form`:  修复 `readonly` 属性在不同组件中的兼容问题 @RylanBot ([#3986](https://github.com/Tencent/tdesign-react/pull/3986))
+- `Form`: 修复 `readonly` 属性在不同组件中的兼容问题 @RylanBot ([#3986](https://github.com/Tencent/tdesign-react/pull/3986))
 - `Form`: @RylanBot ([#3957](https://github.com/Tencent/tdesign-react/pull/3957))
-  - 修复嵌套三层及以上的 FormList 相关方法失效的问题 
+  - 修复嵌套三层及以上的 FormList 相关方法失效的问题
   - 修复 `reset` 时没有触发 `onValueChange` 的问题
   - 修复初始化调用 `setFieldsValue` 时没有触发 `onValuesChange` 的问题
   - 修复非动态表单场景下，`name` 为数字或含有数字时 `setFieldValues` 失败的问题
   - 优化 `key` 的生成，更新值与当前表单值相同时不刷新元素
-- `Tree`: 
+- `Tree`:
   - 修复过滤节点被意外禁用的问题 @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
   - 修复 `setData` 没有自动触发 UI 刷新的问题 @RylanBot ([common#2283](https://github.com/Tencent/tdesign-common/pull/2283))
 - `TreeSelect`: @RylanBot ([#3984](https://github.com/Tencent/tdesign-react/pull/3984))
   - 修复过滤节点的父节点也可以被选中的问题
   - 修复 `blur` 时，输入框内容没有清空的问题
+
 ### 🚧 Others
+
 - `Slider`: 加强组件的泛型支持，便于 `value` 与 `onChange` 联动 @RylanBot ([#3962](https://github.com/Tencent/tdesign-react/pull/3962))
 
-## 🌈 1.15.8 `2025-11-04` 
+## 🌈 1.15.8 `2025-11-04`
+
 ### 🚀 Features
+
 - `Popup`: 添加 `onOverlayClick` 事件以支持内容面板点击触发 @RSS1102 ([#3927](https://github.com/Tencent/tdesign-react/pull/3927))
 - `CheckboxGroup`: 支持 `readonly` API @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
 - `Form`: @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
   - 支持 `readonly` API
   - 支持 `FormRule.pattern` 的类型为 `string`
+
 ### 🐞 Bug Fixes
-- `Select`: 修复 `1.15.7`  版本中全选功能在分组模式下功能异常的问题 @uyarn ([#3941](https://github.com/Tencent/tdesign-react/pull/3941))
+
+- `Select`: 修复 `1.15.7` 版本中全选功能在分组模式下功能异常的问题 @uyarn ([#3941](https://github.com/Tencent/tdesign-react/pull/3941))
 - `Form`: 修复嵌套 `FormList` 无法使用 `setFields` 更新表单的问题 @RylanBot ([#3930](https://github.com/Tencent/tdesign-react/pull/3930))
 - `CheckboxGroup`: 修复被设为 `disabled` 的选项会被 `checkAll` 篡改状态的问题 @RylanBot ([#3885](https://github.com/Tencent/tdesign-react/pull/3885))
 - `SubMenu`: 修复自定义 `popupProps` 的 `visible` 和 `onVisibleChange` 不生效的问题 @RylanBot ([#3912](https://github.com/Tencent/tdesign-react/pull/3912))
 - `DatePicker`: 修复同时开启 `enableTimePicker` 与 `needConfirm={false}` 时，选择日期后未选时间就关闭弹窗的问题 @RylanBot ([#3860](https://github.com/Tencent/tdesign-react/pull/3860))
 - `DateRangePicker`: 修复同时开启 `enableTimePicker` 与 `needConfirm={false}` 时，仍需手动确认的问题 @achideal ([#3860](https://github.com/Tencent/tdesign-react/pull/3860))
 - `Progress`: 修复开启 `theme='plump'` 时，自定义 `label` 被隐藏的问题 @RylanBot ([#3931](https://github.com/Tencent/tdesign-react/pull/3931))
-- `RadioGroup`: @RylanBot 
+- `RadioGroup`: @RylanBot
   - 修复子元素动态更新时，高亮异常的问题 ([#3922](https://github.com/Tencent/tdesign-react/pull/3922))
   - 修复设置 `value` 为空时，高亮块没有消失的问题 ([#3944](https://github.com/Tencent/tdesign-react/pull/3944))
 - `Tree`: @RylanBot
@@ -145,19 +171,24 @@ spline: explain
   - 修复点击 `operation` 区域时将该行节点 `active` 的异常 ([#3889](https://github.com/Tencent/tdesign-react/pull/3889))
 
 ### 🚧 Others
+
 - `Form`: 优化 `getValidateMessage` 方法底层的逻辑 @RylanBot ([#3930](https://github.com/Tencent/tdesign-react/pull/3930))
 
-## 🌈 1.15.7 `2025-10-24` 
+## 🌈 1.15.7 `2025-10-24`
+
 ### 🚀 Features
+
 - `Divider`: 支持 `size` 控制间距大小 @HaixingOoO ([#3893](https://github.com/Tencent/tdesign-react/pull/3893))
+
 ### 🐞 Bug Fixes
+
 - `TreeSelect`: 修复删除不在 `data` 中的选项时产生的报错 @RylanBot ([#3886](https://github.com/Tencent/tdesign-react/pull/3886))
 - `EnhancedTable`: 修复拖拽后动态关闭 `dragSort`，行无法正常展开的异常 @RylanBot ([#3896](https://github.com/Tencent/tdesign-react/pull/3896))
 - `Menu`: 避免在菜单折叠时隐藏 `span` 包裹的图标 @QuentinHsu([common#2303](https://github.com/Tencent/tdesign-common/pull/2303))
 - `Textarea`: 修复内容超长情况下，设置 `autosize` 没有完整自动撑开高度，存在有滚动条的问题 @engvuchen ([#3856](https://github.com/Tencent/tdesign-react/pull/3856))
-- `RadioGroup`: 修复键盘操作时读取到 `null` 产生的报错  @RylanBot ([#3906](https://github.com/Tencent/tdesign-react/pull/3906))
-- `Loading`: 修复 `delay` 不生效的问题  @RylanBot ([#3859](https://github.com/Tencent/tdesign-react/pull/3859))
-- `Form`: 
+- `RadioGroup`: 修复键盘操作时读取到 `null` 产生的报错 @RylanBot ([#3906](https://github.com/Tencent/tdesign-react/pull/3906))
+- `Loading`: 修复 `delay` 不生效的问题 @RylanBot ([#3859](https://github.com/Tencent/tdesign-react/pull/3859))
+- `Form`:
   - 修复错误消息 `max` 和 `min` 英文翻译错误 @liweijie0812([common#2304](https://github.com/Tencent/tdesign-common/pull/2304))
   - 修复嵌套 `FormList` 无法使用 `add` 正确新增表单的问题 @RylanBot ([#3881](https://github.com/Tencent/tdesign-react/pull/3881))
 - `Select`: @RylanBot ([#3879](https://github.com/Tencent/tdesign-react/pull/3879))
@@ -168,39 +199,53 @@ spline: explain
   - 修复数据在非虚拟滚动和虚拟滚动的 `threshold` 切换时，无法正确刷新的问题
   - 修复没开启 `scroll={{type:'virtual'}}`，但启动了相关计算的问题
 
-## 🌈 1.15.6 `2025-10-10` 
+## 🌈 1.15.6 `2025-10-10`
+
 ### 🐞 Bug Fixes
+
 - `VirtualScroll`: 修复引入虚拟滚动的组件在使用子组件配合异步请求场景的组件告警问题 @uyarn ([#3876](https://github.com/Tencent/tdesign-react/pull/3876))
 
-## 🌈 1.15.5 `2025-10-05` 
+## 🌈 1.15.5 `2025-10-05`
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: 修复 `1.15.2` 版本 SSR 场景下使用的问题 @Wesley-0808([#3873](https://github.com/Tencent/tdesign-react/pull/3873))
 - `Descriptions`: 修复无边框模式下的边距问题 @liweijie0812 ([#3873](https://github.com/Tencent/tdesign-react/pull/3873))
 
-## 🌈 1.15.4 `2025-10-01` 
+## 🌈 1.15.4 `2025-10-01`
+
 ### 🚀 Features
-- `ImageViewer`: 支持 `trigger` 传入图片 `index` 参数，trigger  的 `open` 方法参数可能与绑定的元素触发事件存在类型差异情况，若遇到此问题请改成 `()=> open()` 类似匿名函数使用 @betavs ([#3827](https://github.com/Tencent/tdesign-react/pull/3827))
+
+- `ImageViewer`: 支持 `trigger` 传入图片 `index` 参数，trigger 的 `open` 方法参数可能与绑定的元素触发事件存在类型差异情况，若遇到此问题请改成 `()=> open()` 类似匿名函数使用 @betavs ([#3827](https://github.com/Tencent/tdesign-react/pull/3827))
+
 ### 🐞 Bug Fixes
+
 - `Swiper`: 修复在移动端中点击导航条后自动播放失效的问题 @uyarn ([#3862](https://github.com/Tencent/tdesign-react/pull/3862))
 - `List`: 移除 `1.15.2` 版本引入的冗余代码造成开启虚拟滚动时初始化卡顿的问题 @RylanBot ([#3863](https://github.com/Tencent/tdesign-react/pull/3863))
 - `Select`: 移除 `1.15.2` 版本引入的冗余代码造成开启虚拟滚动时初始化卡顿的问题 @RylanBot ([#3863](https://github.com/Tencent/tdesign-react/pull/3863))
 
-## 🌈 1.15.3 `2025-09-29` 
+## 🌈 1.15.3 `2025-09-29`
+
 ### 🐞 Bug Fixes
+
 - `Select`: 修复 `OptionGroup` 的 `style` 与 `className` 没有生效的问题 @uyarn ([#3855](https://github.com/Tencent/tdesign-react/pull/3855))
 
-## 🌈 1.15.2 `2025-09-29` 
+## 🌈 1.15.2 `2025-09-29`
+
 ### 🚀 Features
+
 - `Watermark`: 新增 `layout` API，支持生成不同布局的水印，`watermarkText` 支持配置字体 @Wesley-0808 ([#3817](https://github.com/Tencent/tdesign-react/pull/3817))
-- `Drawer`:  优化拖拽调整大小的过程中，组件的内容会被选中的问题 @uyarn ([#3844](https://github.com/Tencent/tdesign-react/pull/3844))
+- `Drawer`: 优化拖拽调整大小的过程中，组件的内容会被选中的问题 @uyarn ([#3844](https://github.com/Tencent/tdesign-react/pull/3844))
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: 修复多行图文水印图片配置了灰度时，整个画布内容也会灰度的问题 @Wesley-0808 ([#3817](https://github.com/Tencent/tdesign-react/pull/3817))
 - `Slider`: 修复设置 `step` 后的精度问题造成的返回值和相关展示异常 @uyarn ([#3821](https://github.com/Tencent/tdesign-react/pull/3821))
 - `TagInput`: 修复 `onBlur` 中的 `inputValue` 始终为空的问题 @RylanBot ([#3841](https://github.com/Tencent/tdesign-react/pull/3841))
 - `Cascader`: 修复 `single` 模式下，选中唯一的子节点时，父节点意外被高亮的问题 @RylanBot ([#3840](https://github.com/Tencent/tdesign-react/pull/3840))
 - `DateRangePickerPanel`: 修复 `preset` 涉及跨年份的日期时，点击面板后无法同步的问题 @RylanBot ([#3818](https://github.com/Tencent/tdesign-react/pull/3818))
 - `EnhancedTable`: 修复节点拖拽后，再点击展开时，位置被重置的问题 @RylanBot ([#3780](https://github.com/Tencent/tdesign-react/pull/3780))
-- `Table`: @RylanBot 
+- `Table`: @RylanBot
   - 修复开启 `multipleSort` 但没有声明 `sort` 或 `defaultSort` 时，`onSortChange` 始终返回 `undefined` 的问题 ([#3824](https://github.com/Tencent/tdesign-react/pull/3824))
   - 修复同时开启虚拟滚动与设置 `firstFullRow` / `lastFullRow` 等情况时，最后一行内容被遮挡的问题 ([#3792](https://github.com/Tencent/tdesign-react/pull/3792))
   - 修复 `fixedRows` / `firstFullRow` / `lastFullRow` 无法在虚拟滚动下组合使用的问题 ([#3792](https://github.com/Tencent/tdesign-react/pull/3792))
@@ -212,36 +257,42 @@ spline: explain
 - `SelectInput`: @RylanBot ([#3838](https://github.com/Tencent/tdesign-react/pull/3838))
   - 修复自定义 `popupVisible={false}` 时，`onBlur` 不生效的问题
   - 修复开启 `multiple` 时，`onBlur` 缺少 `tagInputValue` 参数的问题
-- `Select`: 
+- `Select`:
   - 修复使用 `keys` 配置 `content` 作为 `label` 或 `value` 无法生效的问题 @RylanBot @uyarn ([#3829](https://github.com/Tencent/tdesign-react/pull/3829))
   - 修复动态切换到虚拟滚动时，出现白屏和滚动条被意外重置的问题 @RylanBot ([#3792](https://github.com/Tencent/tdesign-react/pull/3792)) ([#3836](https://github.com/Tencent/tdesign-react/pull/3836))
   - 修复开启虚拟滚动且动态更新数据，展示数据不同步的问题 @huangchen1031 ([#3839](https://github.com/Tencent/tdesign-react/pull/3839))
-- `List`: 
+- `List`:
   - 修复开启虚拟滚动后，`ListItem` 的部分 API 无法生效的问题 @FlowerBlackG ([#3835](https://github.com/Tencent/tdesign-react/pull/3835))
   - 修复动态切换到虚拟滚动时，滚动条被意外重置的问题 @RylanBot ([#3792](https://github.com/Tencent/tdesign-react/pull/3792)) ([#3836](https://github.com/Tencent/tdesign-react/pull/3836))
 
-## 🌈 1.15.1 `2025-09-12` 
+## 🌈 1.15.1 `2025-09-12`
+
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: 修复 `imageScale` 配置效果异常的问题 @uyarn ([#3814](https://github.com/Tencent/tdesign-react/pull/3814))
 
-## 🌈 1.15.0 `2025-09-11` 
+## 🌈 1.15.0 `2025-09-11`
+
 ### 🚀 Features
-- `Icon`:  @uyarn ([#3802](https://github.com/Tencent/tdesign-react/pull/3802))
-  - `tdesign-icons-react` 发布 `0.6.0` 版本，新增 `align-bottom`、`no-result`、`no-result-filled`、 `tree-list`、`wifi-no`、 `wifi-no-filled`、`logo-stackblitz-filled`、`logo-stackblitz`、`logo-wecom-filled` 图标，移除 `video-camera-3`、`video-camera-3-filled`、`list` 图标，此前有依赖以下图标升级请注意 ⚠️ 
+
+- `Icon`: @uyarn ([#3802](https://github.com/Tencent/tdesign-react/pull/3802))
+  - `tdesign-icons-react` 发布 `0.6.0` 版本，新增 `align-bottom`、`no-result`、`no-result-filled`、 `tree-list`、`wifi-no`、 `wifi-no-filled`、`logo-stackblitz-filled`、`logo-stackblitz`、`logo-wecom-filled` 图标，移除 `video-camera-3`、`video-camera-3-filled`、`list` 图标，此前有依赖以下图标升级请注意 ⚠️
   - 按需加载方式使用的图标资源支持可变粗细功能，通过 `strokeWidth` 属性进行配置
   - 按需加载方式使用的图标资源支持多色填充功能，通过 `strokeColor` 和 `fillColor` 属性进行配置
 - `DatePicker`: 支持通过覆盖 `popupProps`，使点击 `preset` 时不关闭弹窗 @RylanBot ([#3798](https://github.com/Tencent/tdesign-react/pull/3798))
+
 ### 🐞 Bug Fixes
+
 - `Tree`: @RylanBot ([#3756](https://github.com/Tencent/tdesign-react/pull/3756))
   - 修正节点属性 `date-target` 单词拼写为 `data-target`，之前有使用该属性的业务请注意此变更 ⚠️
   - 修复拖拽后展开收起图标展示异常的问题
-- `MessagePlugin`: 修复 `content` 为 `''` / `undefined` / `null` 时产生的报错  @RylanBot ([#3778](https://github.com/Tencent/tdesign-react/pull/3778))
-- `Table`: 
+- `MessagePlugin`: 修复 `content` 为 `''` / `undefined` / `null` 时产生的报错 @RylanBot ([#3778](https://github.com/Tencent/tdesign-react/pull/3778))
+- `Table`:
   - 修复未开启 `<React.StrictMode>` 时，`Loading` 挂载导致的页面闪烁问题 @RylanBot ([#3775](https://github.com/Tencent/tdesign-react/pull/3775))
   - 修复 `size='small'` 的 `firstFullRow` 尺寸比 `size='medium'` 大的异常 ([#common2253](https://github.com/Tencent/tdesign-common/pull/2253))
 - `Upload`: 修复拖拽模式下 `status` 更新错误 @RSS1102 ([#3801](https://github.com/Tencent/tdesign-react/pull/3801))
 - `Input`: 修复在开启 `readonly` 或者禁用 `allowInput` 情况下没有触发 `onFocus` 和 `onBlur` 的问题 @RylanBot ([#3800](https://github.com/Tencent/tdesign-react/pull/3800))
-- `Cascader`: 
+- `Cascader`:
   - 修复启用 `multiple` 与 `valueType='full'` 时，`valueDisplay` 渲染异常的问题 @RSS1102 ([#3809](https://github.com/Tencent/tdesign-react/pull/3809))
   - 修复 `1.11.0` 版本引入的新特性，导致无法选中底部选项的问题 @RylanBot ([#3772](https://github.com/Tencent/tdesign-react/pull/3772))
 - `Select`: 避免下拉框的打开与关闭时，频繁重复触发 `valueDisplay` 的渲染 @RylanBot ([#3808](https://github.com/Tencent/tdesign-react/pull/3808))
@@ -252,29 +303,40 @@ spline: explain
 - `Tooltip`: 修复 `delay` API 的类型不完整问题 @HaixingOoO ([#3806](https://github.com/Tencent/tdesign-react/pull/3806))
 
 ### 🚧 Others
+
 - `react-render`: 修复引入 `react-19-adapter` 后仍然显示需要引入相关模块的警告的问题 @HaixingOoO ([#3790](https://github.com/Tencent/tdesign-react/pull/3790))
 
-## 🌈 1.14.5 `2025-08-26` 
-### 🐞 Bug Fixes
-- `Watermark`:  完善水印组件在 SSR 场景的兼容问题 @uyarn ([#3765](https://github.com/Tencent/tdesign-react/pull/3765))
+## 🌈 1.14.5 `2025-08-26`
 
-## 🌈 1.14.3 `2025-08-26` 
 ### 🐞 Bug Fixes
+
+- `Watermark`: 完善水印组件在 SSR 场景的兼容问题 @uyarn ([#3765](https://github.com/Tencent/tdesign-react/pull/3765))
+
+## 🌈 1.14.3 `2025-08-26`
+
+### 🐞 Bug Fixes
+
 - `Pagination`: 修复跳转图标没有重置回正确状态的问题 @phalera ([#3758](https://github.com/Tencent/tdesign-react/pull/3758))
 - `Watermark`: @uyarn ([#3760](https://github.com/Tencent/tdesign-react/pull/3760))
   - 修复 `1.14.0` 版本默认文字颜色缺失透明度的问题
   - 修复 `1.14.0` 版本不兼容 SSR 场景的问题
 
-## 🌈 1.14.2 `2025-08-22` 
+## 🌈 1.14.2 `2025-08-22`
+
 ### 🐞 Bug Fixes
+
 - `Dialog`: 修复 `1.14.0` 版本引入的新特性导致 `draggable` 禁用失败的问题 @RylanBot ([#3753](https://github.com/Tencent/tdesign-react/pull/3753))
 
-## 🌈 1.14.1 `2025-08-22` 
+## 🌈 1.14.1 `2025-08-22`
+
 ### 🐞 Bug Fixes
+
 - `Steps`: 修复 `1.13.2` 版本引起的 `theme` 不为 `default` 时重复渲染图标的问题 @RSS1102 ([#3748](https://github.com/Tencent/tdesign-react/pull/3748))
 
-## 🌈 1.14.0 `2025-08-21` 
+## 🌈 1.14.0 `2025-08-21`
+
 ### 🚀 Features
+
 - `Tabs`: 将 `remove` 事件从删除图标移至外层容器, 保证替换图标功能正常使用，有覆盖删除图标样式请注意此变更 ⚠️ @RSS1102 ([#3736](https://github.com/Tencent/tdesign-react/pull/3736))
 - `Card`: 新增 `headerClassName`、`headerStyle`、`bodyClassName`、`bodyStyle`、`footerClassName`、`footerStyle`，方便用于定制卡片组件的各部分样式 @lifeiFront ([#3737](https://github.com/Tencent/tdesign-react/pull/3737))
 - `Form`: `rules` 支持配置嵌套字段进行校验 @uyarn ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
@@ -290,32 +352,34 @@ spline: explain
 - `Statistic`: 修改 `color` 属性类型为字符串，以支持任何 [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) 支持的颜色值 @RSS1102 ([#3706](https://github.com/Tencent/tdesign-react/pull/3706))
 
 ### 🐞 Bug Fixes
+
 - `Tree`: @RylanBot
-  - 修复 `draggable` 在 `disabled` 状态下依旧生效的异常，此前有依赖此错误的业务请注意此变动 ⚠️ ([#3740](https://github.com/Tencent/tdesign-react/pull/3740)) 
+  - 修复 `draggable` 在 `disabled` 状态下依旧生效的异常，此前有依赖此错误的业务请注意此变动 ⚠️ ([#3740](https://github.com/Tencent/tdesign-react/pull/3740))
   - 修复 `checkStrictly` 默认为 false 时，父子节点 `disabled` 状态没有关联的问题 ([#3739](https://github.com/Tencent/tdesign-react/pull/3739))
   - 修复 Drag 相关事件的回调中 `node` 为 null 的异常 ([#3728](https://github.com/Tencent/tdesign-react/pull/3728))
 - `Form`: @uyarn
-    - 修复嵌套表单受外层 `FormList` 影响数据构造的问题 ([#3715](https://github.com/Tencent/tdesign-react/pull/3715))
-    - 修复嵌套表单中内层表单受外层表单影响校验结果字段的问题 ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
+  - 修复嵌套表单受外层 `FormList` 影响数据构造的问题 ([#3715](https://github.com/Tencent/tdesign-react/pull/3715))
+  - 修复嵌套表单中内层表单受外层表单影响校验结果字段的问题 ([#3738](https://github.com/Tencent/tdesign-react/pull/3738))
 - `FormList`: 解决 `1.13.2` 引入的修复，导致手动 `setFields` 设置初始值而非利用 `initialData` 后无法新增数据的问题 @RylanBot ([#3730](https://github.com/Tencent/tdesign-react/pull/3730))
 - `Input`: 修复密码输入框点击图标切换内容可见性时，光标位置没能被保留 @RylanBot ([#3726](https://github.com/Tencent/tdesign-react/pull/3726))
 - `Table`: @RylanBot ([#3733](https://github.com/Tencent/tdesign-react/pull/3733))
-    - 修复开启虚拟滚动时，动态更新数据时导致白屏的问题  
-    - 修复开启虚拟滚动时，表头与下方表格的宽度未同步变化
-    - 修复开启虚拟滚动时，滚动条意外被重置回第一行的位置
-    - 修复 `dragSort='row-handler-col'` 时，列拖拽不生效的问题 ([#3734](https://github.com/Tencent/tdesign-react/pull/3734))
-    - 修复 `size='small'` 的 `firstFullRow` 尺寸比 `size='medium'` 大的异常 ([common#2253](https://github.com/Tencent/tdesign-common/pull/2253))
+  - 修复开启虚拟滚动时，动态更新数据时导致白屏的问题
+  - 修复开启虚拟滚动时，表头与下方表格的宽度未同步变化
+  - 修复开启虚拟滚动时，滚动条意外被重置回第一行的位置
+  - 修复 `dragSort='row-handler-col'` 时，列拖拽不生效的问题 ([#3734](https://github.com/Tencent/tdesign-react/pull/3734))
+  - 修复 `size='small'` 的 `firstFullRow` 尺寸比 `size='medium'` 大的异常 ([common#2253](https://github.com/Tencent/tdesign-common/pull/2253))
 - `Watermark`: 修复深色模式下，文字水印内容显示不明显的问题 @HaixingOoO @liweijie0812 ([#3692](https://github.com/Tencent/tdesign-react/pull/3692))
 - `DatePicker`: 优化年份选择模式下选择同面板年份后面板内容的展示效果 @uyarn ([#3744](https://github.com/Tencent/tdesign-react/pull/3744))
 
+## 🌈 1.13.2 `2025-08-01`
 
-## 🌈 1.13.2 `2025-08-01` 
 ### 🐞 Bug Fixes
-- `DatePicker`: 
+
+- `DatePicker`:
   - 处理多选情况下周和季度模式的标签删除异常的问题 @betavs ([#3664](https://github.com/Tencent/tdesign-react/pull/3664))
   - 修复多选模式下的 `placeholder` 没能正常消失 @RylanBot ([#3666](https://github.com/Tencent/tdesign-react/pull/3666))
 - `EnhancedTable`: @RylanBot
-  - 解决 `1.13.0` 版本中引入的修复，导致异步场景下 `data` 更新失败的问题 ([#3690](https://github.com/Tencent/tdesign-react/pull/3690)) 
+  - 解决 `1.13.0` 版本中引入的修复，导致异步场景下 `data` 更新失败的问题 ([#3690](https://github.com/Tencent/tdesign-react/pull/3690))
   - 修复使用 `tree` API 时 ，动态初始化 `columns` 时不存在 unique key ([#3669](https://github.com/Tencent/tdesign-react/pull/3669))
   - 修复叶子节点的判断条件过宽，导致 `className` 对应样式未正常渲染 ([#3681](https://github.com/Tencent/tdesign-react/pull/3681))
 - `SelectInput`: 修复在 `useOverlayInnerStyle` 中获取滚动条的时设置 `display` 导致的一些 bug @HaixingOoO ([#3677](https://github.com/Tencent/tdesign-react/pull/3677))
@@ -333,18 +397,23 @@ spline: explain
 ## 🌈 1.13.1 `2025-07-11`
 
 ### 🐞 Bug Fixes
+
 - `QRCode`: 修复 `canvas` 二维码 Safari 样式兼容问题 @lifeiFront ([common#2207](https://github.com/Tencent/tdesign-common/pull/2207))
 
-## 🌈 1.13.0 `2025-07-10` 
+## 🌈 1.13.0 `2025-07-10`
+
 ### 🚀 Features
+
 - `React19`: 新增兼容 React 19 使用的 adapter，在 React 19 中使用请参考使用文档的详细说明 @HaixingOoO @uyarn([#3640](https://github.com/Tencent/tdesign-react/pull/3640))
 - `QRCode`: 新增 `QRCode` 二维码组件 @lifeiFront @wonkzhang ([#3612](https://github.com/Tencent/tdesign-react/pull/3612))
 - `Alert`: 新增 `closeBtn` API，与其他组件保持一致，`close` 将在未来版本废弃，请尽快调整为 `closeBtn` 使用 ⚠️ @ngyyuusora ([#3625](https://github.com/Tencent/tdesign-react/pull/3625))
 - `Form`: 新增在重新打开 Form 时，重置表单内容的特性 @alisdonwang ([#3613](https://github.com/Tencent/tdesign-react/pull/3613))
 - `ImageViewer`: 支持在移动端使用时，通过双指进行缩放图片的功能 @RylanBot ([#3629](https://github.com/Tencent/tdesign-react/pull/3629))
 - `locale`: 支持内置多语言的英文版本的单复数场景正常展示 @YunYouJun ([#3639](https://github.com/Tencent/tdesign-react/pull/3639))
+
 ### 🐞 Bug Fixes
-- `ColorPicker`: 
+
+- `ColorPicker`:
   - 修复点击渐变点时，色板没有同步更新的问题 @RylanBot ([#3624](https://github.com/Tencent/tdesign-react/pull/3624))
   - 修复面板输入非法字符场景和多重置空场景下没有重置输入框内容的缺陷 @uyarn ([#3653](https://github.com/Tencent/tdesign-react/pull/3653))
 - `Dropdown`: 修复部分场景下拉菜单节点获取异常导致的错误问题 @uyarn ([#3657](https://github.com/Tencent/tdesign-react/pull/3657))
@@ -354,46 +423,52 @@ spline: explain
 - `Popup`: 修复 `1.11.2` 引入 popper.js 的 `arrow` 修饰符导致箭头位置偏移 @RylanBot ([#3652](https://github.com/Tencent/tdesign-react/pull/3652))
 - `Loading`: 修复在 iPad 微信上图标位置错误的问题 @Nero978([#3655](https://github.com/Tencent/tdesign-react/pull/3655))
 - `Menu`: 解决 `expandMutex` 存在嵌套子菜单时，容易失效的问题 @RylanBot ([#3621](https://github.com/Tencent/tdesign-react/pull/3621))
-- `Table`: 
+- `Table`:
   - 修复吸顶功能不随高度变化的问题 @huangchen1031 ([#3620](https://github.com/Tencent/tdesign-react/pull/3620))
   - 修复 `showHeader` 为 `false` 时，`columns` 动态变化报错的问题 @RylanBot ([#3637](https://github.com/Tencent/tdesign-react/pull/3637))
 - `EnhancedTable`: 修复 `tree.defaultExpandAll` 无法生效的问题 @RylanBot ([#3638](https://github.com/Tencent/tdesign-react/pull/3638))
 - `Textarea`: 修复超出最大高度后换行时抖动的问题 @RSS1102 ([#3631](https://github.com/Tencent/tdesign-react/pull/3631))
 
-## 🌈 1.12.3 `2025-06-13` 
+## 🌈 1.12.3 `2025-06-13`
+
 ### 🚀 Features
+
 - `Form`: 新增 `requiredMarkPosition` API，可定义必填符号的位置 @Wesley-0808 ([#3586](https://github.com/Tencent/tdesign-react/pull/3586))
 - `ConfigProvider`: 全局配置 `FormConfig` 新增 `requiredMaskPosition` 配置，用于全局配置必填符号的位置 @Wesley-0808 ([#3586](https://github.com/Tencent/tdesign-react/pull/3586))
+
 ### 🐞 Bug Fixes
+
 - `Drawer`: 修复 `cancelBtn` 和 `confirmBtn` 的类型缺失 `null` 声明的问题 @RSS1102 ([#3602](https://github.com/Tencent/tdesign-react/pull/3602))
 - `ImageViewer`: 修复显示错误图片在小窗口图片查看器的尺寸异常 @RylanBot([#3607](https://github.com/Tencent/tdesign-react/pull/3607))
 - `Menu`: `popupProps` 的 `delay` 属性在 `SubMenu` 中无法生效的问题 @RylanBot ([#3599](https://github.com/Tencent/tdesign-react/pull/3599))
 - `Menu`: 开启 `expandMutex` 后，如果存在二级 `SubMenu`，菜单无法展开 @RylanBot ([#3601](https://github.com/Tencent/tdesign-react/pull/3601))
-- `Select`:  修复 `checkAll` 设为 `disabled` 后依旧会触发全选的问题 @RylanBot ([#3563](https://github.com/Tencent/tdesign-react/pull/3563))
+- `Select`: 修复 `checkAll` 设为 `disabled` 后依旧会触发全选的问题 @RylanBot ([#3563](https://github.com/Tencent/tdesign-react/pull/3563))
 - `Table`: 优化关闭列配置弹窗时，修复选择列数据与所展示列数据不一致的问题 @RSS1102 ([#3608](https://github.com/Tencent/tdesign-react/pull/3608))
 - `TabPanel`: 修复通过 `style` 设置 `display` 属性无法正常生效的问题 @uyarn ([#3609](https://github.com/Tencent/tdesign-react/pull/3609))
-- `Tabs`:  修复开启懒加载后始终会先渲染第一个`TabPanel`的问题 @HaixingOoO ([#3614](https://github.com/Tencent/tdesign-react/pull/3614))
+- `Tabs`: 修复开启懒加载后始终会先渲染第一个`TabPanel`的问题 @HaixingOoO ([#3614](https://github.com/Tencent/tdesign-react/pull/3614))
 - `TreeSelect`: 修复 `label` API 无法正常使用的问题 @RylanBot ([#3603](https://github.com/Tencent/tdesign-react/pull/3603))
 
-## 🌈 1.12.2 `2025-05-30` 
+## 🌈 1.12.2 `2025-05-30`
+
 ### 🚀 Features
+
 - `Cascader`: 新增支持使用 `option` 方法自定义下拉选项内容的能力 @huangchen1031 ([#3565](https://github.com/Tencent/tdesign-react/pull/3565))
 - `MenuGroup`: 新增支持 `className` and `style` 的使用 @wang-ky ([#3568](https://github.com/Tencent/tdesign-react/pull/3568))
 - `InputNumber`: `decimalPlaces` 新增支持 `enableRound` 参数，用于控制是否启用四舍五入 @RylanBot ([#3564](https://github.com/Tencent/tdesign-react/pull/3564))
 - `TagInput`: 优化可拖拽时，鼠标光标显示为移动光标 @liweijie0812 ([#3552](https://github.com/Tencent/tdesign-react/pull/3552))
 
-
 ### 🐞 Bug Fixes
+
 - `Card`: 修复 `content` prop 不生效的问题 @RylanBot ([#3553](https://github.com/Tencent/tdesign-react/pull/3553))
-- `Cascader`: 
-     - 修复选项存在超长文字在大小尺寸下展示异常的问题 @Shabi-x([#3551](https://github.com/Tencent/tdesign-react/pull/3551))
-     - 修复初始化后，异步更新 `options` 时，`displayValue` 无变化的问题 @huangchen1031 ([#3549](https://github.com/Tencent/tdesign-react/pull/3549))
+- `Cascader`:
+  - 修复选项存在超长文字在大小尺寸下展示异常的问题 @Shabi-x([#3551](https://github.com/Tencent/tdesign-react/pull/3551))
+  - 修复初始化后，异步更新 `options` 时，`displayValue` 无变化的问题 @huangchen1031 ([#3549](https://github.com/Tencent/tdesign-react/pull/3549))
 - `DatePicker`: 修复 `onFocus` 事件触发时机问题 @l123wx ([#3578](https://github.com/Tencent/tdesign-react/pull/3578))
 - `Drawer`: 优化 `TNode` 重新渲染导致输入光标错误的问题 @betavs ([#3544](https://github.com/Tencent/tdesign-react/pull/3544))
--  `Form`:
-    - 修复在 `onValuesChange` 中通过 `setFields` 设置相同值继续触发 `onValuesChange` 导致 `re-render` 的问题 @HaixingOoO ([#3304](https://github.com/Tencent/tdesign-react/pull/3304))
-    - 修复 `FormList` 删除 `field` 后 `reset` 值初始化错误的问题 @l123wx ([#3557](https://github.com/Tencent/tdesign-react/pull/3557))
-    - 兼容 `1.11.7` 版本前单独使用 `FormItem` 的场景 @uyarn ([#3588](https://github.com/Tencent/tdesign-react/pull/3588))
+- `Form`:
+  - 修复在 `onValuesChange` 中通过 `setFields` 设置相同值继续触发 `onValuesChange` 导致 `re-render` 的问题 @HaixingOoO ([#3304](https://github.com/Tencent/tdesign-react/pull/3304))
+  - 修复 `FormList` 删除 `field` 后 `reset` 值初始化错误的问题 @l123wx ([#3557](https://github.com/Tencent/tdesign-react/pull/3557))
+  - 兼容 `1.11.7` 版本前单独使用 `FormItem` 的场景 @uyarn ([#3588](https://github.com/Tencent/tdesign-react/pull/3588))
 - `Guide`: 优化组件在屏幕大小变化时没有重新计算位置的问题 @HaixingOoO ([#3543](https://github.com/Tencent/tdesign-react/pull/3543))
 - `List`: 修复空子节点导致获取子节点 `props` 失败的问题 @RSS1102 ([#3570](https://github.com/Tencent/tdesign-react/pull/3570))
 - `Popconfirm`: 修复 `confirmBtn` 属性的 children 不生效的问题 @huangchen1031 ([#3556](https://github.com/Tencent/tdesign-react/pull/3556))
@@ -402,18 +477,19 @@ spline: explain
 - `TreeSelect`: 修复单点已选中的值时，会删除已选中的值的问题 @HaixingOoO ([#3573](https://github.com/Tencent/tdesign-react/pull/3573))
 
 ### 🚧 Others
+
 - `Dialog`: 优化组件的初始化渲染时间 @RylanBot ([#3561](https://github.com/Tencent/tdesign-react/pull/3561))
 
+## 🌈 1.12.1 `2025-05-07`
 
-
-## 🌈 1.12.1 `2025-05-07` 
 ### 🐞 Bug Fixes
--  修复 1.12.0 兼容 React 18 以下的问题 @uyarn ([#3545](https://github.com/Tencent/tdesign-react/pull/3545))
 
+- 修复 1.12.0 兼容 React 18 以下的问题 @uyarn ([#3545](https://github.com/Tencent/tdesign-react/pull/3545))
 
+## 🌈 1.12.0 `2025-04-28`
 
-## 🌈 1.12.0 `2025-04-28` 
 ### 🚀 Features
+
 - `React`: 全面升级相关依赖，兼容在 React19 中使用 @HaixingOoO ([#3438](https://github.com/Tencent/tdesign-react/pull/3438))
 - `ColorPicker`: @RylanBot ([#3503](https://github.com/Tencent/tdesign-react/pull/3503)) 使用渐变模式的业务请注意此变更 ⚠️
   - 自动根据「触发器 / 最近颜色 / 预设颜色」的色值进行切换单色和渐变模式
@@ -423,78 +499,99 @@ spline: explain
 - `Drawer`: 新增 `lazy` 属性，用于懒加载场景，`forceRender` 已声明废弃，未来版本将被移除 @RSS1102 ([#3527](https://github.com/Tencent/tdesign-react/pull/3527))
 - `Dialog`: 新增 `lazy` 属性，用于懒加载场景，`forceRender` 已声明废弃，未来版本将被移除 @RSS1102 ([#3515](https://github.com/Tencent/tdesign-react/pull/3515))
 
-
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: @RylanBot ([#3503](https://github.com/Tencent/tdesign-react/pull/3503))
   - 修复渐变点无法正常更新颜色和位置的问题
   - 修复开启透明通道时的返回值格式化异常
 
+## 🌈 1.11.8 `2025-04-28`
 
-## 🌈 1.11.8 `2025-04-28` 
 ### 🚀 Features
-- `ConfigProvider`:  支持全局上下文配置作用于 Message 相关插件 @lifeiFront ([#3513](https://github.com/Tencent/tdesign-react/pull/3513))
+
+- `ConfigProvider`: 支持全局上下文配置作用于 Message 相关插件 @lifeiFront ([#3513](https://github.com/Tencent/tdesign-react/pull/3513))
 - `Icon`: 新增 `logo-miniprogram` 小程序、`logo-cnb` 云原生构建、`seal` 印章、`quote`引号等图标 @taowensheng1997 @uyarn ([#3517](https://github.com/Tencent/tdesign-react/pull/3517))
 - `Upload`: `image-flow` 模式下支持进度及自定义错误文本 @ngyyuusora ([#3525](https://github.com/Tencent/tdesign-react/pull/3525))
 - `Select`: 多选通过面板移除选项新增 `onRemove` 回调 @QuentinHsu ([#3526](https://github.com/Tencent/tdesign-react/pull/3526))
+
 ### 🐞 Bug Fixes
+
 - `InputNumber`: 优化数字输入框的边界问题 @Sight-wcg([#3519](https://github.com/Tencent/tdesign-react/pull/3519))
 - `Select`:
-    - 修复 `1.11.2` 版本后光标异常及子组件方式回调函数中缺失完整 `option` 信息的问题 @HaixingOoO @uyarn ([#3520](https://github.com/Tencent/tdesign-react/pull/3520))  ([#3529](https://github.com/Tencent/tdesign-react/pull/3529))
-    - 优化多选移除标签相关事件修正为不同的 `trigger`,  不同触发场景分别调整为 `clear`、`remove-tag`和 `uncheck`，修正全选选项的 `trigger` 错误 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
-    - 修复单选情况下再次点击选中的选项会触发 `change` 事件的问题 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
-    - 修复多选情况下按下 `backspace` 无法触发 `change` 事件的问题 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - 修复 `1.11.2` 版本后光标异常及子组件方式回调函数中缺失完整 `option` 信息的问题 @HaixingOoO @uyarn ([#3520](https://github.com/Tencent/tdesign-react/pull/3520)) ([#3529](https://github.com/Tencent/tdesign-react/pull/3529))
+  - 优化多选移除标签相关事件修正为不同的 `trigger`, 不同触发场景分别调整为 `clear`、`remove-tag`和 `uncheck`，修正全选选项的 `trigger` 错误 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - 修复单选情况下再次点击选中的选项会触发 `change` 事件的问题 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
+  - 修复多选情况下按下 `backspace` 无法触发 `change` 事件的问题 @betavs ([#3388](https://github.com/Tencent/tdesign-react/pull/3388))
 
-## 🌈 1.11.7 `2025-04-18` 
+## 🌈 1.11.7 `2025-04-18`
+
 ### 🚀 Features
+
 - `ConfigProvider`: 新增 `isContextEffectPlugin` API，默认关闭，开启后全局配置会影响到 `Dialog`、`Loading`、`Drawer`、`Notification` 和 `Popup` 组件的函数式调用 @lifeiFront ([#3488](https://github.com/Tencent/tdesign-react/pull/3488)) ([#3504](https://github.com/Tencent/tdesign-react/pull/3504))
-- `Tree`: `checkProps`参数支持函数传入，支持不同节点设置不同checkProps @phalera ([#3501](https://github.com/Tencent/tdesign-react/pull/3501))
+- `Tree`: `checkProps`参数支持函数传入，支持不同节点设置不同 checkProps @phalera ([#3501](https://github.com/Tencent/tdesign-react/pull/3501))
 - `Cascader`：新增 `onClear` 事件回调 @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
 - `DatePicker`: 新增 `onClear` 事件回调 @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
 - `TimePicker`: 新增 `onClear` 事件回调 @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
-- `ColorPicker`: 
-    - 新增 `clearable` API @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
-    - 新增 `onClear` 事件回调 @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+- `ColorPicker`:
+  - 新增 `clearable` API @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+  - 新增 `onClear` 事件回调 @RylanBot ([#3509](https://github.com/Tencent/tdesign-react/pull/3509))
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: 确保外部组件主动关闭 Popup 的时候，能有对应的 `onVisibleChange` 回调 @RylanBot ([#3510](https://github.com/Tencent/tdesign-react/pull/3510))
 - `Drawer`: 新增 `DrawerPlugin`，支持函数式调用，具体使用参考示例 @Wesley-0808 ([#3381](https://github.com/Tencent/tdesign-react/pull/3381))
 - `InputNumber`: 修复组件未受 value 属性控制的问题 @RSS1102 ([#3499](https://github.com/Tencent/tdesign-react/pull/3499))
 - `ImageViewer`:
-     - 修复设置 `step` 存在精度展示异常的问题 @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
-     - 修复 `imageScale` 中参数必填的类型错误 @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
+  - 修复设置 `step` 存在精度展示异常的问题 @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
+  - 修复 `imageScale` 中参数必填的类型错误 @uyarn ([#3491](https://github.com/Tencent/tdesign-react/pull/3491))
 - `Slider`: 修复打开了输入框模式下，使用 `theme` 为 `col` 的输入框的场景下没有限制大小的问题 @RSS1102 ([#3500](https://github.com/Tencent/tdesign-react/pull/3500))
 - `Tabs`: 优化选项卡 `label` 过长时滑动按钮失效的问题 @wonkzhang ([common#2108](https://github.com/Tencent/tdesign-common/pull/2108))
 
-## 🌈 1.11.6 `2025-04-11` 
+## 🌈 1.11.6 `2025-04-11`
+
 ### 🚀 Features
+
 - `Breadcrumb`: 新增 `ellipsis`、`maxItems`、`itemsAfterCollapse`、`itemsBeforeCollapse` 相关 API，用于折叠选项的场景，具体使用参考示例 @moecasts ([#3487](https://github.com/Tencent/tdesign-react/pull/3487))
 
 ### 🐞 Bug Fixes
+
 - `RadioGroup`: 优化切换展示的高亮效果问题 @RylanBot ([#3446](https://github.com/Tencent/tdesign-react/pull/3446))
 - `Tag`: 修复 `style` 优先级低于 `color`，导致无法强制覆盖标签样式的场景 @uyarn ([#3492](https://github.com/Tencent/tdesign-react/pull/3492))
 - `ColorPicker`: 修复单色和渐变切换使用的效果异常问题 @RylanBot ([#3493](https://github.com/Tencent/tdesign-react/pull/3493))
 - `Table`: 修复可调整列宽表格右侧拖拽调整的异常问题 @uyarn ([#3496](https://github.com/Tencent/tdesign-react/pull/3496))
 - `Swiper`: 优化默认容器高度，避免 navigator 位置异常的问题 @uyarn ([#3490](https://github.com/Tencent/tdesign-react/pull/3490))
+
 ### 📝 Documentation
+
 - `Swiper`: 优化组件跳转沙箱演示缺失示例样式的问题 @uyarn ([#3490](https://github.com/Tencent/tdesign-react/pull/3490))
 
 ### 🚧 Others
--  `1.12.0` 版本将全面兼容 React 19 的使用，有 React 19相关使用场景需求，可升级 `1.12.0-alpha.3` 版本进行试用
 
-## 🌈 1.11.4 `2025-04-03` 
+- `1.12.0` 版本将全面兼容 React 19 的使用，有 React 19 相关使用场景需求，可升级 `1.12.0-alpha.3` 版本进行试用
+
+## 🌈 1.11.4 `2025-04-03`
+
 ### 🐞 Bug Fixes
+
 - `Select`: 修复 `options`为空时会导致报错引发白屏的问题 @2ue ([#3484](https://github.com/Tencent/tdesign-react/pull/3484))
 - `Tree`: 修复 icon 为 false 仍然触发点击和展开相关逻辑的问题 @uyarn ([#3485](https://github.com/Tencent/tdesign-react/pull/3485))
 
-## 🌈 1.11.3 `2025-04-01` 
+## 🌈 1.11.3 `2025-04-01`
+
 ### 🚀 Features
+
 - `ConfigProvider`: `Pagination` 新增 `Jumper` 配置，用于自定义跳转部分样式 @RylanBot ([#3421](https://github.com/Tencent/tdesign-react/pull/3421))
+
 ### 🐞 Bug Fixes
-- `Textarea`: 修復 `TextArea`在 `Dialog` 的 `autofocus` 的bug 和 `autosize` 不生效 @HaixingOoO ([#3471](https://github.com/Tencent/tdesign-react/pull/3471))
+
+- `Textarea`: 修復 `TextArea`在 `Dialog` 的 `autofocus` 的 bug 和 `autosize` 不生效 @HaixingOoO ([#3471](https://github.com/Tencent/tdesign-react/pull/3471))
 - `lib`: 修复 `1.11.2` 版本中 `lib` 产物冗余样式导致`next.js`中使用异常及版本号缺失的问题 @uyarn ([#3474](https://github.com/Tencent/tdesign-react/pull/3474))
 - `Table`: 修复受控方法下 `Pagination` 状态计算错误的问题 @huangchen1031 ([#3473](https://github.com/Tencent/tdesign-react/pull/3473))
 
-## 🌈 1.11.2 `2025-03-28` 
+## 🌈 1.11.2 `2025-03-28`
+
 ### 🚀 Features
+
 - `ImageViewer`: 新增 `onDownload` API，用于自定义预览图片下载的回调功能 @lifeiFront ([#3408](https://github.com/Tencent/tdesign-react/pull/3408))
 - `ConfigProvider`: `Input` 新增 `clearTrigger` 配置，用于全局模式在有值时显示关闭按钮的功能 @RylanBot ([#3412](https://github.com/Tencent/tdesign-react/pull/3412))
 - `Descriptions`: 新增 `tableLayout` 属性 @liweijie0812 ([#3434](https://github.com/Tencent/tdesign-react/pull/3434))
@@ -503,40 +600,51 @@ spline: explain
 - `Tabs`: 新增 `lazy` API，支持配置懒加载功能 @HaixingOoO ([#3426](https://github.com/Tencent/tdesign-react/pull/3426))
 
 ### 🐞 Bug Fixes
+
 - `ConfigProvider`: 修复全局配置二级配置影响非`Context`范围的问题 @uyarn ([#3441](https://github.com/Tencent/tdesign-react/pull/3441))
 - `Dialog`: 取消和确认按钮添加类名，方便定制需求 @RSS1102 ([#3417](https://github.com/Tencent/tdesign-react/pull/3417))
 - `Drawer`: 修复拖拽改变大小的时候获取宽度可能不正确的问题 @wonkzhang ([#3420](https://github.com/Tencent/tdesign-react/pull/3420))
-- `Guide`:  修复 `popupProps` 穿透属性 `overlayClassName` 无效  @RSS1102 ([#3433](https://github.com/Tencent/tdesign-react/pull/3433))
+- `Guide`: 修复 `popupProps` 穿透属性 `overlayClassName` 无效 @RSS1102 ([#3433](https://github.com/Tencent/tdesign-react/pull/3433))
 - `Popup`: 解决组件修饰符 `arrow` 属性设置不生效的问题 @wonkzhang ([#3437](https://github.com/Tencent/tdesign-react/pull/3437))
 - `Select`: 修复单选框在 `readonly` 模式下有光标和 `clear` 图标的问题 @wonkzhang ([#3436](https://github.com/Tencent/tdesign-react/pull/3436))
 - `Table`:
   - 修复开启虚拟滚动时，`fixedRows` 的渲染问题 @huangchen1031 ([#3427](https://github.com/Tencent/tdesign-react/pull/3427))
   - 修复可选中行表格在火狐浏览器中的样式异常问题 @uyarn ([common#2093](https://github.com/Tencent/tdesign-common/pull/2093))
 - `Tooltip`: 修复 `React 16` 下，`TooltipLite` 的 `mouse` 计算位置错误的问题 @moecasts ([#3465](https://github.com/Tencent/tdesign-react/pull/3465))
-- `Tree`:  修复部分场景下移除节点后组件报错的问题 @2ue ([#3463](https://github.com/Tencent/tdesign-react/pull/3463))
+- `Tree`: 修复部分场景下移除节点后组件报错的问题 @2ue ([#3463](https://github.com/Tencent/tdesign-react/pull/3463))
+
 ### 📝 Documentation
+
 - `Card`: 修复文档内容的文案错误问题 @betavs ([#3448](https://github.com/Tencent/tdesign-react/pull/3448))
 
+## 🌈 1.11.1 `2025-02-28`
 
-## 🌈 1.11.1 `2025-02-28` 
 ### 🚀 Features
-- `Layout`: 子组件 `Content` 新增  `content` API  @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
+
+- `Layout`: 子组件 `Content` 新增 `content` API @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
+
 ### 🐞 Bug Fixes
-- `reactRender`: fix `React19` `reactRender` error @HaixingOoO ([#3380](https://github.com/Tencent/tdesign-react/pull/3380))
-- `Table`: 修复虚拟滚动下的footer渲染问题 @huangchen1031 ([#3383](https://github.com/Tencent/tdesign-react/pull/3383))
-- `fix`: 修复`1.11.0` cjs 产物的异常 @uyarn ([#3392](https://github.com/Tencent/tdesign-react/pull/3392))
-### 📝 Documentation
-- `ConfigProvider`: 增加 `globalConfig` API 文档  @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
 
-## 🌈 1.11.0 `2025-02-20` 
+- `reactRender`: fix `React19` `reactRender` error @HaixingOoO ([#3380](https://github.com/Tencent/tdesign-react/pull/3380))
+- `Table`: 修复虚拟滚动下的 footer 渲染问题 @huangchen1031 ([#3383](https://github.com/Tencent/tdesign-react/pull/3383))
+- `fix`: 修复`1.11.0` cjs 产物的异常 @uyarn ([#3392](https://github.com/Tencent/tdesign-react/pull/3392))
+
+### 📝 Documentation
+
+- `ConfigProvider`: 增加 `globalConfig` API 文档 @liweijie0812 ([#3384](https://github.com/Tencent/tdesign-react/pull/3384))
+
+## 🌈 1.11.0 `2025-02-20`
+
 ### 🚀 Features
-- `Cascader`:  新增支持在打开菜单时，自动滚动到首个已选项所在节点的能力 @uyarn ([#3357](https://github.com/Tencent/tdesign-react/pull/3357))
+
+- `Cascader`: 新增支持在打开菜单时，自动滚动到首个已选项所在节点的能力 @uyarn ([#3357](https://github.com/Tencent/tdesign-react/pull/3357))
 - `DatePicker`: 调整组件禁用日期 `before` 和 `after` 参数的逻辑，调整为禁用 `before` 定义之前和 `after` 定义之后的日期选择，此前有使用相关 API 请注意此变更 ⚠️ @lifeiFront ([#3362](https://github.com/Tencent/tdesign-react/pull/3362))
 - `List`: 新增 `scroll` API，用于大数据量下支持开启虚拟滚动 @HaixingOoO ([#3363](https://github.com/Tencent/tdesign-react/pull/3363))
 - `Menu`: 菜单新增折叠收起的动画效果 @hd10180 ([#3342](https://github.com/Tencent/tdesign-react/pull/3342))
 - `TagInput`: 新增 `maxRows` API，用于设置最大展示行数 @Shabi-x ([#3293](https://github.com/Tencent/tdesign-react/pull/3293))
 
 ### 🐞 Bug Fixes
+
 - `Card`: 修复 React 19 中的告警问题 @HaixingOoO ([#3369](https://github.com/Tencent/tdesign-react/pull/3369))
 - `Cascader`: 修复多选动态加载使用异常的问题 @uyarn ([#3376](https://github.com/Tencent/tdesign-react/pull/3376))
 - `CheckboxGroup`: 修复 `onChange` 的 `context` 参数缺少 `option` 的问题 @HaixingOoO ([#3349](https://github.com/Tencent/tdesign-react/pull/3349))
@@ -548,18 +656,22 @@ spline: explain
 - `Textarea`: 修复使用 `autofocus` API 且 `value` 有值时，光标没有跟随内容末尾的问题 @HaixingOoO ([#3358](https://github.com/Tencent/tdesign-react/pull/3358))
 - `Transfer`: 修复 `TransferItem` 无效的问题 @HaixingOoO ([#3339](https://github.com/Tencent/tdesign-react/pull/3339))
 
-
 ### 🚧 Others
--  调整组件依赖 `lodash` 依赖为`lodash-es` @zhangpaopao0609  ([#3345](https://github.com/Tencent/tdesign-react/pull/3345))
 
-## 🌈 1.10.5 `2025-01-16` 
+- 调整组件依赖 `lodash` 依赖为`lodash-es` @zhangpaopao0609 ([#3345](https://github.com/Tencent/tdesign-react/pull/3345))
+
+## 🌈 1.10.5 `2025-01-16`
+
 ### 🚀 Features
+
 - `RadioGroup`: 新增 `theme` API，用于决定使用 options 时渲染的子组件样式 @HaixingOoO ([#3303](https://github.com/Tencent/tdesign-react/pull/3303))
 - `Upload`: 新增 `imageProps` API，用于在上传图片场景下透传 `Image` 组件的相关属性 @HaixingOoO ([#3317](https://github.com/Tencent/tdesign-react/pull/3317))
 - `AutoComplete`: 新增 `empty` API ，用于支持自定义空节点内容 @liweijie0812 ([#3319](https://github.com/Tencent/tdesign-react/pull/3319))
 - `Drawer`: `sizeDraggable`新增支持`SizeDragLimit`类型的功能实现 @huangchen1031 ([#3323](https://github.com/Tencent/tdesign-react/pull/3323))
 - `Icon`: 新增 `logo-alipay`、`logo-behance-filled`等图标，修改 `logo-wecom` 图标，移除不合理的 `logo-wecom-filled` 图标 @uyarn ([#3326](https://github.com/Tencent/tdesign-react/pull/3326))
+
 ### 🐞 Bug Fixes
+
 - `Select`: 修复 `onChange` 回调 `context` 中的全部选项的值没有包含选项本身全部内容的问题 @uyarn ([#3305](https://github.com/Tencent/tdesign-react/pull/3305))
 - `DateRangePicker`: 开始结束值同时存在的逻辑判断错误问题 @betavs ([#3301](https://github.com/Tencent/tdesign-react/pull/3301))
 - `Notification`: 修复使用 `attach` 属性配置导致渲染节点异常的问题 @centuryPark ([#3306](https://github.com/Tencent/tdesign-react/pull/3306))
@@ -568,15 +680,20 @@ spline: explain
 - `Statistic`: 修复 `decimalPlaces=0` 时数值动画期间精度错误的问题 @huangchen1031 ([#3327](https://github.com/Tencent/tdesign-react/pull/3327))
 - `ImageViewer`: 修复开启 `closeOnOverlay` 时，点击蒙层关闭存在闪烁情况的问题 @huangchen1031
 
+## 🌈 1.10.4 `2024-12-25`
 
-## 🌈 1.10.4 `2024-12-25` 
 ### 🚀 Features
+
 - `Tree`: 支持 `onScroll` API，用于处理滚动事件回调 @HaixingOoO ([#3295](https://github.com/Tencent/tdesign-react/pull/3295))
 - `TooltipLite`: `mouse` 模式下优化为完全跟随鼠标位置，更符合 API 描述 @moecasts ([#3267](https://github.com/Tencent/tdesign-react/pull/3267))
+
 ### 🐞 Bug Fixes
+
 - `Select`: 修复全选默认返回值错误的问题 @uyarn ([#3298](https://github.com/Tencent/tdesign-react/pull/3298))
 - `Upload`: 优化部分尺寸上传组件图片展示的样式问题 @huangchen1031 ([#3290](https://github.com/Tencent/tdesign-react/pull/3290))
+
 ### 📝 Documentation
+
 - `Stackblitz`: 调整`Stackblitz`示例的启动方式，并修复部分示例无法使用`stackblitz`或`codesandbox`运行的问题 @uyarn ([#3297](https://github.com/Tencent/tdesign-react/pull/3297))
 
 ## 🌈 1.10.2 `2024-12-19`
@@ -585,7 +702,7 @@ spline: explain
 
 - `Alert`: 在 `maxLine >= message` 数组长度的情况下，不再展示 `展开更多/收起` 的按钮 @miownag ([#3281](https://github.com/Tencent/tdesign-react/pull/3281))
 - `ConfigProvider`: `attach` 属性支持配置 `drawer` 组件，支持全局配置 `drawer` 的挂载位置 @HaixingOoO ([#3272](https://github.com/Tencent/tdesign-react/pull/3272))
-- `DatePicker`: 多选模式支持周选择和年选择的场景 @HaixingOoO @uyarn  ([#3264](https://github.com/Tencent/tdesign-react/pull/3264))
+- `DatePicker`: 多选模式支持周选择和年选择的场景 @HaixingOoO @uyarn ([#3264](https://github.com/Tencent/tdesign-react/pull/3264))
 - `Form`: 新增 `supportNumberKey` API，支持在`1.9.3`版本后不支持数字键值的场景使用，若不需要支持数字类型作为表单键值请关闭此 API @uyarn ([#3277](https://github.com/Tencent/tdesign-react/pull/3277))
 - `Radio`: 新增 `Radio` 及 `RadioGroup` 的 `reaonly` 属性的支持 @liweijie0812 ([#3280](https://github.com/Tencent/tdesign-react/pull/3280))
 - `Tree`: 实例新增 `setIndeterminate` 方法，支持手动设置半选的功能 @uyarn ([#3261](https://github.com/Tencent/tdesign-react/pull/3261))
@@ -594,6 +711,7 @@ spline: explain
 - `RangeInput`: 支持 `label` API @liweijie0812 ([#3276](https://github.com/Tencent/tdesign-react/pull/3276))
 
 ### 🐞 Bug Fixes
+
 - `DateRangePicker`: 修复在跨年的场景下的展示异常问题 @huangchen1031 ([#3275](https://github.com/Tencent/tdesign-react/pull/3275))
 - `Menu`: 优化菜单项点击事件的绑定问题避免边界触发异常的问题 @huangchen1031 ([#3241](https://github.com/Tencent/tdesign-react/pull/3241))
 - `ImageViewer`: 修复不受控时，`visable`改变时都会触发`onClose`的问题 @HaixingOoO ([#3244](https://github.com/Tencent/tdesign-react/pull/3244))
@@ -605,20 +723,23 @@ spline: explain
 - `TextArea`: 优化 `TextArea` 初始化时 `autosize` 下计算高度的逻辑 @HaixingOoO ([#3286](https://github.com/Tencent/tdesign-react/pull/3286))
 
 ### 🚧 Others
+
 - `Alert`: 优化测试用例代码类型和添加对于 `className`、`style` 的测试 @RSS1102 ([#3284](https://github.com/Tencent/tdesign-react/pull/3284))
 
+## 🌈 1.10.1 `2024-11-28`
 
-## 🌈 1.10.1 `2024-11-28` 
 ### 🚀 Features
+
 - `DatePicker`: 新增 `multiple` API，用于支持日期选择器多选功能，具体使用请参考示例 @HaixingOoO ([#3199](https://github.com/Tencent/tdesign-react/pull/3199))
 - `DatePicker`: 新增 `disableTime` API，用于更方便地设置禁用时间部分 @HaixingOoO ([#3226](https://github.com/Tencent/tdesign-react/pull/3226))
-- `Dialog`: 新增 `beforeClose` 和 `beforeOpen` API，用于在打开和关闭弹窗时执行更多回调操作 @Wesley-0808  ([#3203](https://github.com/Tencent/tdesign-react/pull/3203))
+- `Dialog`: 新增 `beforeClose` 和 `beforeOpen` API，用于在打开和关闭弹窗时执行更多回调操作 @Wesley-0808 ([#3203](https://github.com/Tencent/tdesign-react/pull/3203))
 - `Drawer`: 新增 `beforeClose` 和 `beforeOpen` API，用于在打开和关闭抽屉时执行更多回调操作 @Wesley-0808 ([#3203](https://github.com/Tencent/tdesign-react/pull/3203))
+
 ### 🐞 Bug Fixes
 
 - `ColorPicker`: 修复 `colorMode` 部分文案没有支持国际化的问题 @l123wx ([#3221](https://github.com/Tencent/tdesign-react/pull/3221))
 - `Form`: 修复 `setFieldsValue` 和 `setFields` 没有触发 `onValuesChange` 的问题 @uyarn ([#3232](https://github.com/Tencent/tdesign-react/pull/3232))
-- `Notification`: 修改 `NotificationPlugin` 的 `offset` 属性默认值，使其更符合常规习惯 @huangchen1031  ([#3231](https://github.com/Tencent/tdesign-react/pull/3231))
+- `Notification`: 修改 `NotificationPlugin` 的 `offset` 属性默认值，使其更符合常规习惯 @huangchen1031 ([#3231](https://github.com/Tencent/tdesign-react/pull/3231))
 - `Select`:
   - 修复 `collapsedItems` 参数 `collapsedSelectedItems` 的错误 @RSS1102 ([#3214](https://github.com/Tencent/tdesign-react/pull/3214))
   - 修复多选下拉框全选功能失效的问题 @huangchen1031 ([#3216](https://github.com/Tencent/tdesign-react/pull/3216))
@@ -626,13 +747,19 @@ spline: explain
   - 修复可过滤表格在处理 `null`类型的异常问题 @2ue ([#3197](https://github.com/Tencent/tdesign-react/pull/3197))
   - 修复单元格为数字 0 且开启省略时渲染异常的问题 @uyarn ([#3233](https://github.com/Tencent/tdesign-react/pull/3233))
 - `Tree`: 修复 `scrollTo` 方法滚动的异常行为 @uyarn ([#3235](https://github.com/Tencent/tdesign-react/pull/3235))
+
 ### 📝 Documentation
+
 - `Dialog`: 修复代码示例的错误 @RSS1102 ([#3229](https://github.com/Tencent/tdesign-react/pull/3229))
+
 ### 🚧 Others
+
 - `TextArea`: 优化 `TextArea` 事件类型 @HaixingOoO ([#3211](https://github.com/Tencent/tdesign-react/pull/3211))
 
-## 🌈 1.10.0 `2024-11-15` 
+## 🌈 1.10.0 `2024-11-15`
+
 ### 🚀 Features
+
 - `Select`: `collapsedItems` 方法的参数 `collapsedSelectedItems` 扩充为 `options`，使用 `collapsedItems` 请注意此变更 ⚠️ @RSS1102 ([#3185](https://github.com/Tencent/tdesign-react/pull/3185))
 - `Icon`: @uyarn ([#3194](https://github.com/Tencent/tdesign-react/pull/3194))
   - 图标库发布 `0.4.0` 版本，新增 907 个新图标
@@ -645,46 +772,58 @@ spline: explain
 - `Form`: 新增 `getValidateMessage` 实例方法 @moecasts ([#3180](https://github.com/Tencent/tdesign-react/pull/3180))
 
 ### 🐞 Bug Fixes
-- `TagInput`: 修复在 `readonly` 模式下仍可以通过Backspace按键删除已选项的缺陷 @RSS1102 ([#3172](https://github.com/Tencent/tdesign-react/pull/3172))
+
+- `TagInput`: 修复在 `readonly` 模式下仍可以通过 Backspace 按键删除已选项的缺陷 @RSS1102 ([#3172](https://github.com/Tencent/tdesign-react/pull/3172))
 - `Form`: 修复 `1.9.3` 版本，`FormItem` 在 `Form` 外设置了 `name` 属性有异常的问题 @l123wx ([#3183](https://github.com/Tencent/tdesign-react/pull/3183))
 - `Select`: 修复 valueType 为 object 时，点击全选按钮后 onChange 回调参数类型错误的问题 @l123wx ([#3193](https://github.com/Tencent/tdesign-react/pull/3193))
 - `Table`: 修复动态设置 `expandTreeNode` 没有正常展示子节点的问题 @uyarn ([#3202](https://github.com/Tencent/tdesign-react/pull/3202))
 - `Tree`: 修复动态切换 `expandAll` 的功能异常问题 @uyarn ([#3204](https://github.com/Tencent/tdesign-react/pull/3204))
 - `Drawer`: 修复无法自定义 `confirmBtn` 和 `closeBtn`内容的问题 @RSS1102 ([#3191](https://github.com/Tencent/tdesign-react/pull/3191))
+
 ### 📝 Documentation
+
 - `Icon`: 优化图标检索功能，支持中英文搜索图标 @uyarn ([#3194](https://github.com/Tencent/tdesign-react/pull/3194))
-- `Popup`: 新增 `popperOption` 使用示例 @HaixingOoO  ([#3200](https://github.com/Tencent/tdesign-react/pull/3200))
+- `Popup`: 新增 `popperOption` 使用示例 @HaixingOoO ([#3200](https://github.com/Tencent/tdesign-react/pull/3200))
 
+## 🌈 1.9.3 `2024-10-31`
 
-## 🌈 1.9.3 `2024-10-31` 
 ### 🐞 Bug Fixes
+
 - `Select`: 修复`valueDisplay`下的`onClose`回调问题 @uyarn ([#3154](https://github.com/Tencent/tdesign-react/pull/3154))
 - `Typography`: 修复 `Typography` 的`Ellipsis` 功能在中文下的问题 @HaixingOoO ([#3158](https://github.com/Tencent/tdesign-react/pull/3158))
 - `Form`: 修复 `FormList` 或 `FormItem` 数据中的 `getFieldsValue` 问题 @HaixingOoO ([#3149](https://github.com/Tencent/tdesign-react/pull/3149))
 - `Form`: 修复动态渲染表单无法使用 `setFieldsValue` 预设数据的问题 @l123wx ([#3145](https://github.com/Tencent/tdesign-react/pull/3145))
 - `lib`: 修复`1.9.2`升级依赖改动导致`lib`错误携带`style`导致在`next`下不可用的异常 @honkinglin ([#3165](https://github.com/Tencent/tdesign-react/pull/3165))
 
+## 🌈 1.9.2 `2024-10-17`
 
-
-## 🌈 1.9.2 `2024-10-17` 
 ### 🚀 Features
+
 - `TimePicker`: 新增 `autoSwap` API，支持 `1.9.0` 版本之后仍可以保持选定的左右侧时间大小顺序 @uyarn ([#3146](https://github.com/Tencent/tdesign-react/pull/3146))
+
 ### 🐞 Bug Fixes
+
 - `TabPanel`: 修复 `label` 改变时，激活的选项卡底部横线没更新 @HaixingOoO ([#3134](https://github.com/Tencent/tdesign-react/pull/3134))
 - `Drawer`: 修复打开页面抖动的问题 @RSS1102 ([#3141](https://github.com/Tencent/tdesign-react/pull/3141))
 - `Dialog`: 修复打开 `dialog` 时页面抖动的问题 @RSS1102 ([#3141](https://github.com/Tencent/tdesign-react/pull/3141))
 - `Select`: 修复使用 `OptionGroup `时无法自动定位到选中项问题 @moecasts ([#3139](https://github.com/Tencent/tdesign-react/pull/3139))
+
 ### 🚧 Others
+
 - `Loading`: 优化 live demo 展示效果 @uyarn ([#3144](https://github.com/Tencent/tdesign-react/pull/3144))
 - `DatePicker`: 移除文档中错误的 `value` 类型描述 @uyarn ([#3144](https://github.com/Tencent/tdesign-react/pull/3144))
 
-## 🌈 1.9.1 `2024-09-26` 
+## 🌈 1.9.1 `2024-09-26`
+
 ### 🚀 Features
+
 - `ImageViewer`: 优化图片预览旋转的重置效果 @sylsaint ([#3108](https://github.com/Tencent/tdesign-react/pull/3108))
 - `Table`: 可展开收起场景下新增 `t-table__row--expanded` 和 `t-table__row--folded` 用于区分展开和收起的行 @uyarn ([#3099](https://github.com/Tencent/tdesign-react/pull/3099))
 - `TimePicker`: 支持时间区间选择器自动调整左右区间 @uyarn ([#3117](https://github.com/Tencent/tdesign-react/pull/3117))
 - `Rate`: 新增 `clearable` API，用于清空评分 @HaixingOoO ([#3114](https://github.com/Tencent/tdesign-react/pull/3114))
+
 ### 🐞 Bug Fixes
+
 - `Dropdown`: 修复设置 `panelTopContent` 后子菜单 `top` 计算错误的问题 @moecasts ([#3106](https://github.com/Tencent/tdesign-react/pull/3106))
 - `TreeSelect`: 修改多选状态下默认点击父节点选项的行为为选中，如果需要点击展开，请配置 `treeProps.expandOnClickNode` @HaixingOoO ([#3111](https://github.com/Tencent/tdesign-react/pull/3111))
 - `Menu`: 修复二级菜单展开收起状态没有关联右侧箭头变化的问题 @uyarn ([#3110](https://github.com/Tencent/tdesign-react/pull/3110))
@@ -693,11 +832,13 @@ spline: explain
 - `ColorPicker`:
   - 修复部分场景下子组件存在重复渲染的异常问题 @uyarn ([#3118](https://github.com/Tencent/tdesign-react/pull/3118))
   - 修复渐变模式下，明度滑块和渐变滑块颜色不联动的问题 @huangchen1031 ([#3109](https://github.com/Tencent/tdesign-react/pull/3109))
-### 🚧 Others
-- `Site`: 站点切换语言时组件跟随切换语言 @RSS1102 ([#3100](https://github.com/Tencent/tdesign-react/pull/3100))
-- `Form`: 新增自定义表单控件的文档说明和示例 @miownag  ([#3112](https://github.com/Tencent/tdesign-react/pull/3112))
 
-## 🌈 1.9.0 `2024-09-12` 
+### 🚧 Others
+
+- `Site`: 站点切换语言时组件跟随切换语言 @RSS1102 ([#3100](https://github.com/Tencent/tdesign-react/pull/3100))
+- `Form`: 新增自定义表单控件的文档说明和示例 @miownag ([#3112](https://github.com/Tencent/tdesign-react/pull/3112))
+
+## 🌈 1.9.0 `2024-09-12`
 
 ### 🚀 Features
 
@@ -721,19 +862,23 @@ spline: explain
 - `Statistic`: 修复 `classname` 和 `style` 未透传功能异常的问题 @liweijie0812 ([#3089](https://github.com/Tencent/tdesign-react/pull/3089))
 - `TimePicker`: 修复 `format` 仅支持 HH:mm:ss 格式的问题 @liweijie0812 ([#3066](https://github.com/Tencent/tdesign-react/pull/3066))
 
+## 🌈 1.8.1 `2024-08-23`
 
-## 🌈 1.8.1 `2024-08-23` 
 ### 🐞 Bug Fixes
+
 - `Select`: 修复自定义 `content` 时的渲染的问题 @uyarn ([#3058](https://github.com/Tencent/tdesign-react/pull/3058))
 - `Rate`: 修复 `1.8.0` 版本中评分描述不显示的问题 @liweijie0812 ([#3060](https://github.com/Tencent/tdesign-react/pull/3060))
 - `Popup`: 修复 `panel` 为 null 场景下的部分事件回调缺失和错误的问题 @uyarn ([#3061](https://github.com/Tencent/tdesign-react/pull/3061))
 
-## 🌈 1.8.0 `2024-08-22` 
+## 🌈 1.8.0 `2024-08-22`
+
 ### 🚀 Features
+
 - `Empty`: 新增 `Empty` 空状态组件 @ZWkang @HaixingOoO @double-deng ([#2817](https://github.com/Tencent/tdesign-react/pull/2817))
 - `ConfigProvider`: 支持 `colonText` 属性配置 `Descriptions`、`Form` 组件的 `colon` 属性 @liweijie0812 ([#3055](https://github.com/Tencent/tdesign-react/pull/3055))
 
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: 修复 `slider` 部分在鼠标移入移出的缺陷 @Jippp ([#3042](https://github.com/Tencent/tdesign-react/pull/3042))
 - `useVirtualScroll`: 修改 `visibleData` 计算方式，解决可视区域过高时，滚动后底部留白的问题 @huangchen1031 ([#2999](https://github.com/Tencent/tdesign-react/pull/2999))
 - `Table`: 修复拖拽排序时，祖先节点内的顺序错误的问题 @uyarn ([#3046](https://github.com/Tencent/tdesign-react/pull/3046))
@@ -741,100 +886,124 @@ spline: explain
 - `Popup`: 修复某些场景下，隐藏时定位会闪烁的问题 @HaixingOoO ([#3052](https://github.com/Tencent/tdesign-react/pull/3052))
 
 ### 🚧 Others
+
 - `Popup`: 修复官网`Popup`的位置展示问题 @HaixingOoO ([#3048](https://github.com/Tencent/tdesign-react/pull/3048))
 - `DatePicker`: 修复 presets 示例代码错误的问题 @uyarn ([#3050](https://github.com/Tencent/tdesign-react/pull/3050))
 
-## 🌈 1.7.9 `2024-08-07` 
+## 🌈 1.7.9 `2024-08-07`
+
 ### 🐞 Bug Fixes
-- `Tree`:  修复`1.7.8`版本更新导致的展开收起功能的缺陷 @HaixingOoO ([#3039](https://github.com/Tencent/tdesign-react/pull/3039))
 
+- `Tree`: 修复`1.7.8`版本更新导致的展开收起功能的缺陷 @HaixingOoO ([#3039](https://github.com/Tencent/tdesign-react/pull/3039))
 
-## 🌈 1.7.8 `2024-08-01` 
+## 🌈 1.7.8 `2024-08-01`
+
 ### 🚀 Features
-- `ConfigProvider`: 新增 `attach` API， 支持全局配置attach或全局配置部分组件的attach @HaixingOoO ([#3001](https://github.com/Tencent/tdesign-react/pull/3001))
+
+- `ConfigProvider`: 新增 `attach` API， 支持全局配置 attach 或全局配置部分组件的 attach @HaixingOoO ([#3001](https://github.com/Tencent/tdesign-react/pull/3001))
 - `DatePicker`: 新增 `needConfirm` API，支持日期时间选择器不需要点击确认按钮保存选择时间 @HaixingOoO ([#3011](https://github.com/Tencent/tdesign-react/pull/3011))
 - `DateRangePicker` 支持 `borderless` 模式 @liweijie0812 ([#3015](https://github.com/Tencent/tdesign-react/pull/3015))
 - `RangeInput`: 支持 `borderless` 模式 @liweijie0812 ([#3015](https://github.com/Tencent/tdesign-react/pull/3015))
 - `TimeRangePicker`: 支持 `borderless` 模式 @liweijie0812 ([#3015](https://github.com/Tencent/tdesign-react/pull/3015))
 - `Descriptions`: layout 类型定义调整为字符串多类型 @liweijie0812 ([#3021](https://github.com/Tencent/tdesign-react/pull/3021))
 - `Rate`: 评分组件支持国际化配置 @uyarn ([#3023](https://github.com/Tencent/tdesign-react/pull/3023))
+
 ### 🐞 Bug Fixes
+
 - `Upload`: 修复部分图标不支持全局替换的问题 @uyarn ([#3009](https://github.com/Tencent/tdesign-react/pull/3009))
 - `Select`: 修复 `Select` 的 `label` 和 `prefixIcon` 的多选状态下的显示问题 @HaixingOoO ([#3019](https://github.com/Tencent/tdesign-react/pull/3019))
 - `Tree`: 修复部分场景下首个子节点设置 `checked` 后导致整个树初始化状态异常的问题 @uyarn ([#3023](https://github.com/Tencent/tdesign-react/pull/3023))
 - `DropdownItem`: 修复禁用状态影响组件本身响应行为的缺陷 @uyarn ([#3024](https://github.com/Tencent/tdesign-react/pull/3024))
 - `TagInput`: `onDragSort` 中使用 `useRef` 导致的上下文错误 @Heising ([#3003](https://github.com/Tencent/tdesign-react/pull/3003))
+
 ### 🚧 Others
+
 - `Dialog`: 修复位置示例错误问题 @novlan1 ([#3005](https://github.com/Tencent/tdesign-react/pull/3005))
 - `RangeInput`: 增加`liveDemo` @liweijie0812 ([#3015](https://github.com/Tencent/tdesign-react/pull/3015))
 
-## 🌈 1.7.7 `2024-07-18` 
+## 🌈 1.7.7 `2024-07-18`
+
 ### 🚀 Features
+
 - `Icon`: 新增有序列表图标 `list-numbered`，优化`lock-off`的绘制路径 @DOUBLE-DENG ([icon#9f4acfd](https://github.com/Tencent/tdesign-icons/commit/9f4acfdda58f84f9bca71a22f033e27127dd26db))
 - `BreadcrumbItem`: 增加 `tooltipProps` 扩展，方便定制内置的 `tooltip` 的相关属性 @carolin913 ([#2990](https://github.com/Tencent/tdesign-react/pull/2990))
 - `ImageViewer`: 新增 `attach` API，支持自定义挂载节点 @HaixingOoO ([#2995](https://github.com/Tencent/tdesign-react/pull/2995))
 - `Drawer`: 新增 `onSizeDragEnd` API，用于需要拖拽缩放回调的场景 @NWYLZW ([#2975](https://github.com/Tencent/tdesign-react/pull/2975))
 
 ### 🐞 Bug Fixes
+
 - `Icon`: 修复图标`chart-column`的命名错误问题 @uyarn ([#2979](https://github.com/Tencent/tdesign-react/pull/2979))
 - `Input`: 修复禁用状态下仍可以切换明文密文的问题 @uyarn ([#2991](https://github.com/Tencent/tdesign-react/pull/2991))
 - `Table`: @uyarn
-    - 修复只存在一列可拖拽的表格缩小时的样式异常问题 ([#2994](https://github.com/Tencent/tdesign-react/pull/2994))
-    - 修复部分场景下向前缩放时的报错的问题([#2994](https://github.com/Tencent/tdesign-react/pull/2994))
-    - 修复空数据下展示内容没有居中展示的问题 ([#2996](https://github.com/Tencent/tdesign-react/pull/2996))
+  - 修复只存在一列可拖拽的表格缩小时的样式异常问题 ([#2994](https://github.com/Tencent/tdesign-react/pull/2994))
+  - 修复部分场景下向前缩放时的报错的问题([#2994](https://github.com/Tencent/tdesign-react/pull/2994))
+  - 修复空数据下展示内容没有居中展示的问题 ([#2996](https://github.com/Tencent/tdesign-react/pull/2996))
+
 ### 🚧 Others
-- docs(Checkbox): 优化`Checkbox`文档内容 @Heising  ([common#1835](https://github.com/Tencent/tdesign-common/pull/1835))
 
+- docs(Checkbox): 优化`Checkbox`文档内容 @Heising ([common#1835](https://github.com/Tencent/tdesign-common/pull/1835))
 
-## 🌈 1.7.6 `2024-06-27` 
+## 🌈 1.7.6 `2024-06-27`
+
 ### 🚀 Features
+
 - `Tabs`: 支持通过滚轮或者触摸板进行滚动操作，新增 `scrollPosition` API，支持配置选中滑块滚动最终停留位置 @oljc ([#2954](https://github.com/Tencent/tdesign-react/pull/2954))
 - `ImageViewer`: 新增 `isSvg` 属性，支持原生 `SVG` 预览显示，用于对 `SVG` 进行操作的场景 @HaixingOoO ([#2958](https://github.com/Tencent/tdesign-react/pull/2958))
 - `Input`: 新增 `spellCheck` API @NWYLZW ([#2941](https://github.com/Tencent/tdesign-react/pull/2941))
 
 ### 🐞 Bug Fixes
+
 - `DatePicker`: 修复单独使用 `DateRangePickerPanel` 面板头部点击逻辑与 `DateRangePicker` 不一致的问题 @uyarn ([#2944](https://github.com/Tencent/tdesign-react/pull/2944))
 - `Form`: 修复嵌套 `FormList` 场景下使用 `shouldUpdate` 导致循环渲染的问题 @moecasts ([#2948](https://github.com/Tencent/tdesign-react/pull/2948))
 - `Tabs`: 修复 `1.7.4` 版本后，`Tabs` 的 className 影响 `TabItem` 的问题 @uyarn ([#2946](https://github.com/Tencent/tdesign-react/pull/2946))
-- `Table`: 
+- `Table`:
   - 修复 `usePagination` 中 `pagination` 动态变化的功能问题 @HaixingOoO ([#2960](https://github.com/Tencent/tdesign-react/pull/2960))
   - 修复鼠标右键表格也可以触发列宽拖拽的问题 @HaixingOoO ([#2961](https://github.com/Tencent/tdesign-react/pull/2961))
   - 修复只存在一列可被 resize 的使用场景下，拖拽功能异常的问题 @uyarn ([#2959](https://github.com/Tencent/tdesign-react/pull/2959))
 
 ### 🚧 Others
-- 站点全量新增 TypeScript 示例代码 @uyarn @HaixingOoO @ZWkang  ([#2871](https://github.com/Tencent/tdesign-react/pull/2871))
 
+- 站点全量新增 TypeScript 示例代码 @uyarn @HaixingOoO @ZWkang ([#2871](https://github.com/Tencent/tdesign-react/pull/2871))
 
-## 🌈 1.7.5 `2024-05-31` 
+## 🌈 1.7.5 `2024-05-31`
+
 ### 🐞 Bug Fixes
+
 - `DatePicker`: 修复点击`jump`按钮的逻辑没有同步下拉选择的改动的缺陷 @uyarn ([#2934](https://github.com/Tencent/tdesign-react/pull/2934))
 
-## 🌈 1.7.4 `2024-05-30` 
+## 🌈 1.7.4 `2024-05-30`
+
 ### 🚀 Features
+
 - `DatePicker`: 优化日期区间选择器头部区间的变化逻辑，选择后左侧区间大于右侧区间，则默认调整为左侧区间始终比右侧区间小 1 @uyarn ([#2932](https://github.com/Tencent/tdesign-react/pull/2932))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: 修复 `Cascader` 搜索时 `checkStrictly` 模式父节点不显示 @HaixingOoO ([#2914](https://github.com/Tencent/tdesign-react/pull/2914))
 - `Select`: 修复半选状态的全选选项展示样式问题 @uyarn ([#2915](https://github.com/Tencent/tdesign-react/pull/2915))
 - `Menu`: 修复 `HeadMenu` 下 `MenuItem` 类名透传失效的问题 @uyarn ([#2917](https://github.com/Tencent/tdesign-react/pull/2917))
 - `TabPanel`: 修复类名透传失效的问题 @uyarn ([#2917](https://github.com/Tencent/tdesign-react/pull/2917))
 - `Breadcrumb`: 修复暗色模式下的分隔符不可见问题 @NWYLZW ([#2920](https://github.com/Tencent/tdesign-react/pull/2920))
 - `Checkbox`:
-   - 修复无法渲染为值为 0 的选项 @NWYLZW ([#2925](https://github.com/Tencent/tdesign-react/pull/2925))
-   - 修复受控状态无法被 onChange 回调中正确消费的问题 @NWYLZW ([#2926](https://github.com/Tencent/tdesign-react/pull/2926))
+  - 修复无法渲染为值为 0 的选项 @NWYLZW ([#2925](https://github.com/Tencent/tdesign-react/pull/2925))
+  - 修复受控状态无法被 onChange 回调中正确消费的问题 @NWYLZW ([#2926](https://github.com/Tencent/tdesign-react/pull/2926))
 - `SelectInput`: 修复 `interface.d.ts` 文件缺少 `size` 类型的问题 @HaixingOoO ([#2930](https://github.com/Tencent/tdesign-react/pull/2930))
 - `DatePicker`: 修复单独使用面板没有兼容无 `onMonthChange` 回调的场景的问题 @uyarn ([#2932](https://github.com/Tencent/tdesign-react/pull/2932))
 - `DateRangePickerPanel`: 修复在下拉框中选择年/月时选择出现日期改变错乱的问题 @liyucang-git ([#2922](https://github.com/Tencent/tdesign-react/pull/2922))
 - `InputNumber`: 修复 `allowInputOverLimit=false` 大小值判断时，value 为 undefined 时，会出现显示 Infinity 的问题 @HaixingOoO ([common#1802](https://github.com/Tencent/tdesign-common/pull/1802))
 
-## 🌈 1.7.3 `2024-05-18` 
+## 🌈 1.7.3 `2024-05-18`
+
 ### 🐞 Bug Fixes
+
 - `Menu`: 修复二级及以下 `Submenu` 没有处理 classname 的缺陷 @uyarn ([#2911](https://github.com/Tencent/tdesign-react/pull/2911))
-- `Upload`: 修复手动上传的bug @HaixingOoO ([#2912](https://github.com/Tencent/tdesign-react/pull/2912))
-- `Avatar`: 修复配合Popup使用浮层不展示的异常 @uyarn
+- `Upload`: 修复手动上传的 bug @HaixingOoO ([#2912](https://github.com/Tencent/tdesign-react/pull/2912))
+- `Avatar`: 修复配合 Popup 使用浮层不展示的异常 @uyarn
 
 ## 🌈 1.7.1 `2024-05-16`
 
 ### 🚀 Features
+
 - `Avatar`: 新增 `Click`、`Hover` 和 `Contextmenu` 等鼠标事件，支持对头像操作的场景使用 @NWYLZW ([#2906](https://github.com/Tencent/tdesign-react/pull/2906))
 - `Dialog`: 支持 `setConfirmLoading` 的使用 @ZWkang ([#2883](https://github.com/Tencent/tdesign-react/pull/2883))
 - `SelectInput`: 支持 `size` 属性 @HaixingOoO ([#2894](https://github.com/Tencent/tdesign-react/pull/2894))
@@ -846,37 +1015,45 @@ spline: explain
 - `TagInput`: 新增 `borderless` API，支持无边框模式 @uyarn ([#2878](https://github.com/Tencent/tdesign-react/pull/2878))
 - `TimePicker`: 新增 `borderless` API，支持无边框模式 @uyarn ([#2878](https://github.com/Tencent/tdesign-react/pull/2878))
 - `Scroll`: 调整 `1.6.0` 后针对 Chrome 滚动条样式的兼容方法，不依赖`autoprefixer`的版本 @loopzhou ([#2890](https://github.com/Tencent/tdesign-react/pull/2890))
+
 ### 🐞 Bug Fixes
+
 - `ColorPicker`: 修复切换预览颜色时，通道按钮位置不变的问题 @fennghuang ([#2880](https://github.com/Tencent/tdesign-react/pull/2880))
 - `Form`: 修复由于 `FormItem`的修改，没有触发监听`FormList`的`useWatch`的问题 @HaixingOoO ([#2904](https://github.com/Tencent/tdesign-react/pull/2904))
-- `Menu`: @uyarn 
+- `Menu`: @uyarn
   - 修复使用`dist`样式因为样式优先级问题导致子菜单位置偏移的问题 ([#2890](https://github.com/Tencent/tdesign-react/pull/2890))
   - 提升 `t-popup__menu` 的样式优先级，解决 dist 内样式优先级一致导致样式异常的问题 ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
 - `Pagination`: 修复当前页输入小数后没有自动调整的问题 @uyarn ([#2886](https://github.com/Tencent/tdesign-react/pull/2886))
-- `Select`: 
-   - 修复 `creatable` 功能异常问题 @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
-   - 修复 `reserveKeyword` 配合 `Option Children` 用法的异常问题 @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
-   - 优化已选样式覆盖已禁用样式的问题 @fython ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
+- `Select`:
+  - 修复 `creatable` 功能异常问题 @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
+  - 修复 `reserveKeyword` 配合 `Option Children` 用法的异常问题 @uyarn ([#2903](https://github.com/Tencent/tdesign-react/pull/2903))
+  - 优化已选样式覆盖已禁用样式的问题 @fython ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
 - `Slider`: 修复 `sliderRef.current` 可能为空的问题 @ZWkang ([#2868](https://github.com/Tencent/tdesign-react/pull/2868))
-- `Table`: 
+- `Table`:
   - 修复卸载表格时数据为空导致报错的异常 @duxphp ([#2900](https://github.com/Tencent/tdesign-react/pull/2900))
   - 修复 `1.5.0` 版本后部分场景下使用固定列导致异常的问题 @uyarn ([#2889](https://github.com/Tencent/tdesign-react/pull/2889))
 - `TagInput`:
   - 修复没有透传 `tagProps` 到折叠选项的问题 @uyarn ([#2869](https://github.com/Tencent/tdesign-react/pull/2869))
   - 扩展 `collapsedItems` 的删除功能 @HaixingOoO ([#2881](https://github.com/Tencent/tdesign-react/pull/2881))
 - `TreeSelect`: 修复需要通过 `treeProps` 设置 `keys` 属性才生效的问题 @ZWkang ([#2896](https://github.com/Tencent/tdesign-react/pull/2896))
-- `Upload`: 
+- `Upload`:
   - 修复手动修改上传进度的 bug @HaixingOoO ([#2901](https://github.com/Tencent/tdesign-react/pull/2901))
   - 修复图片上传错误类型下的样式异常的问题 @uyarn ([#2905](https://github.com/Tencent/tdesign-react/pull/2905))
+
 ### 🚧 Others
+
 - `TagInput`: 补充 `Size` 属性的相关文档 @HaixingOoO ([#2894](https://github.com/Tencent/tdesign-react/pull/2894))
 - `Typography`: 删除多余的 `defaultProps` @HaixingOoO ([#2866](https://github.com/Tencent/tdesign-react/pull/2866))
 - `Upload`: 修复文档中关于 OPTIONS 方法的说明 @Summer-Shen ([#2865](https://github.com/Tencent/tdesign-react/pull/2865))
-  
-## 🌈 1.7.0 `2024-04-25` 
+
+## 🌈 1.7.0 `2024-04-25`
+
 ### 🚀 Features
+
 - `Typography`: 新增 `Typography` 排版组件 @insekkei ([#2821](https://github.com/Tencent/tdesign-react/pull/2821))
+
 ### 🐞 Bug Fixes
+
 - `Table`: 在 `effect` 异步里执行获取数据时和更新数据，可能会导致一些 bug @HaixingOoO ([#2848](https://github.com/Tencent/tdesign-react/pull/2848))
 - `DatePicker`: 修复日期选择器中月份选择回跳初始状态的异常 @uyarn ([#2854](https://github.com/Tencent/tdesign-react/pull/2854))
 - `Form`: `useWatch` 在一定情况下，name 的不同会导致视图问题的缺陷 @HaixingOoO ([#2853](https://github.com/Tencent/tdesign-react/pull/2853))
@@ -884,109 +1061,141 @@ spline: explain
 - `Dropdown`: 修复选项长度为空仍展示浮层的问题 @uyarn ([#2860](https://github.com/Tencent/tdesign-react/pull/2860))
 - `Dropdown`: 优化 `Dropdown` 的 `children` 透传 `disabled` @HaixingOoO ([#2862](https://github.com/Tencent/tdesign-react/pull/2862))
 - `SelectInput`: 修复非受控属性 `defaultPopupVisible` 不生效的问题 @uyarn ([#2861](https://github.com/Tencent/tdesign-react/pull/2861))
-- `Style`: 修复部分节点前缀无法统一替换的缺陷 @ZWkang  @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
+- `Style`: 修复部分节点前缀无法统一替换的缺陷 @ZWkang @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
 - `Upload`: 修复 `method` 枚举值 `options` 错误的问题 @summer-shen @uyarn ([#2863](https://github.com/Tencent/tdesign-react/pull/2863))
 
-## 🌈 1.6.0 `2024-04-11` 
+## 🌈 1.6.0 `2024-04-11`
+
 ### 🚀 Features
+
 - `Portal`: `Portal` 新增懒加载 `forceRender`，默认为 `lazy` 模式，优化性能，兼容 `SSR` 渲染，对 `Dialog` 和 `Drawer` 组件可能存在破坏性影响 ⚠️ @HaixingOoO ([#2826](https://github.com/Tencent/tdesign-react/pull/2826))
+
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: 修复 `imageReferrerpolicy` 没有对顶部缩略图生效的问题 @uyarn ([#2815](https://github.com/Tencent/tdesign-react/pull/2815))
 - `Descriptions`: 修复 `props` 缺少 `className` 和 `style` 属性的问题 @HaixingOoO ([#2818](https://github.com/Tencent/tdesign-react/pull/2818))
 - `Layout`: 修复 `Layout` 添加 `Aside` 页面布局会跳动的问题 @HaixingOoO ([#2824](https://github.com/Tencent/tdesign-react/pull/2824))
 - `Input`: 修复在 `React16` 版本下阻止冒泡失败的问题 @HaixingOoO ([#2833](https://github.com/Tencent/tdesign-react/pull/2833))
-- `DatePicker`: 修复 `1.5.3` 版本之后处理Date类型和周选择器的异常 @uyarn ([#2841](https://github.com/Tencent/tdesign-react/pull/2841))
-- `Guide`:  
-     - 优化 `SSR` 下的使用问题 @HaixingOoO ([#2842](https://github.com/Tencent/tdesign-react/pull/2842))
-     - 修复 `SSR` 场景下组件初始化渲染位置异常的问题 @uyarn ([#2832](https://github.com/Tencent/tdesign-react/pull/2832))
+- `DatePicker`: 修复 `1.5.3` 版本之后处理 Date 类型和周选择器的异常 @uyarn ([#2841](https://github.com/Tencent/tdesign-react/pull/2841))
+- `Guide`:
+  - 优化 `SSR` 下的使用问题 @HaixingOoO ([#2842](https://github.com/Tencent/tdesign-react/pull/2842))
+  - 修复 `SSR` 场景下组件初始化渲染位置异常的问题 @uyarn ([#2832](https://github.com/Tencent/tdesign-react/pull/2832))
 - `Scroll`: 修复由于 `Chrome 121` 版本支持 scroll width 之后导致 `Table`、`Select` 及部分出现滚动条组件的样式异常问题 @loopzhou ([common#1765](https://github.com/Tencent/tdesign-vue/pull/1765)) @uyarn ([#2843](https://github.com/Tencent/tdesign-react/pull/2843))
 - `Locale`: 优化 `DatePicker` 部分模式的语言包 @uyarn ([#2843](https://github.com/Tencent/tdesign-react/pull/2843))
 - `Tree`: 修复初始化后 `draggable` 属性丢失响应式的问题 @Liao-js ([#2838](https://github.com/Tencent/tdesign-react/pull/2838))
 - `Style`: 支持通过 `less` 总入口打包样式的需求 @NWYLZW @uyarn ([common#1757](https://github.com/Tencent/tdesign-common/pull/1757)) ([common#1766](https://github.com/Tencent/tdesign-common/pull/1766))
 
+## 🌈 1.5.5 `2024-03-28`
 
-## 🌈 1.5.5 `2024-03-28` 
 ### 🐞 Bug Fixes
+
 - `ImageViewer`: 修复 `imageReferrerpolicy` 没有对顶部缩略图生效的问题 @uyarn ([#2815](https://github.com/Tencent/tdesign-react/pull/2815))
 
-## 🌈 1.5.4 `2024-03-28` 
+## 🌈 1.5.4 `2024-03-28`
+
 ### 🚀 Features
+
 - `ImageViewer`: 新增`imageReferrerpolicy` API，支持配合 Image 组件的需要配置 Referrerpolicy 的场景 @uyarn ([#2813](https://github.com/Tencent/tdesign-react/pull/2813))
+
 ### 🐞 Bug Fixes
+
 - `Select`: 修复 `onRemove` 事件没有正常触发的问题 @Ali-ovo ([#2802](https://github.com/Tencent/tdesign-react/pull/2802))
 - `Skeleton`: 修复`children`为必须的类型问题 @uyarn ([#2805](https://github.com/Tencent/tdesign-react/pull/2805))
 - `Tabs`: 提供 `action` 区域默认样式 @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
-- `Locale`: 修复`image`和`imageViewer` 英语语言包异常的问题 @uyarn  @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
+- `Locale`: 修复`image`和`imageViewer` 英语语言包异常的问题 @uyarn @HaixingOoO ([#2808](https://github.com/Tencent/tdesign-react/pull/2808))
 - `Image`: `referrerpolicy` 参数被错误传递到外层 `div` 上，实际传递目标为原生 `image` 标签 @NWYLZW ([#2811](https://github.com/Tencent/tdesign-react/pull/2811))
 
-## 🌈 1.5.3 `2024-03-14` 
+## 🌈 1.5.3 `2024-03-14`
+
 ### 🚀 Features
+
 - `BreadcrumbItem`: 支持 `onClick` 事件 @HaixingOoO ([#2795](https://github.com/Tencent/tdesign-react/pull/2795))
-- `Tag`: 组件新增`color`API，支持自定义颜色 @maoyiluo  @uyarn ([#2799](https://github.com/Tencent/tdesign-react/pull/2799))
+- `Tag`: 组件新增`color`API，支持自定义颜色 @maoyiluo @uyarn ([#2799](https://github.com/Tencent/tdesign-react/pull/2799))
+
 ### 🐞 Bug Fixes
+
 - `FormList`: 修复多个组件卡死的问题 @HaixingOoO ([#2788](https://github.com/Tencent/tdesign-react/pull/2788))
 - `DatePicker`: 修复 `format` 与 `valueType` 不一致的场景下计算错误的问题 @uyarn ([#2798](https://github.com/Tencent/tdesign-react/pull/2798))
+
 ### 🚧 Others
-- `Portal`: 添加Portal测试用例 @HaixingOoO ([#2791](https://github.com/Tencent/tdesign-react/pull/2791))
+
+- `Portal`: 添加 Portal 测试用例 @HaixingOoO ([#2791](https://github.com/Tencent/tdesign-react/pull/2791))
 - `List`: 完善 List 测试用例 @HaixingOoO ([#2792](https://github.com/Tencent/tdesign-react/pull/2792))
 - `Alert`: 完善 Alert 测试,优化代码 @HaixingOoO ([#2793](https://github.com/Tencent/tdesign-react/pull/2793))
 
-## 🌈 1.5.2 `2024-02-29` 
+## 🌈 1.5.2 `2024-02-29`
+
 ### 🚀 Features
-- `Cascader`: 新增`valueDisplay`和`label` API的支持 @HaixingOoO ([#2736](https://github.com/Tencent/tdesign-react/pull/2736))
+
+- `Cascader`: 新增`valueDisplay`和`label` API 的支持 @HaixingOoO ([#2736](https://github.com/Tencent/tdesign-react/pull/2736))
 - `Descriptions`: 组件支持嵌套 @HaixingOoO ([#2777](https://github.com/Tencent/tdesign-react/pull/2777))
 - `Tabs`: 调整激活 `Tab` 下划线与 `TabHeader` 边框的层级关系 @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
+
 ### 🐞 Bug Fixes
+
 - `Grid`: 尺寸计算错误，宽度兼容异常 @NWYLZW ([#2738](https://github.com/Tencent/tdesign-react/pull/2738))
 - `Cascader`: 修复`clearable`点击清除按钮触发三次`onChange`的问题 @HaixingOoO ([#2736](https://github.com/Tencent/tdesign-react/pull/2736))
 - `Dialog`: 修复`useDialogPosition`渲染多次绑定事件 @HaixingOoO ([#2749](https://github.com/Tencent/tdesign-react/pull/2749))
 - `Guide`: 修复自定义内容功能失效 @zhangpaopao0609 ([#2752](https://github.com/Tencent/tdesign-react/pull/2752))
 - `Tree`: 修复设置 `keys.children` 后展开图标没有正常变化的问题 @uyarn ([#2746](https://github.com/Tencent/tdesign-react/pull/2746))
-- `Tree`: 修复 `Tree` 自定义label `setData` 没有渲染的问题 @HaixingOoO ([#2776](https://github.com/Tencent/tdesign-react/pull/2776))
-- `Tree`: 修复设置 `Tree` 宽度，`TreeItem` 的 `checkbox` 会被压缩，`label` 省略号失效的问题 @HaixingOoO  @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
-- `Select`: @uyarn 
-    - 修复通过滚动加载选项选中后滚动行为异常的问题 ([#2779](https://github.com/Tencent/tdesign-react/pull/2779))
-    - 修复使用 `size` API 时，虚拟滚动的功能异常问题  ([#2756](https://github.com/Tencent/tdesign-react/pull/2756))
+- `Tree`: 修复 `Tree` 自定义 label `setData` 没有渲染的问题 @HaixingOoO ([#2776](https://github.com/Tencent/tdesign-react/pull/2776))
+- `Tree`: 修复设置 `Tree` 宽度，`TreeItem` 的 `checkbox` 会被压缩，`label` 省略号失效的问题 @HaixingOoO @uyarn ([#2780](https://github.com/Tencent/tdesign-react/pull/2780))
+- `Select`: @uyarn
+  - 修复通过滚动加载选项选中后滚动行为异常的问题 ([#2779](https://github.com/Tencent/tdesign-react/pull/2779))
+  - 修复使用 `size` API 时，虚拟滚动的功能异常问题 ([#2756](https://github.com/Tencent/tdesign-react/pull/2756))
 
-## 🌈 1.5.1 `2024-01-25` 
+## 🌈 1.5.1 `2024-01-25`
+
 ### 🚀 Features
+
 - `Popup`: 支持 `Plugin` 方式使用。 @HaixingOoO ([#2717](https://github.com/Tencent/tdesign-react/pull/2717))
 - `Transfer`: 支持 `direction` API @uyarn ([#2727](https://github.com/Tencent/tdesign-react/pull/2727))
 - `Tabs`: 新增 `action` API，支持自定义右侧区域 @uyarn ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
+
 ### 🐞 Bug Fixes
+
 - `Pagination`: `Jump to` 调整为大写，保持一致性 @wangyewei ([#2716](https://github.com/Tencent/tdesign-react/pull/2716))
 - `Table`: 修复`Modal`里的`Form`表单，使用`shouldUpdate`卸载有时无法找到表单的方法。 @duxphp ([#2675](https://github.com/Tencent/tdesign-react/pull/2675))
 - `Table`: 列宽调整和行展开场景，修复行展开时，会重置列宽调整结果问题 @chaishi ([#2722](https://github.com/Tencent/tdesign-react/pull/2722))
 - `Select`: 修复`Select`多选状态下选中内容滚动的问题。 @HaixingOoO ([#2721](https://github.com/Tencent/tdesign-react/pull/2721))
-- `Transfer`: 修复 `disabled` API功能异常的问题 @uyarn ([#2727](https://github.com/Tencent/tdesign-react/pull/2727))
+- `Transfer`: 修复 `disabled` API 功能异常的问题 @uyarn ([#2727](https://github.com/Tencent/tdesign-react/pull/2727))
 - `Swiper`: 修复向左切换轮播动画时顺序错乱的问题 @HaixingOoO ([#2725](https://github.com/Tencent/tdesign-react/pull/2725))
 - `Form`: 修复计算 `^` 字符异常的问题 @uyarn ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
 - `Loading`: 修复未设置 `z-index` 默认值的问题 @betavs ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
-- `CheckTag`: 修复设置 `className` 会覆盖全部已有类名的缺陷  @uyarn ([#2730](https://github.com/Tencent/tdesign-react/pull/2730))
+- `CheckTag`: 修复设置 `className` 会覆盖全部已有类名的缺陷 @uyarn ([#2730](https://github.com/Tencent/tdesign-react/pull/2730))
 - `TreeSelect`: 修复 `onEnter` 事件不触发的问题 @uyarn ([#2731](https://github.com/Tencent/tdesign-react/pull/2731))
 - `Menu`: 修复 `collapsed` 的 `scroll` 样式 @Except10n ([#2718](https://github.com/Tencent/tdesign-react/pull/2718))
 - `Cascader`: 修复长列表场景下，在 `Safari` 中使用的样式异常问题 @uyarn ([#2728](https://github.com/Tencent/tdesign-react/pull/2728))
 
-## 🌈 1.5.0 `2024-01-11` 
+## 🌈 1.5.0 `2024-01-11`
+
 ### 🚨 Breaking Changes
+
 - `Dialog`: 该版本将 `className` 错误挂载进行了修复，现在的 `className` 只会被挂载到 `Dialog` 的上层容器元素 Context 之中。如果你需要直接修改 `Dialog` 本体的样式，可以切换使用为 `dialogClassName` 进行修改。
+
 ### 🚀 Features
+
 - `Descriptions`: 新增 `Descriptions` 描述组件 @HaixingOoO ([#2706](https://github.com/Tencent/tdesign-react/pull/2706))
 - `Dialog`: 添加了 `dialogClassName` 用于处理内部 dialog 节点样式。建议之前通过 `className` 直接修改弹窗本体样式的用户切换使用为 `dialogClassName` @NWYLZW ([#2639](https://github.com/Tencent/tdesign-react/pull/2639))
+
 ### 🐞 Bug Fixes
+
 - `Cascader`: 修复 Cascader 的 `trigger=hover` 过滤之后，选择操作存在异常 bug @HaixingOoO ([#2702](https://github.com/Tencent/tdesign-react/pull/2702))
 - `Upload`: 修复 Upload 的 `uploadFilePercent` 类型未定义 @betavs ([#2703](https://github.com/Tencent/tdesign-react/pull/2703))
 - `Dialog`: 修复了 Dialog 的 `className` 进行的多次节点挂载错误，`className` 将仅被挂载至 ctx 元素上 @NWYLZW ([#2639](https://github.com/Tencent/tdesign-react/pull/2639))
 - `TreeSelect`: 修复 `suffixIcon` 错误并添加了相关示例 @Ali-ovo ([#2692](https://github.com/Tencent/tdesign-react/pull/2692))
 
-## 🌈 1.4.3 `2024-01-02` 
+## 🌈 1.4.3 `2024-01-02`
+
 ### 🐞 Bug Fixes
+
 - `AutoComplete`: 修复`ActiveIndex=-1`没匹配时，回车会报错的问题 @Ali-ovo ([#2300](https://github.com/Tencent/tdesign-react/pull/2300))
-- `Cascader`: 修复`1.4.2` Cascader单选过滤下不触发选中的缺陷 @HaixingOoO ([#2700](https://github.com/Tencent/tdesign-react/pull/2700))
+- `Cascader`: 修复`1.4.2` Cascader 单选过滤下不触发选中的缺陷 @HaixingOoO ([#2700](https://github.com/Tencent/tdesign-react/pull/2700))
 
+## 🌈 1.4.2 `2023-12-28`
 
-## 🌈 1.4.2 `2023-12-28` 
 ### 🚀 Features
+
 - `Card`: 添加 `LoadingProps` 属性 @HaixingOoO ([#2677](https://github.com/Tencent/tdesign-react/pull/2677))
 - `DatePicker`: `DateRangePicker` 新增`cancelRangeSelectLimit`，支持不限制 RangePicker 选择的前后范围 @uyarn ([#2684](https://github.com/Tencent/tdesign-react/pull/2684))
 - `Space`: 元素为空时，不再渲染一个子元素 @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
@@ -995,44 +1204,51 @@ spline: explain
   - 输入框类型的上传组件，新增类名 `t-upload--theme-file-input`
   - 新增支持 `uploadPastedFiles`，表示允许粘贴上传文件
   - 新增 `cancelUploadButton` 和 `uploadButton`，支持自定义上传按钮和取消上传按钮
-  - 新增 `imageViewerProps`，透传图片预览组件全部属性 
+  - 新增 `imageViewerProps`，透传图片预览组件全部属性
   - 新增 `showImageFileName`，用于控制是否显示图片名称
   - 支持传入默认值为非数组形式
   - 支持 `fileListDisplay=null` 时，隐藏文件列表；并新增更加完整的 `fileListDisplay` 参数，用于自定义 UI
+
 ### 🐞 Bug Fixes
-- `Table`:  异步获取最新的树形结构数据时，优先使用 `window.requestAnimationFrame` 函数，以防闪屏 @lazybonee ([#2668](https://github.com/Tencent/tdesign-react/pull/2668))
+
+- `Table`: 异步获取最新的树形结构数据时，优先使用 `window.requestAnimationFrame` 函数，以防闪屏 @lazybonee ([#2668](https://github.com/Tencent/tdesign-react/pull/2668))
 - `Table`: 修复筛选值为 `0/false` 时，筛选图标不能高亮问题 @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
 - `Cascader`: 修复组件在 filter 之后进行选择操作和清除内容存在异常 bug @HaixingOoO ([#2674](https://github.com/Tencent/tdesign-react/pull/2674))
 - `ColorPicker`: 全局设置 `border-box` 后造成颜色列表样式问题 @carolin913
-- `Pagination`: 将总数单位 `项` 改为 `条` , 保持内容一致性  @dinghuihua ([#2679](https://github.com/Tencent/tdesign-react/pull/2679))
+- `Pagination`: 将总数单位 `项` 改为 `条` , 保持内容一致性 @dinghuihua ([#2679](https://github.com/Tencent/tdesign-react/pull/2679))
 - `InputNumber`: 修复 `min=0` 或 `max=0` 限制无效问题 @chaishi ([#2352](https://github.com/Tencent/tdesign-react/pull/2352))
 - `Watermark`: 修复行内 style 引起的无法 sticky 定位问题 @carolin913 ([#2685](https://github.com/Tencent/tdesign-react/pull/2685))
 - `Calendar`: 修复卡片模式下未正常展示周信息的缺陷 @uyarn ([#2686](https://github.com/Tencent/tdesign-react/pull/2686))
 - `Upload`: @chaishi ([#2671](https://github.com/Tencent/tdesign-react/pull/2671))
   - 修复手动上传时，无法更新上传进度问题
   - 修复 `uploadFilePercent` 参数类型问题
-    
- ## 🌈 1.4.1 `2023-12-14` 
+
+## 🌈 1.4.1 `2023-12-14`
+
 ### 🚀 Features
+
 - `Radio`: 支持通过空格键（Space）选中选项 @liweijie0812 ([#2638](https://github.com/Tencent/tdesign-react/pull/2638))
 - `Dropdown`: 移除对 left 的 item 样式特殊处理 @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
+
 ### 🐞 Bug Fixes
-- `AutoComplete`: 修复部分特殊字符匹配报错的问题  @ZWkang ([#2631](https://github.com/Tencent/tdesign-react/pull/2631))
-- `DatePicker`: 
+
+- `AutoComplete`: 修复部分特殊字符匹配报错的问题 @ZWkang ([#2631](https://github.com/Tencent/tdesign-react/pull/2631))
+- `DatePicker`:
   - 修复日期点击清空内容时弹窗会闪烁的缺陷 @HaixingOoO ([#2641](https://github.com/Tencent/tdesign-react/pull/2641))
-  - 修复日期选择禁用后，后缀图标颜色改变的问题 @HaixingOoO  @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
+  - 修复日期选择禁用后，后缀图标颜色改变的问题 @HaixingOoO @uyarn ([#2663](https://github.com/Tencent/tdesign-react/pull/2663))
   - 修复禁用状态下点击组件边缘仍能显示 `Panel` @Zz-ZzzZ ([#2653](https://github.com/Tencent/tdesign-react/pull/2653))
 - `Dropdown`: 修复下拉菜单禁用状态可点击的问题 @betavs ([#2648](https://github.com/Tencent/tdesign-react/pull/2648))
 - `DropdownItem`: 修复遗漏 `Divider` 类型的缺陷 @uyarn ([#2649](https://github.com/Tencent/tdesign-react/pull/2649))
 - `Popup`: 修复 `disabled` 属性未生效的缺陷 @uyarn ([#2665](https://github.com/Tencent/tdesign-react/pull/2665))
-- `Select`: 修复 `InputChange` 事件在blur时trigger异常的问题 @uyarn ([#2664](https://github.com/Tencent/tdesign-react/pull/2664))
+- `Select`: 修复 `InputChange` 事件在 blur 时 trigger 异常的问题 @uyarn ([#2664](https://github.com/Tencent/tdesign-react/pull/2664))
 - `SelectInput`: 修复 popup 内容宽度计算问题 @HaixingOoO ([#2647](https://github.com/Tencent/tdesign-react/pull/2647))
 - `ImageViewer`: 图片预览添加默认的缩放比例和按下 ESC 时是否触发图片预览器关闭事件 @HaixingOoO ([#2652](https://github.com/Tencent/tdesign-react/pull/2652))
 - `Table`: @chaishi
-    - 修复 `EnhancedTable` 树节点无法正常展开问题 ([#2661](https://github.com/Tencent/tdesign-react/pull/2661))
-    - 修复虚拟滚动场景，树节点无法展开问题 ([#2659](https://github.com/Tencent/tdesign-react/pull/2659))
+  - 修复 `EnhancedTable` 树节点无法正常展开问题 ([#2661](https://github.com/Tencent/tdesign-react/pull/2661))
+  - 修复虚拟滚动场景，树节点无法展开问题 ([#2659](https://github.com/Tencent/tdesign-react/pull/2659))
 
- ## 🌈 1.4.0 `2023-11-30`
+## 🌈 1.4.0 `2023-11-30`
+
 ### 🚀 Features
 
 - `Space`: 兼容支持组件间距在低级浏览器中的呈现 @chaishi ([#2602](https://github.com/Tencent/tdesign-react/pull/2602))
@@ -1043,444 +1259,546 @@ spline: explain
 - `ColorPicker`: 修复 `format` 为 `hex` 时，配合 `enableAlpha` 调整透明度不生效的问题 @uyarn ([#2628](https://github.com/Tencent/tdesign-react/pull/2628))
 - `ColorPicker`: 修复修改颜色上方滑杆按钮颜色不变 @HaixingOoO ([#2615](https://github.com/Tencent/tdesign-react/pull/2615))
 - `Table`: 修复 `lazyLoad` 懒加载效果 @chaishi ([#2605](https://github.com/Tencent/tdesign-react/pull/2605))
-- `Tree`: 
-    - 修复树组件节点的 `open class` 状态控制逻辑错误导致的样式异常 @NWYLZW ([#2611](https://github.com/Tencent/tdesign-react/pull/2611))
-    - 指定滚动到特定节点 API 中的 `key` 和 `index` 应为可选 @uyarn ([#2626](https://github.com/Tencent/tdesign-react/pull/2626))
+- `Tree`:
+  - 修复树组件节点的 `open class` 状态控制逻辑错误导致的样式异常 @NWYLZW ([#2611](https://github.com/Tencent/tdesign-react/pull/2611))
+  - 指定滚动到特定节点 API 中的 `key` 和 `index` 应为可选 @uyarn ([#2626](https://github.com/Tencent/tdesign-react/pull/2626))
 - `Drawer`: 修复 `mode` 为 `push` 时,推开内容区域为 drawer 节点的父节点。 @HaixingOoO ([#2614](https://github.com/Tencent/tdesign-react/pull/2614))
 - `Radio`: 修复表单 `disabled` 未生效在 `Radio 上的问题 @li-jia-nan ([#2397](https://github.com/Tencent/tdesign-react/pull/2397))
 - `Pagination`: 修复当 `total` 为 0 并且 `pageSize` 改变时，`current` 值为 0 的问题 @betavs ([#2624](https://github.com/Tencent/tdesign-react/pull/2624))
 - `Image`: 修复图片在 SSR 模式下不会触发原生事件 @HaixingOoO ([#2616](https://github.com/Tencent/tdesign-react/pull/2616))
 
- ## 🌈 1.3.1 `2023-11-15` 
+## 🌈 1.3.1 `2023-11-15`
+
 ### 🚀 Features
+
 - `Upload`: 拖拽上传文件场景，即使文件类型错误，也触发 `drop` 事件 @chaishi ([#2591](https://github.com/Tencent/tdesign-react/pull/2591))
+
 ### 🐞 Bug Fixes
-- `Tree`: 
-    - 修复不添加 `activable` 参数也可触发 `onClick` 事件 @HaixingOoO ([#2568](https://github.com/Tencent/tdesign-react/pull/2568))
-    - 修复可编辑表格编辑组件之间的联动不生效 @HaixingOoO ([#2572](https://github.com/Tencent/tdesign-react/pull/2572))
-- `Notification`: 
-    - 修复连续弹两个 `Notification`，第一次实际只显示一个 @HaixingOoO ([#2595](https://github.com/Tencent/tdesign-react/pull/2595))
-    - 使用 `flushSync` 在 `useEffect` 中会警告，现在改用循环 `setTimeout 来处理 @HaixingOoO ([#2597](https://github.com/Tencent/tdesign-react/pull/2597))
-- `Dialog`: 
-    - 修复 `Dialog` 中 引入 `Input` 组件，从 `Input` 中间输入光标会跳转到最后 @HaixingOoO ([#2485](https://github.com/Tencent/tdesign-react/pull/2485))
-    - 修复弹窗的头部标题显示影响了取消按钮的位置 @HaixingOoO ([#2593](https://github.com/Tencent/tdesign-react/pull/2593))
+
+- `Tree`:
+  - 修复不添加 `activable` 参数也可触发 `onClick` 事件 @HaixingOoO ([#2568](https://github.com/Tencent/tdesign-react/pull/2568))
+  - 修复可编辑表格编辑组件之间的联动不生效 @HaixingOoO ([#2572](https://github.com/Tencent/tdesign-react/pull/2572))
+- `Notification`:
+  - 修复连续弹两个 `Notification`，第一次实际只显示一个 @HaixingOoO ([#2595](https://github.com/Tencent/tdesign-react/pull/2595))
+  - 使用 `flushSync` 在 `useEffect` 中会警告，现在改用循环 `setTimeout 来处理 @HaixingOoO ([#2597](https://github.com/Tencent/tdesign-react/pull/2597))
+- `Dialog`:
+  - 修复 `Dialog` 中 引入 `Input` 组件，从 `Input` 中间输入光标会跳转到最后 @HaixingOoO ([#2485](https://github.com/Tencent/tdesign-react/pull/2485))
+  - 修复弹窗的头部标题显示影响了取消按钮的位置 @HaixingOoO ([#2593](https://github.com/Tencent/tdesign-react/pull/2593))
 - `Popup`: 修复 `PopupRef` 的类型缺失问题 @Ricinix ([#2577](https://github.com/Tencent/tdesign-react/pull/2577))
 - `Tabs`: 修复重复点击激活的选项卡，也会触发 `onChange` 事件。 @HaixingOoO ([#2588](https://github.com/Tencent/tdesign-react/pull/2588))
 - `Radio`: 根据对应 variant 选择 Radio.Button 进行展示 @NWYLZW ([#2589](https://github.com/Tencent/tdesign-react/pull/2589))
 - `Input`: 修复设置最大长度后回删的异常行为 @uyarn ([#2598](https://github.com/Tencent/tdesign-react/pull/2598))
 - `Link`: 修复前后图标没有垂直居中的问题 @uyarn ([#2598](https://github.com/Tencent/tdesign-react/pull/2598))
-- `Select`: 修复 `inputchange` 事件context参数异常的问题 @uyarn ([#2600](https://github.com/Tencent/tdesign-react/pull/2600))
+- `Select`: 修复 `inputchange` 事件 context 参数异常的问题 @uyarn ([#2600](https://github.com/Tencent/tdesign-react/pull/2600))
 - `DatePicker`: 修复 `PaginationMini`未更新导致切换行为异常的问题 @Ricinix ([#2587](https://github.com/Tencent/tdesign-react/pull/2587))
 - `Form`: 修复 setFields 触发 onValuesChange 导致的死循环 @honkinglin ([#2570](https://github.com/Tencent/tdesign-react/pull/2570))
 
- ## 🌈 1.3.0 `2023-10-19` 
+## 🌈 1.3.0 `2023-10-19`
+
 ### 🚀 Features
+
 - `TimelineItem`: 添加点击事件 @Zzongke ([#2545](https://github.com/Tencent/tdesign-react/pull/2545))
 - `Tag`: @chaishi ([#2524](https://github.com/Tencent/tdesign-react/pull/2524))
-    - 支持多种风格标签配置
-    - 支持标签组`CheckTagGroup`的使用，详见示例文档
+  - 支持多种风格标签配置
+  - 支持标签组`CheckTagGroup`的使用，详见示例文档
+
 ### 🐞 Bug Fixes
-- `locale`: 添加缺失it_IT、ru_RU、zh_TW 的语言环境 @Zzongke ([#2542](https://github.com/Tencent/tdesign-react/pull/2542))
+
+- `locale`: 添加缺失 it_IT、ru_RU、zh_TW 的语言环境 @Zzongke ([#2542](https://github.com/Tencent/tdesign-react/pull/2542))
 - `Cascader`: `change` 事件中 `source` 异常问题 @betavs ([#2544](https://github.com/Tencent/tdesign-react/pull/2544))
-- `Tree`: 修复`allowFoldNodeOnFilter`为true下过滤后节点的展示结果 @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
+- `Tree`: 修复`allowFoldNodeOnFilter`为 true 下过滤后节点的展示结果 @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
 - `TagInput`: 修复在只有一个选项时，删除过滤文字会误删已选项的缺陷 @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
 - `TreeSelect`: 调整过滤选项后的交互行为，与其他实现框架保持一致 @uyarn ([#2552](https://github.com/Tencent/tdesign-react/pull/2552))
 - `Rate`: 修复鼠标快速移动，会出现多个 text 显示的问题 @Jon-Millent ([#2551](https://github.com/Tencent/tdesign-react/pull/2551))
 
- ## 🌈 1.2.6 `2023-09-28` 
+## 🌈 1.2.6 `2023-09-28`
+
 ### 🚀 Features
+
 - `Table`: 优化渲染次数 @chaishi ([#2514](https://github.com/Tencent/tdesign-react/pull/2514))
 - `Card`: `title` 使用 `div` 取代 `span` 在自定义场景下更符合规范 @uyarn ([#2517](https://github.com/Tencent/tdesign-react/pull/2517))
 - `Tree`: 支持通过 key 匹配单一 value 指定滚动到特定位置，具体使用方式请参考示例代码 @uyarn ([#2519](https://github.com/Tencent/tdesign-react/pull/2519))
+
 ### 🐞 Bug Fixes
+
 - `Form`: 修复 formList 嵌套数据获取异常 @honkinglin ([#2529](https://github.com/Tencent/tdesign-react/pull/2529))
 - `Table`: 修复数据切换时 `rowspanAndColspan` 渲染问题 @chaishi ([#2514](https://github.com/Tencent/tdesign-react/pull/2514))
 - `Cascader`: hover 没有子节点数据的父节点时未更新子节点 @betavs ([#2528](https://github.com/Tencent/tdesign-react/pull/2528))
 - `DatePicker`: 修复切换月份失效问题 @honkinglin ([#2531](https://github.com/Tencent/tdesign-react/pull/2531))
-- `Dropdown`: 修复`Dropdown` disabled API失效的问题 @uyarn ([#2532](https://github.com/Tencent/tdesign-react/pull/2532))
+- `Dropdown`: 修复`Dropdown` disabled API 失效的问题 @uyarn ([#2532](https://github.com/Tencent/tdesign-react/pull/2532))
 
- ## 🌈 1.2.5 `2023-09-14` 
+## 🌈 1.2.5 `2023-09-14`
+
 ### 🚀 Features
+
 - `Steps`: 全局配置添加步骤条的已完成图标自定义 @Zzongke ([#2491](https://github.com/Tencent/tdesign-react/pull/2491))
 - `Table`: 可筛选表格，`onFilterChange` 事件新增参数 `trigger: 'filter-change' | 'confirm' | 'reset' | 'clear'`，表示触发筛选条件变化的来源 @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
-- `Form`: trigger新增`submit`选项 @honkinglin ([#2507](https://github.com/Tencent/tdesign-react/pull/2507))
+- `Form`: trigger 新增`submit`选项 @honkinglin ([#2507](https://github.com/Tencent/tdesign-react/pull/2507))
 - `ImageViewer`: `onIndexChange` 事件新增 `trigger` 枚举值 `current` @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Image`: @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
-    - 新增 `fallback`，表示图片的兜底图，原始图片加载失败时会显示兜底图
-    - 新增支持 `src` 类型为 `File`，支持通过 `File` 预览图片
+  - 新增 `fallback`，表示图片的兜底图，原始图片加载失败时会显示兜底图
+  - 新增支持 `src` 类型为 `File`，支持通过 `File` 预览图片
 - `Upload`: 文案列表支持显示缩略图 @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Tree`: @uyarn ([#2509](https://github.com/Tencent/tdesign-react/pull/2509))
-    - 支持虚拟滚动场景通过 `key` 滚动到特定节点 
-    - 支持虚拟滚动场景低于 `threshold` 仍可运行 `scrollTo` 操作
+  - 支持虚拟滚动场景通过 `key` 滚动到特定节点
+  - 支持虚拟滚动场景低于 `threshold` 仍可运行 `scrollTo` 操作
+
 ### 🐞 Bug Fixes
+
 - `ConfigProvider`: 修复切换多语言失效的问题 @uyarn ([#2501](https://github.com/Tencent/tdesign-react/pull/2501))
 - `Table`:
-    - 可筛选表格，修复 `resetValue` 在清空筛选时，未能重置到指定 `resetValue` 值的问题 @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
-    - 树形结构表格，修复 expandedTreeNodes.sync 和 expanded-tree-nodes-change 使用 expandTreeNodeOnClick 时无效问题 @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
-    - 单元格在编辑模式下，保存的时候对于链式的colKey处理错误，未能覆盖原来的值 @Empire-suy ([#2493](https://github.com/Tencent/tdesign-react/pull/2493))
-    - 可编辑表格，修复多个可编辑表格同时存在时，校验互相影响问题 @chaishi ([#2498](https://github.com/Tencent/tdesign-react/pull/2498))
+  - 可筛选表格，修复 `resetValue` 在清空筛选时，未能重置到指定 `resetValue` 值的问题 @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
+  - 树形结构表格，修复 expandedTreeNodes.sync 和 expanded-tree-nodes-change 使用 expandTreeNodeOnClick 时无效问题 @chaishi ([#2492](https://github.com/Tencent/tdesign-react/pull/2492))
+  - 单元格在编辑模式下，保存的时候对于链式的 colKey 处理错误，未能覆盖原来的值 @Empire-suy ([#2493](https://github.com/Tencent/tdesign-react/pull/2493))
+  - 可编辑表格，修复多个可编辑表格同时存在时，校验互相影响问题 @chaishi ([#2498](https://github.com/Tencent/tdesign-react/pull/2498))
 - `TagInput`: 修复折叠展示选项尺寸大小问题 @uyarn ([#2503](https://github.com/Tencent/tdesign-react/pull/2503))
 - `Tabs`: 修复使用 list 传 props 且 destroyOnHide 为 false 下， 会丢失 panel 内容的问题 @lzy2014love ([#2500](https://github.com/Tencent/tdesign-react/pull/2500))
-- `Menu`: 修复菜单 `expandType` 默认模式下menuitem传递onClick不触发的问题 @Zzongke ([#2502](https://github.com/Tencent/tdesign-react/pull/2502))
+- `Menu`: 修复菜单 `expandType` 默认模式下 menuitem 传递 onClick 不触发的问题 @Zzongke ([#2502](https://github.com/Tencent/tdesign-react/pull/2502))
 - `ImageViewer`: 修复无法通过 `visible` 直接打开预览弹框问题 @chaishi ([#2494](https://github.com/Tencent/tdesign-react/pull/2494))
 - `Tree`: 修复 `1.2.0` 版本后部分 `TreeNodeModel` 的操作失效的异常 @uyarn ([#2509](https://github.com/Tencent/tdesign-react/pull/2509))
 
- ## 🌈 1.2.4 `2023-08-31` 
+## 🌈 1.2.4 `2023-08-31`
+
 ### 🚀 Features
-- `Table`: 树形结构，没有设置 `expandedTreeNodes` 情况下，data 数据发生变化时，自动重置收起所有展开节点（如果希望保持展开节点，请使用属性 `expandedTreeNodes` 控制  @chaishi ([#2470](https://github.com/Tencent/tdesign-react/pull/2470))
+
+- `Table`: 树形结构，没有设置 `expandedTreeNodes` 情况下，data 数据发生变化时，自动重置收起所有展开节点（如果希望保持展开节点，请使用属性 `expandedTreeNodes` 控制 @chaishi ([#2470](https://github.com/Tencent/tdesign-react/pull/2470))
+
 ### 🐞 Bug Fixes
+
 - `Watermark`: 修改水印节点，不影响水印展示 @tingtingcheng6 ([#2459](https://github.com/Tencent/tdesign-react/pull/2459))
 - `Table`: @chaishi ([#2470](https://github.com/Tencent/tdesign-react/pull/2470))
-    - 拖拽排序 + 本地数据分页场景，修复拖拽排序事件参数 `currentIndex/targetIndex/current/target` 等不正确问题
-    - 拖拽排序 + 本地数据分页场景，修复在第二页以后的分页数据中拖拽调整顺序后，会自动跳转到第一页问题
-    - 支持分页非受控用法的拖拽排序场景 
+  - 拖拽排序 + 本地数据分页场景，修复拖拽排序事件参数 `currentIndex/targetIndex/current/target` 等不正确问题
+  - 拖拽排序 + 本地数据分页场景，修复在第二页以后的分页数据中拖拽调整顺序后，会自动跳转到第一页问题
+  - 支持分页非受控用法的拖拽排序场景
 - `Slider`: 修复初始值为 0 时，`label` 位置错误的缺陷 @Zzongke ([#2477](https://github.com/Tencent/tdesign-react/pull/2477))
-- `Tree`: 支持`store.children`调用getChildren方法 @uyarn ([#2480](https://github.com/Tencent/tdesign-react/pull/2480)) 
+- `Tree`: 支持`store.children`调用 getChildren 方法 @uyarn ([#2480](https://github.com/Tencent/tdesign-react/pull/2480))
 
-## 🌈 1.2.3 `2023-08-24` 
+## 🌈 1.2.3 `2023-08-24`
+
 ### 🐞 Bug Fixes
+
 - `Table`: 修复 usePrevious 报错 @honkinglin ([#2464](https://github.com/Tencent/tdesign-react/pull/2464))
-- `ImageViewer`: 修复引入文件路径报错 @honkinglin ([#2465](https://github.com/Tencent/tdesign-react/pull/2465)) 
+- `ImageViewer`: 修复引入文件路径报错 @honkinglin ([#2465](https://github.com/Tencent/tdesign-react/pull/2465))
 
-## 🌈 1.2.2 `2023-08-24` 
+## 🌈 1.2.2 `2023-08-24`
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
-    - 树形结构，新增组件实例方法 `removeChildren`，用于移除子节点 
-    - 树形结构，支持通过属性 `expandedTreeNodes.sync` 自由控制展开节点，非必传属性
+  - 树形结构，新增组件实例方法 `removeChildren`，用于移除子节点
+  - 树形结构，支持通过属性 `expandedTreeNodes.sync` 自由控制展开节点，非必传属性
 - `Tree`: 新增`scrollTo`方法 支持在虚拟滚动场景下滚动到指定节点的需求 @uyarn ([#2460](https://github.com/Tencent/tdesign-react/pull/2460))
+
 ### 🐞 Bug Fixes
+
 - `TagInput`: 修复输入中文时被卡住的问题 @Zzongke ([#2438](https://github.com/Tencent/tdesign-react/pull/2438))
 - `Table`:
-    - 点击行展开/点击行选中，修复 `expandOnRowClick`和 `selectOnRowClick` 无法独立控制行点击执行交互问题 @chaishi ([#2452](https://github.com/Tencent/tdesign-react/pull/2452))
-    - 树形结构，修复组件实例方法 展开全部 `expandAll` 问题 @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
-- `Form`: 修复FormList组件使用form setFieldsValue、reset异常 @nickcdon ([#2406](https://github.com/Tencent/tdesign-react/pull/2406)) 
+  - 点击行展开/点击行选中，修复 `expandOnRowClick`和 `selectOnRowClick` 无法独立控制行点击执行交互问题 @chaishi ([#2452](https://github.com/Tencent/tdesign-react/pull/2452))
+  - 树形结构，修复组件实例方法 展开全部 `expandAll` 问题 @chaishi ([#2453](https://github.com/Tencent/tdesign-react/pull/2453))
+- `Form`: 修复 FormList 组件使用 form setFieldsValue、reset 异常 @nickcdon ([#2406](https://github.com/Tencent/tdesign-react/pull/2406))
 
-## 🌈 1.2.1 `2023-08-16` 
+## 🌈 1.2.1 `2023-08-16`
+
 ### 🚀 Features
+
 - `Anchor`: 新增 `getCurrentAnchor` 支持自定义高亮锚点 @ontheroad1992 ([#2436](https://github.com/Tencent/tdesign-react/pull/2436))
 - `MenuItem`: `onClick` 事件增加 `value` 返回值 @dexterBo ([#2441](https://github.com/Tencent/tdesign-react/pull/2441))
 - `FormItem`: 新增 `valueFormat` 函数支持格式化数据 @honkinglin ([#2445](https://github.com/Tencent/tdesign-react/pull/2445))
+
 ### 🐞 Bug Fixes
+
 - `Dialog`: 修复闪烁问题 @linjunc ([#2435](https://github.com/Tencent/tdesign-react/pull/2435))
 - `Select`: @uyarn ([#2446](https://github.com/Tencent/tdesign-react/pull/2446))
-    - 修复多选丢失 `title` 的问题
-    - 开启远程搜索时不执行内部过滤
+  - 修复多选丢失 `title` 的问题
+  - 开启远程搜索时不执行内部过滤
 - `Popconfirm`: 无效的 `className` 和 `style` Props @betavs ([#2420](https://github.com/Tencent/tdesign-react/pull/2420))
-- `DatePicker`: 修复 hover cell 造成不必要的渲染 @j10ccc ([#2440](https://github.com/Tencent/tdesign-react/pull/2440)) 
+- `DatePicker`: 修复 hover cell 造成不必要的渲染 @j10ccc ([#2440](https://github.com/Tencent/tdesign-react/pull/2440))
 
- ## 🌈 1.2.0 `2023-08-10` 
+## 🌈 1.2.0 `2023-08-10`
 
 ### 🚨 Breaking Changes
+
 - `Icon`: @uyarn ([#2429](https://github.com/Tencent/tdesign-react/pull/2429))
-    - 新增 960 个图标
-    - 调整图标命名 `photo` 为 `camera`，`books` 为 `bookmark`, `stop-cirle-1` 为 `stop-circle-stroke`
-    - 移除 `money-circle` 图标，具体请查看图标页面
+  - 新增 960 个图标
+  - 调整图标命名 `photo` 为 `camera`，`books` 为 `bookmark`, `stop-cirle-1` 为 `stop-circle-stroke`
+  - 移除 `money-circle` 图标，具体请查看图标页面
 
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2402](https://github.com/Tencent/tdesign-react/pull/2402))
-    - 新增 `lazyLoad` 用于懒加载整个表格
-    - 可编辑单元格，新增 `edit.keepEditMode` ，用于保持单元格始终为编辑模式
-    - 可筛选表格，支持透传 `attrs/style/classNames` 属性、样式、类名等信息到自定义组件
-    - 可筛选表格，当前 `filterValue` 未设置过滤值的默认值时，不再透传 undefined 到筛选器组件，某些组件的默认值必须为数组，不允许是 undefined 
+  - 新增 `lazyLoad` 用于懒加载整个表格
+  - 可编辑单元格，新增 `edit.keepEditMode` ，用于保持单元格始终为编辑模式
+  - 可筛选表格，支持透传 `attrs/style/classNames` 属性、样式、类名等信息到自定义组件
+  - 可筛选表格，当前 `filterValue` 未设置过滤值的默认值时，不再透传 undefined 到筛选器组件，某些组件的默认值必须为数组，不允许是 undefined
+
 ### 🐞 Bug Fixes
-- `Cascader`:  传入的 value 不在 options中时会直接报错 @peng-yin ([#2414](https://github.com/Tencent/tdesign-react/pull/2414))
+
+- `Cascader`: 传入的 value 不在 options 中时会直接报错 @peng-yin ([#2414](https://github.com/Tencent/tdesign-react/pull/2414))
 - `Menu`: 修复同一个 `MenuItem` 多次触发 `onChange` 的问题 @leezng ([#2424](https://github.com/Tencent/tdesign-react/pull/2424))
 - `Drawer`: 抽屉组件在 `visible` 默认为 `true` 时，无法正常显示 @peng-yin ([#2415](https://github.com/Tencent/tdesign-react/pull/2415))
 - `Table`: @chaishi ([#2402](https://github.com/Tencent/tdesign-react/pull/2402))
-    - 虚拟滚动场景，修复表头宽度和表内容宽度不一致问题
-    - 虚拟滚动场景，修复默认的滚动条长度（位置）和滚动后的不一致问题 
+  - 虚拟滚动场景，修复表头宽度和表内容宽度不一致问题
+  - 虚拟滚动场景，修复默认的滚动条长度（位置）和滚动后的不一致问题
 
 ## 🌈 1.1.17 `2023-07-28`
+
 ### 🐞 Bug Fixes
+
 - `Tabs`: 修复 list 传空数组时的 js 报错 @zhenglianghan ([#2393](https://github.com/Tencent/tdesign-react/pull/2393))
 - `ListItemMeta`: 修复 `description` 传递自定义元素 @qijizh ([#2396](https://github.com/Tencent/tdesign-react/pull/2396))
 - `Tree`: 修复开启虚拟滚动时部分场景下节点回滚的交互异常问题 @uyarn ([#2399](https://github.com/Tencent/tdesign-react/pull/2399))
 - `Tree`: 修复 `1.1.15` 版本后基于 `level` 属性的操作无法正常工作的问题 @uyarn ([#2399](https://github.com/Tencent/tdesign-react/pull/2399))
 
 ## 🌈 1.1.16 `2023-07-26`
+
 ### 🚀 Features
+
 - `TimePicker`: @uyarn ([#2388](https://github.com/Tencent/tdesign-react/pull/2388))
-    - `disableTime` 回调新增毫秒参数
-    - 优化展示不可选时间选项时滚动到不可选选项的体验 
+  - `disableTime` 回调新增毫秒参数
+  - 优化展示不可选时间选项时滚动到不可选选项的体验
 - `Dropdown`: 新增 `panelTopContent` 及 `panelBottomContent`，支持需要上下额外节点的场景使用 @uyarn ([#2387](https://github.com/Tencent/tdesign-react/pull/2387))
 
 ### 🐞 Bug Fixes
+
 - `Table`:
-    - 可编辑表格场景，支持设置 `colKey` 值为链式属性，如：`a.b.c` @chaishi ([#2381](https://github.com/Tencent/tdesign-react/pull/2381))
-    - 树形结构表格，修复当 `selectedRowKeys` 中的值在 data 数据中不存在时报错问题 @chaishi ([#2385](https://github.com/Tencent/tdesign-react/pull/2385))
+  - 可编辑表格场景，支持设置 `colKey` 值为链式属性，如：`a.b.c` @chaishi ([#2381](https://github.com/Tencent/tdesign-react/pull/2381))
+  - 树形结构表格，修复当 `selectedRowKeys` 中的值在 data 数据中不存在时报错问题 @chaishi ([#2385](https://github.com/Tencent/tdesign-react/pull/2385))
 - `Guide`: 修复设置 `step1` 为 `-1` 时需要隐藏组件的功能 @uyarn ([#2389](https://github.com/Tencent/tdesign-react/pull/2389))
 
-## 🌈 1.1.15 `2023-07-19` 
-### 🚀 Features
-- `DatePicker`: 优化关闭浮层后重置默认选中区域 @honkinglin ([#2371](https://github.com/Tencent/tdesign-react/pull/2371))
-### 🐞 Bug Fixes
-- `Dialog`: 修复 `theme=danger` 无效问题 @chaishi ([#2365](https://github.com/Tencent/tdesign-react/pull/2365))
-- `Popconfirm`: 当 `confirmBtn/cancelBtn` 值类型为 `Object` 时未透传 @imp2002 ([#2361](https://github.com/Tencent/tdesign-react/pull/2361)) 
+## 🌈 1.1.15 `2023-07-19`
 
-## 🌈 1.1.14 `2023-07-12` 
 ### 🚀 Features
+
+- `DatePicker`: 优化关闭浮层后重置默认选中区域 @honkinglin ([#2371](https://github.com/Tencent/tdesign-react/pull/2371))
+
+### 🐞 Bug Fixes
+
+- `Dialog`: 修复 `theme=danger` 无效问题 @chaishi ([#2365](https://github.com/Tencent/tdesign-react/pull/2365))
+- `Popconfirm`: 当 `confirmBtn/cancelBtn` 值类型为 `Object` 时未透传 @imp2002 ([#2361](https://github.com/Tencent/tdesign-react/pull/2361))
+
+## 🌈 1.1.14 `2023-07-12`
+
+### 🚀 Features
+
 - `Tree`: 支持虚拟滚动 @uyarn ([#2359](https://github.com/Tencent/tdesign-react/pull/2359))
 - `Table`: 树形结构，添加行层级类名，方便业务设置不同层级的样式 @chaishi ([#2354](https://github.com/Tencent/tdesign-react/pull/2354))
 - `Radio`: 优化选项组换行情况 @ontheroad1992 ([#2358](https://github.com/Tencent/tdesign-react/pull/2358))
 - `Upload`: @chaishi ([#2353](https://github.com/Tencent/tdesign-react/pull/2353))
-    - 新增组件实例方法，`uploadFilePercent` 用于更新文件上传进度
-    - `theme=image`，支持使用 `fileListDisplay` 自定义 UI 内容
-    - `theme=image`，支持点击名称打开新窗口访问图片
-    - 拖拽上传场景，支持 `accept` 文件类型限制
+  - 新增组件实例方法，`uploadFilePercent` 用于更新文件上传进度
+  - `theme=image`，支持使用 `fileListDisplay` 自定义 UI 内容
+  - `theme=image`，支持点击名称打开新窗口访问图片
+  - 拖拽上传场景，支持 `accept` 文件类型限制
 
 ### 🐞 Bug Fixes
+
 - `Upload`: 自定义上传方法，修复未能正确返回上传成功或失败后的文件问题 @chaishi ([#2353](https://github.com/Tencent/tdesign-react/pull/2353))
 
-## 🌈 1.1.13 `2023-07-05` 
+## 🌈 1.1.13 `2023-07-05`
+
 ### 🐞 Bug Fixes
+
 - `Tag`: 修复 `children` 为数字 `0` 时的渲染异常 @HelKyle ([#2335](https://github.com/Tencent/tdesign-react/pull/2335))
 - `Input`: 修复 `limitNumber` 部分在 `disabled` 状态下的样式问题 @uyarn ([#2338](https://github.com/Tencent/tdesign-react/pull/2338))
 - `TagInput`: 修复前置图标的样式缺陷 @uyarn ([#2342](https://github.com/Tencent/tdesign-react/pull/2342))
 - `SelectInput`: 修复失焦时未清空输入内容的缺陷 @uyarn ([#2342](https://github.com/Tencent/tdesign-react/pull/2342))
 
-## 🌈 1.1.12 `2023-06-29` 
+## 🌈 1.1.12 `2023-06-29`
 
 ### 🚀 Features
+
 - `Site`: 支持英文站点 @uyarn ([#2316](https://github.com/Tencent/tdesign-react/pull/2316))
 
 ### 🐞 Bug Fixes
+
 - `Slider`: 修复数字输入框 `theme` 固定为 `column` 的问题 @Ali-ovo ([#2289](https://github.com/Tencent/tdesign-react/pull/2289))
 - `Table`: 列宽调整和自定义列共存场景，修复通过自定义列配置表格列数量变少时，表格总宽度无法再恢复变小 @chaishi ([#2325](https://github.com/Tencent/tdesign-react/pull/2325))
 
-## 🌈 1.1.11 `2023-06-20` 
+## 🌈 1.1.11 `2023-06-20`
+
 ### 🐞 Bug Fixes
+
 - `Table`: @chaishi ([#2297](https://github.com/Tencent/tdesign-react/pull/2297))
-    - 可拖拽调整列宽场景，修复 `resizable=false` 无效问题，默认值为 false
-    - 本地数据排序场景，修复异步拉取数据时，取消排序数据会导致空列表问题
-    - 修复固定表格 + 固定列 + 虚拟滚动场景，表头不对齐问题
-    - 可编辑单元格/可编辑行场景，修复数据始终校验上一个值问题，调整为校验最新输入值
-    - 修复本地数据排序，多字段排序场景，示例代码缺失问题
+  - 可拖拽调整列宽场景，修复 `resizable=false` 无效问题，默认值为 false
+  - 本地数据排序场景，修复异步拉取数据时，取消排序数据会导致空列表问题
+  - 修复固定表格 + 固定列 + 虚拟滚动场景，表头不对齐问题
+  - 可编辑单元格/可编辑行场景，修复数据始终校验上一个值问题，调整为校验最新输入值
+  - 修复本地数据排序，多字段排序场景，示例代码缺失问题
 - `ColorPicker`: @uyarn ([#2301](https://github.com/Tencent/tdesign-react/pull/2301))
-    - 初始化为渐变模式时，支持空字符串作为初始值
-    - 修复 `recentColors` 等字段的类型问题
-    - 修复内部下拉选项未透传 `popupProps` 的缺陷
+  - 初始化为渐变模式时，支持空字符串作为初始值
+  - 修复 `recentColors` 等字段的类型问题
+  - 修复内部下拉选项未透传 `popupProps` 的缺陷
 
+## 🌈 1.1.10 `2023-06-13`
 
-## 🌈 1.1.10 `2023-06-13` 
 ### 🚀 Features
+
 - `Menu`:
-    - `Submenu` 新增 `popupProps` 属性，允许透传设置底层 Popup 弹窗属性 @xiaosansiji ([#2284](https://github.com/Tencent/tdesign-react/pull/2284))
-    - 弹出菜单使用 Popup 重构 @xiaosansiji ([#2274](https://github.com/Tencent/tdesign-react/pull/2274))
+  - `Submenu` 新增 `popupProps` 属性，允许透传设置底层 Popup 弹窗属性 @xiaosansiji ([#2284](https://github.com/Tencent/tdesign-react/pull/2284))
+  - 弹出菜单使用 Popup 重构 @xiaosansiji ([#2274](https://github.com/Tencent/tdesign-react/pull/2274))
 
 ### 🐞 Bug Fixes
+
 - `InputNumber`: 初始值为 `undefined` / `null`，且存在 `decimalPlaces` 时，不再进行小数点纠正 @chaishi ([#2273](https://github.com/Tencent/tdesign-react/pull/2273))
 - `Select`: 修复 `onBlur` 方法回调参数异常的问题 @Ali-ovo ([#2281](https://github.com/Tencent/tdesign-react/pull/2281))
 - `Dialog`: 修复在 SSR 环境下报错 @night-c ([#2280](https://github.com/Tencent/tdesign-react/pull/2280))
 - `Table`: 修复组件设置 `expandOnRowClick` 为 `true` 时，点击整行报错 @pe-3 ([#2275](https://github.com/Tencent/tdesign-react/pull/2275))
 
-## 🌈 1.1.9 `2023-06-06` 
+## 🌈 1.1.9 `2023-06-06`
+
 ### 🚀 Features
+
 - `DatePicker`: 支持 `onConfirm` 事件 @honkinglin ([#2260](https://github.com/Tencent/tdesign-react/pull/2260))
 - `Menu`: 优化侧边导航菜单收起时，`Tooltip` 展示菜单内容 @xiaosansiji ([#2263](https://github.com/Tencent/tdesign-react/pull/2263))
 - `Swiper`: navigation 类型支持 `dots` `dots-bar` @carolin913 ([#2246](https://github.com/Tencent/tdesign-react/pull/2246))
 - `Table`: 新增 `onColumnResizeChange` 事件 @honkinglin ([#2262](https://github.com/Tencent/tdesign-react/pull/2262))
 
 ### 🐞 Bug Fixes
+
 - `TreeSelect`: 修复 `keys` 属性没有透传给 `Tree` 的问题 @uyarn ([#2267](https://github.com/Tencent/tdesign-react/pull/2267))
-- `InputNumber`:  修复部分小数点数字无法输入问题 @chaishi ([#2264](https://github.com/Tencent/tdesign-react/pull/2264))
+- `InputNumber`: 修复部分小数点数字无法输入问题 @chaishi ([#2264](https://github.com/Tencent/tdesign-react/pull/2264))
 - `ImageViewer`: 修复触控板缩放操作异常问题 @honkinglin ([#2265](https://github.com/Tencent/tdesign-react/pull/2265))
 - `TreeSelect`: 修复当 `label` 是 `reactNode` 场景下展示问题 @Ali-ovo ([#2258](https://github.com/Tencent/tdesign-react/pull/2258))
 
-## 🌈 1.1.8 `2023-05-25` 
+## 🌈 1.1.8 `2023-05-25`
+
 ### 🚀 Features
+
 - `TimePicker`: 没有选中值时不允许点击确认按钮 @uyarn ([#2240](https://github.com/Tencent/tdesign-react/pull/2240))
 
 ### 🐞 Bug Fixes
+
 - `Form`: 修复 `FormList` 数据透传问题 @honkinglin ([#2239](https://github.com/Tencent/tdesign-react/pull/2239))
 
-## 🌈 1.1.7 `2023-05-19` 
+## 🌈 1.1.7 `2023-05-19`
+
 ### 🐞 Bug Fixes
+
 - `Tooltip`: 修复箭头偏移问题 @uyarn ([#1347](https://github.com/Tencent/tdesign-common/pull/1347))
 
-## 🌈 1.1.6 `2023-05-18` 
+## 🌈 1.1.6 `2023-05-18`
+
 ### 🚀 Features
+
 - `TreeSelect`: 支持 `panelConent` API @ArthurYung ([#2182](https://github.com/Tencent/tdesign-react/pull/2182))
 
 ### 🐞 Bug Fixes
+
 - `Select`: 修复可创建重复 label 的选项的缺陷 @uyarn ([#2221](https://github.com/Tencent/tdesign-react/pull/2221))
 - `Skeleton`: 修复使用 `rowCol` 时额外多渲染一行 theme 的缺陷 @uyarn ([#2223](https://github.com/Tencent/tdesign-react/pull/2223))
 - `Form`:
-    - 修复异步渲染使用 `useWatch` 报错问题 @honkinglin ([#2220](https://github.com/Tencent/tdesign-react/pull/2220))
-    - 修复 `FormList` 初始值赋值失效问题 @honkinglin ([#2222](https://github.com/Tencent/tdesign-react/pull/2222))
+  - 修复异步渲染使用 `useWatch` 报错问题 @honkinglin ([#2220](https://github.com/Tencent/tdesign-react/pull/2220))
+  - 修复 `FormList` 初始值赋值失效问题 @honkinglin ([#2222](https://github.com/Tencent/tdesign-react/pull/2222))
 
-## 🌈 1.1.5 `2023-05-10` 
+## 🌈 1.1.5 `2023-05-10`
+
 ### 🚀 Features
+
 - `Cascader`: 支持 `suffix`、`suffixIcon` @honkinglin ([#2200](https://github.com/Tencent/tdesign-react/pull/2200))
 
 ### 🐞 Bug Fixes
-- `SelectInput`: 修复 `loading` 在 `disabled` 状态下隐藏问题  @honkinglin ([#2196](https://github.com/Tencent/tdesign-react/pull/2196))
+
+- `SelectInput`: 修复 `loading` 在 `disabled` 状态下隐藏问题 @honkinglin ([#2196](https://github.com/Tencent/tdesign-react/pull/2196))
 - `Image`: 修复组件不支持 `ref` 的问题 @li-jia-nan ([#2198](https://github.com/Tencent/tdesign-react/pull/2198))
 - `BackTop`: 支持 `ref` 透传 @li-jia-nan ([#2202](https://github.com/Tencent/tdesign-react/pull/2202))
 
-## 🌈 1.1.4 `2023-04-27` 
+## 🌈 1.1.4 `2023-04-27`
+
 ### 🚀 Features
+
 - `Select`: 支持 `panelTopContent` 在虚拟滚动等需要滚动下拉框场景的使用，具体使用方式请看示例 @uyarn ([#2184](https://github.com/Tencent/tdesign-react/pull/2184))
 
 ### 🐞 Bug Fixes
+
 - `DatePicker`: 修复第二次点击面板关闭异常问题 @honkinglin ([#2183](https://github.com/Tencent/tdesign-react/pull/2183))
 - `Table`: 修复 `useResizeObserver` ssr error @chaishi ([#2175](https://github.com/Tencent/tdesign-react/pull/2175))
 
-## 🌈 1.1.3 `2023-04-21` 
+## 🌈 1.1.3 `2023-04-21`
+
 ### 🚀 Features
+
 - `DatePicker`: 支持 `onPresetClick` 事件 @honkinglin ([#2165](https://github.com/Tencent/tdesign-react/pull/2165))
 - `Switch`: `onChange` 支持返回 `event` 参数 @carolin913 ([#2162](https://github.com/Tencent/tdesign-react/pull/2162))
 - `Collapse`: `onChange` 支持返回 `event` 参数 @carolin913 ([#2162](https://github.com/Tencent/tdesign-react/pull/2162))
+
 ### 🐞 Bug Fixes
-- `Form`: 
-    - 修复主动 reset 不触发 `onReset` 逻辑 @honkinglin ([#2150](https://github.com/Tencent/tdesign-react/pull/2150))
-    - 修复 `onValuesChange` 事件返回参数问题 @honkinglin ([#2169](https://github.com/Tencent/tdesign-react/pull/2169))
+
+- `Form`:
+  - 修复主动 reset 不触发 `onReset` 逻辑 @honkinglin ([#2150](https://github.com/Tencent/tdesign-react/pull/2150))
+  - 修复 `onValuesChange` 事件返回参数问题 @honkinglin ([#2169](https://github.com/Tencent/tdesign-react/pull/2169))
 - `Select`: 修复多选模式 `size` 属性未生效的问题 @uyarn ([#2163](https://github.com/Tencent/tdesign-react/pull/2163))
 - `Collapse`:
-    - 修复 `Radio` 禁用判断 @duanbaosheng ([#2161](https://github.com/Tencent/tdesign-react/pull/2161))
-    - 修复 `value` 有默认值时受控问题 @moecasts ([#2152](https://github.com/Tencent/tdesign-react/pull/2152))
+  - 修复 `Radio` 禁用判断 @duanbaosheng ([#2161](https://github.com/Tencent/tdesign-react/pull/2161))
+  - 修复 `value` 有默认值时受控问题 @moecasts ([#2152](https://github.com/Tencent/tdesign-react/pull/2152))
 - `Icon`: 修复 manifest 统一入口导出 esm 模块，文档为及时更新的问题 @Layouwen ([#2160](https://github.com/Tencent/tdesign-react/pull/2160))
 
-## 🌈 1.1.2 `2023-04-13` 
+## 🌈 1.1.2 `2023-04-13`
+
 ### 🚀 Features
+
 - `DatePicker`: 优化周选择器高亮判断逻辑性能问题 @honkinglin ([#2136](https://github.com/Tencent/tdesign-react/pull/2136))
+
 ### 🐞 Bug Fixes
-- `Dialog`: 
-    - 修复设置 style width 不生效问题 @honkinglin ([#2132](https://github.com/Tencent/tdesign-react/pull/2132))
-    - 修复 footer 渲染 null 问题 @honkinglin ([#2131](https://github.com/Tencent/tdesign-react/pull/2131))
+
+- `Dialog`:
+  - 修复设置 style width 不生效问题 @honkinglin ([#2132](https://github.com/Tencent/tdesign-react/pull/2132))
+  - 修复 footer 渲染 null 问题 @honkinglin ([#2131](https://github.com/Tencent/tdesign-react/pull/2131))
 - `Select`: 修复多选分组展示样式异常的问题 @uyarn ([#2138](https://github.com/Tencent/tdesign-react/pull/2138))
-- `Popup`: 
-    - 修复 windows 下 scrollTop 出现小数导致判断滚动底部失效 @honkinglin ([#2142](https://github.com/Tencent/tdesign-react/pull/2142))
-    - 修复临界点初次定位问题 @honkinglin ([#2134](https://github.com/Tencent/tdesign-react/pull/2134))
+- `Popup`:
+  - 修复 windows 下 scrollTop 出现小数导致判断滚动底部失效 @honkinglin ([#2142](https://github.com/Tencent/tdesign-react/pull/2142))
+  - 修复临界点初次定位问题 @honkinglin ([#2134](https://github.com/Tencent/tdesign-react/pull/2134))
 - `ColorPicker`: 修复 Frame 中无法拖拽饱和度和 slider 的问题 @insekkei ([#2140](https://github.com/Tencent/tdesign-react/pull/2140))
 
-## 🌈 1.1.1 `2023-04-06` 
+## 🌈 1.1.1 `2023-04-06`
+
 ### 🚀 Features
+
 - `StickyTool`: 新增`sticky-tool`组件 @ZekunWu ([#2065](https://github.com/Tencent/tdesign-react/pull/2065))
 
 ### 🐞 Bug Fixes
+
 - `TagInput`: 修复基于`TagInput`的组件使用筛选时删除关键词时会删除已选值的问题 @2513483494 ([#2113](https://github.com/Tencent/tdesign-react/pull/2113))
-- `InputNumber`: 修复输入小数以0结尾时的功能异常问题 @uyarn ([#2127](https://github.com/Tencent/tdesign-react/pull/2127))
+- `InputNumber`: 修复输入小数以 0 结尾时的功能异常问题 @uyarn ([#2127](https://github.com/Tencent/tdesign-react/pull/2127))
 - `Tree`: 修复组件的 data 属性不受控问题 @PBK-B ([#2119](https://github.com/Tencent/tdesign-react/pull/2119))
 - `Form`: 修复初始数据设置问题 @honkinglin ([#2124](https://github.com/Tencent/tdesign-react/pull/2124))
 - `TreeSelect`: 修复过滤后无法展开问题 @honkinglin ([#2128](https://github.com/Tencent/tdesign-react/pull/2128))
 - `Popup`: 修复右键展示浮层触发浏览器默认事件 @honkinglin ([#2120](https://github.com/Tencent/tdesign-react/pull/2120))
 
-## 🌈 1.1.0 `2023-03-30` 
+## 🌈 1.1.0 `2023-03-30`
+
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2089](https://github.com/Tencent/tdesign-react/pull/2089))
-    - 支持使用 `filterIcon` 支持不同列显示不同的筛选图标
-    - 支持横向滚动到固定列
+  - 支持使用 `filterIcon` 支持不同列显示不同的筛选图标
+  - 支持横向滚动到固定列
 - `Button`: 支持禁用态不触发 href 跳转逻辑 @honkinglin ([#2095](https://github.com/Tencent/tdesign-react/pull/2095))
-- `BackTop`: 新增 BackTop 组件  @meiqi502 ([#2037](https://github.com/Tencent/tdesign-react/pull/2037))
+- `BackTop`: 新增 BackTop 组件 @meiqi502 ([#2037](https://github.com/Tencent/tdesign-react/pull/2037))
 - `Form`: submit 支持返回数据 @honkinglin ([#2096](https://github.com/Tencent/tdesign-react/pull/2096))
 
 ### 🐞 Bug Fixes
+
 - `Table`: @chaishi ([#2089](https://github.com/Tencent/tdesign-react/pull/2089))
-    - 修复 SSR 环境中，document is not undefined 问题
-    - 修复在列显示控制场景中，无法拖拽交换列顺序问题 
-    - 单行选中功能，修复 `allowUncheck: false` 无效问题
+  - 修复 SSR 环境中，document is not undefined 问题
+  - 修复在列显示控制场景中，无法拖拽交换列顺序问题
+  - 单行选中功能，修复 `allowUncheck: false` 无效问题
 - `Dialog`: 修复 Dialog onOpen 事件调用时机问题 @honkinglin ([#2090](https://github.com/Tencent/tdesign-react/pull/2090))
-- `DatePicker`: 修复 `format` 为12小时制时功能异常的问题 @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
-- `Alert`: 修复关闭按钮为文字时的居中和字体大小问题 @Wen1kang  @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
+- `DatePicker`: 修复 `format` 为 12 小时制时功能异常的问题 @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
+- `Alert`: 修复关闭按钮为文字时的居中和字体大小问题 @Wen1kang @uyarn ([#2100](https://github.com/Tencent/tdesign-react/pull/2100))
 - `Watermark`: 修复 `Loading` 组合使用问题 @duanbaosheng ([#2094](https://github.com/Tencent/tdesign-react/pull/2094))
 - `Notification`: 修复获取实例问题 @honkinglin ([#2103](https://github.com/Tencent/tdesign-react/pull/2103))
 - `Radio`: 修复 ts 类型问题 @honkinglin ([#2102](https://github.com/Tencent/tdesign-react/pull/2102))
 
+## 🌈 1.0.5 `2023-03-23`
 
-## 🌈 1.0.5 `2023-03-23` 
 ### 🚀 Features
+
 - `TimePicker`: 新增 `size` API , 用于控制时间输入框大小 @uyarn ([#2081](https://github.com/Tencent/tdesign-react/pull/2081))
 
 ### 🐞 Bug Fixes
+
 - `Form`: 修复 `FormList` 初始数据获取问题 @honkinglin ([#2067](https://github.com/Tencent/tdesign-react/pull/2067))
 - `Watermark`: 修复 NextJS 中 document undefined 的问题 @carolin913 ([#2073](https://github.com/Tencent/tdesign-react/pull/2073))
 - `ColorPicker`: @insekkei ([#2074](https://github.com/Tencent/tdesign-react/pull/2074))
-    - 修复 HEX 色值无法手动输入的问题
-    - 修复最近使用颜色无法删除的问题
+  - 修复 HEX 色值无法手动输入的问题
+  - 修复最近使用颜色无法删除的问题
 - `Dialog`: 修复`onCloseBtnClick`事件无效的问题 @ArthurYung ([#2080](https://github.com/Tencent/tdesign-react/pull/2080))
 - `BreadCrumb`: 修复通过 options 属性无法配置 Icon 的问题 @uyarn ([#2081](https://github.com/Tencent/tdesign-react/pull/2081))
 
+## 🌈 1.0.4 `2023-03-16`
 
-## 🌈 1.0.4 `2023-03-16` 
 ### 🚀 Features
+
 - `Table`: @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
-    - 列宽调整功能，更新列宽调整规则为：列宽较小没有超出时，列宽调整表现为当前列和相邻列的变化；列宽超出存在横向滚动条时，列宽调整仅影响当前列和列总宽
-    - 可编辑单元格(行)功能，支持编辑模式下，数据变化时实时校验，`col.edit.validateTrigger`
-    - 只有固定列存在时，才会出现类名 `.t-table__content--scrollable-to-left` 和 `.t-table__content--scrollable-to-right`
-    - 拖拽功能，支持禁用固定列不可拖拽调整顺序
+  - 列宽调整功能，更新列宽调整规则为：列宽较小没有超出时，列宽调整表现为当前列和相邻列的变化；列宽超出存在横向滚动条时，列宽调整仅影响当前列和列总宽
+  - 可编辑单元格(行)功能，支持编辑模式下，数据变化时实时校验，`col.edit.validateTrigger`
+  - 只有固定列存在时，才会出现类名 `.t-table__content--scrollable-to-left` 和 `.t-table__content--scrollable-to-right`
+  - 拖拽功能，支持禁用固定列不可拖拽调整顺序
 - `Upload`: `theme=file-input` 文件为空时，悬浮时不显示清除按钮 @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
 - `InputNumber`: 支持千分位粘贴 @uyarn ([#2058](https://github.com/Tencent/tdesign-react/pull/2058))
 - `DatePicker`: 支持 `size` 属性 @honkinglin ([#2055](https://github.com/Tencent/tdesign-react/pull/2055))
+
 ### 🐞 Bug Fixes
+
 - `Form`: 修复重置默认值数据类型错误 @honkinglin ([#2046](https://github.com/Tencent/tdesign-react/pull/2046))
 - `TimelineItem`: 修复导出类型 @southorange0929 ([#2053](https://github.com/Tencent/tdesign-react/pull/2053))
 - `Table`: @chaishi ([#2047](https://github.com/Tencent/tdesign-react/pull/2047))
-    - 修复表格宽度抖动问题 
-    - 列宽调整功能，修复 Dialog 中列宽调整问题
-    - 可编辑单元格，修复下拉选择类组件 `abortEditOnEvent` 没有包含 `onChange` 时，依然会在数据变化时触发退出编辑态问题
+  - 修复表格宽度抖动问题
+  - 列宽调整功能，修复 Dialog 中列宽调整问题
+  - 可编辑单元格，修复下拉选择类组件 `abortEditOnEvent` 没有包含 `onChange` 时，依然会在数据变化时触发退出编辑态问题
 - `Table`: 修复 lazy-load reset bug @MrWeilian ([#2041](https://github.com/Tencent/tdesign-react/pull/2041))
 - `ColorPicker`: 修复输入框无法输入的问题 @insekkei ([#2061](https://github.com/Tencent/tdesign-react/pull/2061))
 - `Affix`: 修复 fixed 判断问题 @lio-mengxiang ([#2048](https://github.com/Tencent/tdesign-react/pull/2048))
 
-## 🌈 1.0.3 `2023-03-09` 
+## 🌈 1.0.3 `2023-03-09`
+
 ### 🚀 Features
+
 - `Message`: 鼠标悬停时不自动关闭 @HelKyle ([#2036](https://github.com/Tencent/tdesign-react/pull/2036))
 - `DatePicker`: 支持 `defaultTime` @honkinglin ([#2038](https://github.com/Tencent/tdesign-react/pull/2038))
 
 ### 🐞 Bug Fixes
-- `DatePicker`: 修复月份为0时展示当前月份问题 @honkinglin ([#2032](https://github.com/Tencent/tdesign-react/pull/2032))
+
+- `DatePicker`: 修复月份为 0 时展示当前月份问题 @honkinglin ([#2032](https://github.com/Tencent/tdesign-react/pull/2032))
 - `Upload`: 修复 `upload.method` 无效问题 @i-tengfei ([#2034](https://github.com/Tencent/tdesign-react/pull/2034))
 - `Select`: 修复多选全选初始值为空时选中报错的问题 @uyarn ([#2042](https://github.com/Tencent/tdesign-react/pull/2042))
 - `Dialog`: 修复弹窗垂直居中问题 @KMethod ([#2043](https://github.com/Tencent/tdesign-react/pull/2043))
 
-## 🌈 1.0.2 `2023-03-01` 
+## 🌈 1.0.2 `2023-03-01`
+
 ### 🚀 Features
+
 - `Image`: 图片组件支持特殊格式的地址 `.avif` 和 `.webp` @chaishi ([#2021](https://github.com/Tencent/tdesign-react/pull/2021))
 - `ConfigProvider`: 新增 `Image` 全局配置 `globalConfig.image.replaceImageSrc`，用于统一替换图片地址 @chaishi ([#2021](https://github.com/Tencent/tdesign-react/pull/2021))
 - `List`: `listItemMeta` 支持 `className`、`style` 属性 @honkinglin ([#2005](https://github.com/Tencent/tdesign-react/pull/2005))
 
 ### 🐞 Bug Fixes
+
 - `Form`: @honkinglin ([#2014](https://github.com/Tencent/tdesign-react/pull/2014))
-    - 修复校验信息沿用错误缓存问题
-    - 移除 `FormItem` 多余事件通知逻辑
+  - 修复校验信息沿用错误缓存问题
+  - 移除 `FormItem` 多余事件通知逻辑
 - `Drawer`: 修复拖拽后页面出现滚动条问题 @honkinglin ([#2012](https://github.com/Tencent/tdesign-react/pull/2012))
 - `Input`: 修复异步渲染宽度计算问题 @honkinglin ([#2010](https://github.com/Tencent/tdesign-react/pull/2010))
-- `Textarea`: 调整 limit 展示位置，修复与tips 共存时样式问题 @duanbaosheng ([#2015](https://github.com/Tencent/tdesign-react/pull/2015))
+- `Textarea`: 调整 limit 展示位置，修复与 tips 共存时样式问题 @duanbaosheng ([#2015](https://github.com/Tencent/tdesign-react/pull/2015))
 - `Checkbox`: 修复 ts 类型问题 @NWYLZW ([#2023](https://github.com/Tencent/tdesign-react/pull/2023))
 
+## 🌈 1.0.1 `2023-02-21`
 
-## 🌈 1.0.1 `2023-02-21` 
 ### 🚀 Features
+
 - `Popup`: 新增 `onScrollToBottom` 事件 @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
 - `Select`: @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
-    - 支持虚拟滚动的使用
-    - 支持`autofocus`、`suffix`，`suffixIcon`等API，`onSearch`新增回调参数
-    - Option子组件支持自定义`title`API
-- `Icon`:  加载时注入样式，避免在 next 环境中报错的问题 @uyarn ([#1990](https://github.com/Tencent/tdesign-react/pull/1990))
+  - 支持虚拟滚动的使用
+  - 支持`autofocus`、`suffix`，`suffixIcon`等 API，`onSearch`新增回调参数
+  - Option 子组件支持自定义`title`API
+- `Icon`: 加载时注入样式，避免在 next 环境中报错的问题 @uyarn ([#1990](https://github.com/Tencent/tdesign-react/pull/1990))
 - `Avatar`: 组件内部图片，使用 Image 组件渲染，支持透传 `imageProps` 到 Image 图片组件 @chaishi ([#1993](https://github.com/Tencent/tdesign-react/pull/1993))
 - `DialogPlugin`: 支持自定义 `visbile` @moecasts ([#1998](https://github.com/Tencent/tdesign-react/pull/1998))
 - `Tabs`: 支持拖拽能力 @duanbaosheng ([#1979](https://github.com/Tencent/tdesign-react/pull/1979))
 
 ### 🐞 Bug Fixes
+
 - `Select`: 修复 `onInputchange`触发时机的问题 @uyarn ([#1980](https://github.com/Tencent/tdesign-react/pull/1980))
-- `Radio`: 修复 `disabled` 默认值问题  @honkinglin ([#1977](https://github.com/Tencent/tdesign-react/pull/1977))
+- `Radio`: 修复 `disabled` 默认值问题 @honkinglin ([#1977](https://github.com/Tencent/tdesign-react/pull/1977))
 - `Table`: 确保可编辑单元格保持编辑状态 @moecasts ([#1988](https://github.com/Tencent/tdesign-react/pull/1988))
 - `TagInput`: 修复 `0.45.4` 版本后 `TagInput` 增加 `blur` 行为导致 `Select` / `Cascader` / `TreeSelect` 无法过滤多选的问题 @uyarn ([#1989](https://github.com/Tencent/tdesign-react/pull/1989))
 - `Avatar`: 修复图片无法显示问题 @chaishi ([#1993](https://github.com/Tencent/tdesign-react/pull/1993))
 - `Image`: 修复事件类型问题 @chaishi ([#1993](https://github.com/Tencent/tdesign-react/pull/1993))
 - `Tree`: 修复子节点被折叠后无法被搜索问题 @honkinglin ([#1999](https://github.com/Tencent/tdesign-react/pull/1999))
-- `Popup`:  修复浮层显隐死循环问题 @honkinglin ([#1991](https://github.com/Tencent/tdesign-react/pull/1991))
-- `FormList`:  修复 `onValuesChange` 获取不到最新数据问题 @honkinglin ([#1992](https://github.com/Tencent/tdesign-react/pull/1992))
+- `Popup`: 修复浮层显隐死循环问题 @honkinglin ([#1991](https://github.com/Tencent/tdesign-react/pull/1991))
+- `FormList`: 修复 `onValuesChange` 获取不到最新数据问题 @honkinglin ([#1992](https://github.com/Tencent/tdesign-react/pull/1992))
 - `Drawer`: 修复滚动条检测问题 @honkinglin ([#2001](https://github.com/Tencent/tdesign-react/pull/2001))
 - `Dialog`: 修复滚动条检测问题 @honkinglin ([#2001](https://github.com/Tencent/tdesign-react/pull/2001))
 
-## 🌈 1.0.0 `2023-02-13` 
+## 🌈 1.0.0 `2023-02-13`
+
 ### 🚀 Features
+
 - `Dropdown`: submenu 层级结构调整，增加一层 `t-dropdown__submenu-wrapper` @uyarn ([#1964](https://github.com/Tencent/tdesign-react/pull/1964))
 
 ### 🐞 Bug Fixes
+
 - `Tree`: 修复使用 setItem 设置节点 expanded 时，不触发 `onExpand` 的问题 @genyuMPj ([#1956](https://github.com/Tencent/tdesign-react/pull/1956))
 - `Dropdown`: 修复多层超长菜单的位置异常问题 @uyarn ([#1964](https://github.com/Tencent/tdesign-react/pull/1964))
 
 ## 🌈 0.x `2021-03-26 - 2023-02-08`
+
 前往 [GitHub](https://github.com/Tencent/tdesign-react/blob/develop/packages/tdesign-react/CHANGELOG-0.x.md) 查看 `0.x` 更新日志


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 在 `1.15.9` 中补充日志
  - `Input`: 修正组件及上层 `Select` 等组件在 Safari 中初次渲染 `autoWidth` 失效的问题 @Cat1007 ([common#2336](https://github.com/Tencent/tdesign-common/pull/2336))
 - 把中文日志从 `CRLF` 改为 `LF`（换行符 `\r\n` -> `\n`)，并使用 Prettier 格式化
   - 与 @liweijie0812  已沟通
   <img width="3028" height="932" alt="企业微信截图_35915262-4848-4a5e-87cf-fa0ff302c2fd" src="https://github.com/user-attachments/assets/5da2a807-a8a9-4e8a-8b67-d9b6e08442f6" />
   <img width="200" src="https://github.com/user-attachments/assets/c7a3890f-286b-49a2-a53b-946c80bcbe5c" />

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-react
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
