### PR TITLE
fix(Form): fix React 19 warning when Fragment wraps FormItem children

### DIFF
--- a/packages/components/form/FormItem.tsx
+++ b/packages/components/form/FormItem.tsx
@@ -488,7 +488,9 @@ const FormItem = forwardRef<FormItemInstance, FormItemProps>((originalProps, ref
         <div className={`${classPrefix}-form__controls-content`}>
           {React.Children.map(children, (child, index) => {
             if (!child) return null;
-            if (!React.isValidElement(child)) return child;
+
+            // Fragment can only have `key` and `children` props, skip props injection
+            if (!React.isValidElement(child) || child.type === React.Fragment) return child;
 
             const childType = child.type;
             const isCustomComp = typeof childType === 'object' || typeof childType === 'function';

--- a/packages/tdesign-react/.changelog/pr-4212.md
+++ b/packages/tdesign-react/.changelog/pr-4212.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4212
+contributor: RylanBot
+---
+
+- fix(Form): 修复 React 19 下 Fragment 包裹 FormItem 子元素时产生的警告 @RylanBot ([#4212](https://github.com/Tencent/tdesign-react/pull/4212))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

表单中如果使用了空标签，就会有参数注入到空标签中，导致控制台出现大量警告
- https://codesandbox.io/p/sandbox/tdesign-react-demo-forked-s267lf?file=%2Fsrc%2Fdemo.tsx
<img width="1043" height="116" alt="局部截取_20260413_184359" src="https://github.com/user-attachments/assets/3e359ebf-5718-4627-bf04-fbf208475786" />


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- https://zh-hans.react.dev/warnings/unknown-prop
React 官方没有明确文档变更，但应该是 Fragment props 校验变严格导致的

但找到了不少类似的反馈：
- https://github.com/TanStack/query/discussions/9504
- https://docs.commercetools.com/merchant-center-customizations/releases/2025-06-03-react-19-migration-guide-for-merchant-center-customizations  -> “... wrapping ... with React.Fragment ... now yields a warning”

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
- fix(Form): 修复 React 19 下 Fragment 包裹 FormItem 子元素时产生的警告

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
