### PR TITLE
fix(Tree): do not render title when custom rendering nodes

### DIFF
--- a/packages/components/tree/TreeItem.tsx
+++ b/packages/components/tree/TreeItem.tsx
@@ -25,7 +25,7 @@ import useDraggable from './hooks/useDraggable';
 import { composeRefs } from '../_util/ref';
 import useConfig from '../hooks/useConfig';
 
-import type { CheckboxProps } from '../checkbox'
+import type { CheckboxProps } from '../checkbox';
 import type { TdTreeProps } from './type';
 import type { TreeItemProps } from './interface';
 
@@ -263,14 +263,15 @@ const TreeItem = forwardRef(
           </Checkbox>
         );
       }
+      // 自定义节点（label 为函数或 ReactNode）不展示 title
+      const isCustomLabel = label instanceof Function || isValidElement(node.label);
+
       return (
         <span
           ref={setRefCurrent}
           data-target="label"
           className={labelClasses}
-          // label 可以传入 ReactNode， 如果直接取里面的 children 值，当多层级的时候会有问题
-          // 所以这里判断如果 label是 ReactNode， 并且 text没有值 就不展示 title
-          title={isValidElement(node.label) && !node.data?.text ? '' : String(node.data?.text || node.label)}
+          title={isCustomLabel ? undefined : String(node.data?.text || node.label || '')}
         >
           <span style={{ position: 'relative' }}>{labelText}</span>
         </span>

--- a/packages/tdesign-react/.changelog/pr-4234.md
+++ b/packages/tdesign-react/.changelog/pr-4234.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4234
+contributor: uyarn
+---
+
+- fix(Tree): 当自定义渲染节点时不渲染默认 title @uyarn ([#4234](https://github.com/Tencent/tdesign-react/pull/4234))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Tree): 当自定义渲染节点时不渲染默认 title
#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
