### PR TITLE
fix(table): skip checkProps disabled rows on select all

### DIFF
--- a/packages/components/table/__tests__/row.events.test.tsx
+++ b/packages/components/table/__tests__/row.events.test.tsx
@@ -96,3 +96,28 @@ TABLES.forEach((TTable) => {
     });
   });
 });
+
+describe('PrimaryTable row selection', () => {
+  it('select all skips rows disabled by checkProps', () => {
+    const fn = vi.fn();
+    const columns = [
+      {
+        colKey: 'row-select',
+        type: 'multiple' as const,
+        checkProps: ({ row }) => ({ disabled: row.index === 101 }),
+      },
+      ...SIMPLE_COLUMNS,
+    ];
+
+    const { container } = render(
+      <PrimaryTable rowKey="index" data={data} columns={columns} selectedRowKeys={[]} onSelectChange={fn} />,
+    );
+
+    fireEvent.click(container.querySelector('thead .t-checkbox'));
+
+    expect(fn).toHaveBeenCalledWith(
+      [100, 102, 103, 104],
+      expect.objectContaining({ currentRowKey: 'CHECK_ALL_BOX', type: 'check' }),
+    );
+  });
+});

--- a/packages/components/table/hooks/useRowSelect.tsx
+++ b/packages/components/table/hooks/useRowSelect.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState, MouseEvent, useMemo } from 'react';
 import { intersection, get, isFunction } from 'lodash-es';
-import { isRowSelectedDisabled } from '@tdesign/common-js/table/utils';
 import log from '@tdesign/common-js/log/index';
 import useControlled from '../../hooks/useControlled';
 import {
@@ -31,7 +30,8 @@ export default function useRowSelect(
   const [tSelectedRowKeys, setTSelectedRowKeys] = useControlled(props, 'selectedRowKeys', props.onSelectChange, {
     defaultSelectedRowKeys: props.defaultSelectedRowKeys || [],
   });
-  const selectColumn = columns.find(({ type }) => ['multiple', 'single'].includes(type));
+  const selectColumnIndex = columns.findIndex(({ type }) => ['multiple', 'single'].includes(type));
+  const selectColumn = columns[selectColumnIndex];
 
   const canSelectedRows = useMemo(() => {
     const currentData = reserveSelectedRowOnPaginate ? data : currentPaginateData;
@@ -78,7 +78,8 @@ export default function useRowSelect(
   );
 
   function isDisabled(row: Record<string, any>, rowIndex: number): boolean {
-    return isRowSelectedDisabled(selectColumn, row, rowIndex);
+    if (!selectColumn) return false;
+    return getRowSelectDisabledData({ row, rowIndex, col: selectColumn, colIndex: selectColumnIndex }).disabled;
   }
 
   function getSelectedHeader() {
@@ -109,7 +110,7 @@ export default function useRowSelect(
     const disabled: boolean = typeof col.disabled === 'function' ? col.disabled({ row, rowIndex }) : col.disabled;
     const checkProps = isFunction(col.checkProps) ? col.checkProps({ row, rowIndex }) : col.checkProps;
     return {
-      disabled: disabled || checkProps?.disabled,
+      disabled: Boolean(disabled || checkProps?.disabled),
       checkProps,
     };
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

Fixes #3976

### 💡 需求背景和解决方案

Table 多选列的行 checkbox 已经会读取 `checkProps.disabled`，但表头全选计算可选行时只过滤了 `column.disabled`，导致点击全选时仍会把通过 `checkProps.disabled` 禁用的行加入 `selectedRowKeys`。

本 PR 将全选可选行判断复用行选择单元格的禁用判断，确保 `column.disabled` 和 `checkProps.disabled` 行为一致，并补充回归测试。

### 📝 更新日志

- fix(Table): 表格全选跳过通过 `checkProps.disabled` 禁用的行

### ☑️ 请求合并前的自查清单

- [x] `pnpm exec vitest run packages/components/table/__tests__/row.events.test.tsx --testNamePattern "select all skips rows disabled by checkProps"`
- [x] `pnpm exec vitest run packages/components/table/__tests__/row.events.test.tsx`
- [x] `pnpm exec eslint packages/components/table/hooks/useRowSelect.tsx packages/components/table/__tests__/row.events.test.tsx --max-warnings 0`
- [x] `pnpm run lint:tsc`