### PR TITLE
fix(Form): outer component  being incorrectly triggered by nested component

### DIFF
--- a/packages/components/form/Form.tsx
+++ b/packages/components/form/Form.tsx
@@ -66,7 +66,15 @@ const Form = forwardRefWithStatics(
       form?.getInternalHooks?.(HOOK_MARK)?.flashQueue?.();
     }, [form]);
 
+    // Dialog / Popup 等通过 Portal 渲染时，DOM 已脱离外层 Form，但 React 合成事件仍沿 Fiber 树冒泡
+    // 会导致内层 Form 的 reset / submit 误触发外层 Form 的处理逻辑
+    // 这里过滤掉来自嵌套 Form 的伪冒泡事件
+    function isEventFromSelf(e: React.FormEvent<HTMLFormElement>) {
+      return e?.target === formRef.current;
+    }
+
     function onResetHandler(e: React.FormEvent<HTMLFormElement>) {
+      if (!isEventFromSelf(e)) return;
       [...formMapRef.current.values()].forEach((formItemRef) => {
         formItemRef?.current.resetField();
       });
@@ -74,6 +82,11 @@ const Form = forwardRefWithStatics(
       form.store = {};
       floatingFormDataRef.current = {};
       onReset?.({ e });
+    }
+
+    function onSubmitHandler(e: React.FormEvent<HTMLFormElement>) {
+      if (!isEventFromSelf(e)) return;
+      formInstance.submit(e);
     }
 
     function onFormItemValueChange(changedValue: Record<string, unknown>) {
@@ -112,7 +125,7 @@ const Form = forwardRefWithStatics(
           id={id}
           style={style}
           className={formClass}
-          onSubmit={formInstance.submit}
+          onSubmit={onSubmitHandler}
           onReset={onResetHandler}
         >
           {children}

--- a/packages/tdesign-react/.changelog/pr-4243.md
+++ b/packages/tdesign-react/.changelog/pr-4243.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4243
+contributor: RylanBot
+---
+
+- fix(Form): 修复 Portal 场景下，内部组件的 `reset` 和 `submit` 事件冒泡导致外层组件事件被误触发的问题 @RylanBot ([#4243](https://github.com/Tencent/tdesign-react/pull/4243))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-react/issues/4242

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
- fix(Form): 修复 Portal 场景下，内部组件的 `reset` 和 `submit` 事件冒泡导致外层组件事件被误触发的问题

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
