### PR TITLE
fix(Tabs): avoid ripple when `disabled`

### DIFF
--- a/packages/components/tabs/TabNavItem.tsx
+++ b/packages/components/tabs/TabNavItem.tsx
@@ -54,7 +54,7 @@ const TabNavItem: React.FC<TabNavItemProps> = (props) => {
 
   // 斜八度动画
   const [navItemDom, setRefCurrent] = useDomRefCallback();
-  useRipple(navItemDom);
+  useRipple(disabled ? null : navItemDom);
   return (
     <div
       {...dragProps}

--- a/packages/tdesign-react/.changelog/pr-4264.md
+++ b/packages/tdesign-react/.changelog/pr-4264.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4264
+contributor: RylanBot
+---
+
+- fix(Tabs): 修复 `disabled` 时，点击组件还会触发动画效果的问题 @RylanBot ([#4264](https://github.com/Tencent/tdesign-react/pull/4264))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
- fix(Tabs): 修复 `disabled` 时，点击组件还会触发动画效果的问题

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
