### PR TITLE
feat(TagInput): support tagDisplay API

### DIFF
--- a/packages/components/tag-input/defaultProps.ts
+++ b/packages/components/tag-input/defaultProps.ts
@@ -8,6 +8,7 @@ export const tagInputDefaultProps: TdTagInputProps = {
   autoWidth: false,
   borderless: false,
   clearable: false,
+  disabled: undefined,
   dragSort: false,
   excessTagsDisplayType: 'break-line',
   defaultInputValue: '',

--- a/packages/components/tag-input/tag-input.en-US.md
+++ b/packages/components/tag-input/tag-input.en-US.md
@@ -12,7 +12,7 @@ autoWidth | Boolean | false | \- | N
 borderless | Boolean | false | \- | N
 clearable | Boolean | false | \- | N
 collapsedItems | TElement | - | Typescript: `TNode<{ value: TagInputValue; collapsedSelectedItems: TagInputValue; count: number; onClose: (context: { index: number,  e?: MouseEvent }) => void }>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-disabled | Boolean | - | \- | N
+disabled | Boolean | undefined | \- | N
 dragSort | Boolean | false | \- | N
 excessTagsDisplayType | String | break-line | options: scroll/break-line | N
 inputProps | Object | - | Typescript: `InputProps`，[Input API Documents](./input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N
@@ -20,16 +20,16 @@ inputValue | String / Number | '' | input value。Typescript: `string` | N
 defaultInputValue | String / Number | '' | input value。uncontrolled property。Typescript: `string` | N
 label | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 max | Number | - | max tag number | N
-maxRows | Number | - | max tag rows | N
 minCollapsedNum | Number | 0 | \- | N
 placeholder | String | undefined | placeholder description | N
-prefixIcon | TElement | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-readOnly | Boolean | false | \- | N
-size | String | medium | options: small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+prefixIcon | TElement | - | Typescript: `TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+readonly | Boolean | undefined | \- | N
+size | String | medium | options: small/medium/large。Typescript: `SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 status | String | - | options: default/success/warning/error | N
 suffix | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 suffixIcon | TElement | - | Typescript: `TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 tag | TNode | - | Typescript: `string \| TNode<{ value: string \| number }>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+tagDisplay | Function | - | Typescript: `TNode<{ value: string \| number; index: number; onClose: (context?: { e?: MouseEvent }) => void; }>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 tagProps | Object | - | Typescript: `TagProps`，[Tag API Documents](./tag?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N
 tips | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 value | Array | [] | value。Typescript: `TagInputValue` `type TagInputValue = Array<string \| number>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N

--- a/packages/components/tag-input/tag-input.en-US.md
+++ b/packages/components/tag-input/tag-input.en-US.md
@@ -23,7 +23,7 @@ max | Number | - | max tag number | N
 minCollapsedNum | Number | 0 | \- | N
 placeholder | String | undefined | placeholder description | N
 prefixIcon | TElement | - | Typescript: `TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-readonly | Boolean | undefined | \- | N
+readOnly | Boolean | undefined | \- | N
 size | String | medium | options: small/medium/large。Typescript: `SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 status | String | - | options: default/success/warning/error | N
 suffix | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N

--- a/packages/components/tag-input/tag-input.md
+++ b/packages/components/tag-input/tag-input.md
@@ -20,10 +20,11 @@ inputValue | String / Number | '' | 输入框的值。TS 类型：`string` | N
 defaultInputValue | String / Number | '' | 输入框的值。非受控属性。TS 类型：`string` | N
 label | TNode | - | 左侧文本。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 max | Number | - | 最大允许输入的标签数量 | N
+maxRows | Number | - | 最大允许显示的行数，超出会出现滚动条，默认为不限制。  | N
 minCollapsedNum | Number | 0 | 最小折叠数量，用于标签数量过多的情况下折叠选中项，超出该数值的选中项折叠。值为 0 则表示不折叠 | N
 placeholder | String | undefined | 占位符 | N
 prefixIcon | TElement | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-readonly | Boolean | undefined | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
+readOnly | Boolean | undefined | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 status | String | - | 输入框状态。可选项：default/success/warning/error | N
 suffix | TNode | - | 后置图标前的后置内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N

--- a/packages/components/tag-input/tag-input.md
+++ b/packages/components/tag-input/tag-input.md
@@ -12,7 +12,7 @@ autoWidth | Boolean | false | 宽度随内容自适应 | N
 borderless | Boolean | false | 无边框模式 | N
 clearable | Boolean | false | 是否可清空 | N
 collapsedItems | TElement | - | 标签过多的情况下，折叠项内容，默认为 `+N`。如果需要悬浮就显示其他内容，可以使用 collapsedItems 自定义。`value` 表示当前存在的所有标签，`collapsedSelectedItems` 表示折叠的标签，`count` 表示折叠的数量，`onClose` 表示移除标签的事件回调。TS 类型：`TNode<{ value: TagInputValue; collapsedSelectedItems: TagInputValue; count: number; onClose: (context: { index: number,  e?: MouseEvent }) => void }>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-disabled | Boolean | - | 是否禁用标签输入框 | N
+disabled | Boolean | undefined | 是否禁用标签输入框 | N
 dragSort | Boolean | false | 拖拽调整标签顺序 | N
 excessTagsDisplayType | String | break-line | 标签超出时的呈现方式，有两种：横向滚动显示 和 换行显示。可选项：scroll/break-line | N
 inputProps | Object | - | 透传 Input 输入框组件全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N
@@ -20,16 +20,16 @@ inputValue | String / Number | '' | 输入框的值。TS 类型：`string` | N
 defaultInputValue | String / Number | '' | 输入框的值。非受控属性。TS 类型：`string` | N
 label | TNode | - | 左侧文本。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 max | Number | - | 最大允许输入的标签数量 | N
-maxRows | Number | - | 最大允许显示的行数，超出会出现滚动条，默认为不限制。  | N
 minCollapsedNum | Number | 0 | 最小折叠数量，用于标签数量过多的情况下折叠选中项，超出该数值的选中项折叠。值为 0 则表示不折叠 | N
 placeholder | String | undefined | 占位符 | N
 prefixIcon | TElement | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
-readOnly | Boolean | false | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
+readonly | Boolean | undefined | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 status | String | - | 输入框状态。可选项：default/success/warning/error | N
 suffix | TNode | - | 后置图标前的后置内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 suffixIcon | TElement | - | 组件后置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 tag | TNode | - | 自定义标签的内部内容，每一个标签的当前值。注意和 `valueDisplay` 区分，`valueDisplay`  是用来定义全部标签内容，而非某一个标签。TS 类型：`string \| TNode<{ value: string \| number }>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+tagDisplay | Function | - | 自定义单个标签的整体节点。TS 类型：`TNode<{ value: string \| number; index: number; onClose: (context?: { e?: MouseEvent }) => void; }>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 tagProps | Object | - | 透传 Tag 组件全部属性。TS 类型：`TagProps`，[Tag API Documents](./tag?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N
 tips | TNode | - | 输入框下方提示文本，会根据不同的 `status` 呈现不同的样式。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 value | Array | [] | 值。TS 类型：`TagInputValue` `type TagInputValue = Array<string \| number>`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/tag-input/type.ts) | N

--- a/packages/components/tag-input/type.ts
+++ b/packages/components/tag-input/type.ts
@@ -6,8 +6,8 @@
 
 import { InputProps } from '../input';
 import { TagProps } from '../tag';
-import { TNode, TElement, SizeEnum } from '../common';
-import { MouseEvent, KeyboardEvent, ClipboardEvent, FocusEvent, FormEvent, CompositionEvent } from 'react';
+import type { TNode, TElement, SizeEnum } from '../common';
+import type { MouseEvent, KeyboardEvent, ClipboardEvent, FocusEvent, FormEvent, CompositionEvent } from 'react';
 
 export interface TdTagInputProps {
   /**
@@ -120,6 +120,10 @@ export interface TdTagInputProps {
    * 自定义标签的内部内容，每一个标签的当前值。注意和 `valueDisplay` 区分，`valueDisplay`  是用来定义全部标签内容，而非某一个标签
    */
   tag?: string | TNode<{ value: string | number }>;
+  /**
+   * 自定义单个标签的整体节点
+   */
+  tagDisplay?: TNode<{ value: string | number; index: number; onClose: (context?: { e?: MouseEvent }) => void }>;
   /**
    * 透传 Tag 组件全部属性
    */

--- a/packages/components/tag-input/useTagList.tsx
+++ b/packages/components/tag-input/useTagList.tsx
@@ -19,7 +19,8 @@ interface TagInputProps extends TdTagInputProps, DragSortInnerProps {
 // handle tag add and remove
 export default function useTagList(props: TagInputProps) {
   const { classPrefix: prefix } = useConfig();
-  const { onRemove, max, minCollapsedNum, size, disabled, tagProps, tag, collapsedItems, getDragProps } = props;
+  const { onRemove, max, minCollapsedNum, size, disabled, tagProps, tag, tagDisplay, collapsedItems, getDragProps } =
+    props;
   const readOnly = props.readOnly || props.readonly;
 
   // handle controlled property and uncontrolled property
@@ -81,11 +82,21 @@ export default function useTagList(props: TagInputProps) {
     const list = displayNode
       ? [<Fragment key="display-node">{displayNode}</Fragment>]
       : newList?.map((item, index) => {
-          const tagContent = isFunction(tag) ? tag({ value: item }) : tag;
           const handleClose = (context) => {
             tagProps?.onClose?.(context);
             onClose({ e: context?.e, index });
           };
+          // tagDisplay 优先级高于 tag
+          // 完全接管单个标签的渲染，组件不再包裹 <Tag> 外壳
+          if (isFunction(tagDisplay)) {
+            const node = tagDisplay({
+              value: item,
+              index,
+              onClose: (context) => handleClose(context ?? {}),
+            });
+            return <Fragment key={index}>{node}</Fragment>;
+          }
+          const tagContent = isFunction(tag) ? tag({ value: item }) : tag;
           return (
             <Tag
               key={index}

--- a/packages/tdesign-react/.changelog/pr-4275.md
+++ b/packages/tdesign-react/.changelog/pr-4275.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4275
+contributor: RylanBot
+---
+
+- feat(TagInput): 支持 `tagDisplay` API @RylanBot ([#4275](https://github.com/Tencent/tdesign-react/pull/4275))

--- a/packages/tdesign-react/.changelog/pr-4275.md
+++ b/packages/tdesign-react/.changelog/pr-4275.md
@@ -3,4 +3,4 @@ pr_number: 4275
 contributor: RylanBot
 ---
 
-- feat(TagInput): 支持 `tagDisplay` API @RylanBot ([#4275](https://github.com/Tencent/tdesign-react/pull/4275))
+- feat(TagInput): 新增 `tagDisplay` API，用于完全自定义单个标签的渲染效果 @RylanBot ([#4275](https://github.com/Tencent/tdesign-react/pull/4275))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-react/issues/4246

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

相关需求：https://stackblitz.com/edit/ecnymvwa?file=src%2Fdemo.tsx,package.json


不过发现一个其它 Bug，动态切换的时候（正常情况不会），`clearable` 图标会遮挡文字...暂时没有排查出修复方法
目前可以通过关闭 `autoWidth`，且设置指定宽度规避这个问题

<img width="300"  src="https://github.com/user-attachments/assets/73cac0e7-64f0-496a-a641-dbeac94be6ed" />

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
- feat(TagInput): 新增 `tagDisplay` API，用于完全自定义单个标签的渲染效果

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
