### PR TITLE
chore: downgrade `react-element-to-jsx-string`

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-element-to-jsx-string": "^17.0.0",
+    "react-element-to-jsx-string": "^15.0.0",
     "react-router-dom": "^6.2.2",
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<img width="500" src="https://github.com/user-attachments/assets/e87f5552-4e89-41ac-8f74-ea457d94778b" />

<img width="500" src="https://github.com/user-attachments/assets/6010affc-e6c4-4521-92f7-457e0f931750" />

在兼容 React 19 的 PR 时候升级了 `react-element-to-jsx-string`
- https://github.com/Tencent/tdesign-react/pull/3438/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R131

站点后续的 React 版本降回了 18，但  `react-element-to-jsx-string` 保持了新版本
- https://github.com/Tencent/tdesign-react/pull/3545/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R129

虽然之前一切正常，但在 1.16.9 和 1.17.0 这段时间内，不确定哪个依赖的变更导致了渲染异常，暂时把 `react-element-to-jsx-string` 回退
- `react-element-to-jsx-string@17.0.x` 的 `peerDependencies` 要求 `react: "^19.0.0"`

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-react
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
