### PR TITLE
feat(message): support theme-aware icon callbacks in message config

### DIFF
--- a/packages/components/message/MessageComponent.tsx
+++ b/packages/components/message/MessageComponent.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { fadeIn } from '@tdesign/common-js/message/index';
 
 import noop from '../_util/noop';
+import parseTNode from '../_util/parseTNode';
 import { usePersistFn } from '../hooks/usePersistFn';
 import MessageClose from './MessageClose';
 import MessageIcon from './MessageIcon';
@@ -84,7 +85,7 @@ const MessageComponent = forwardRef<HTMLDivElement, MessageComponentProps>((prop
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
-      {icon === true ? <MessageIcon theme={theme} /> : icon}
+      {parseTNode(icon, { theme }, <MessageIcon theme={theme} />)}
       {content ? content : children}
       <MessageClose closeBtn={closeBtn} onCloseBtnClick={handleCloseBtnClick} />
     </div>

--- a/packages/components/message/_example/config.tsx
+++ b/packages/components/message/_example/config.tsx
@@ -11,7 +11,7 @@ export default function () {
             placement: 'bottom',
             offset: [200, 200],
             closeBtn: <div>关闭吧！！</div>,
-            icon: <div>icon吧！！</div>,
+            icon: ({ theme }) => <div>{theme} icon 吧！！</div>,
             content: 'content 吧！！',
             style: {
               backgroundColor: 'red',

--- a/packages/components/message/message.en-US.md
+++ b/packages/components/message/message.en-US.md
@@ -10,7 +10,7 @@ style | Object | - | CSS(Cascading Style Sheets)，Typescript: `React.CSSPropert
 closeBtn | TNode | undefined | Typescript: `string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 content | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 duration | Number | 3000 | \- | N
-icon | TNode | true | Typescript: `boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+icon | TNode | true | Typescript: `boolean \| TNode<{ theme: MessageThemeList }>`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 theme | String | info | options：info/success/warning/error/question/loading。Typescript: `MessageThemeList` `type MessageThemeList = 'info' \| 'success' \| 'warning' \| 'error' \| 'question' \| 'loading'`。[see more ts definition](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/message/type.ts) | N
 onClose | Function |  | Typescript: `(context: { trigger: 'close-click' \| 'duration-end', e?: MouseEvent }) => void`<br/>close message event | N
 onCloseBtnClick | Function |  | Typescript: `(context: { e: MouseEvent }) => void`<br/> | N

--- a/packages/components/message/message.md
+++ b/packages/components/message/message.md
@@ -31,7 +31,7 @@ style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
 closeBtn | TNode | undefined | 关闭按钮，可以自定义。值为 true 显示默认关闭按钮，值为 false 不显示关闭按钮。值类型为 string 则直接显示值，如：“关闭”。也可以完全自定义按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 content | TNode | - | 用于自定义消息弹出内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 duration | Number | 3000 | 消息内置计时器，计时到达时会触发 duration-end 事件。单位：毫秒。值为 0 则表示没有计时器 | N
-icon | TNode | true | 用于自定义消息前面的图标，优先级大于 theme 设定的图标。值为 false 则不显示图标，值为 true 显示 theme 设定图标。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
+icon | TNode | true | 用于自定义消息前面的图标，优先级大于 theme 设定的图标。值为 false 则不显示图标，值为 true 显示 theme 设定图标。TS 类型：`boolean \| TNode<{ theme: MessageThemeList }>`。[通用类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/common.ts) | N
 theme | String | info | 消息组件风格。可选项：info/success/warning/error/question/loading。TS 类型：`MessageThemeList` `type MessageThemeList = 'info' \| 'success' \| 'warning' \| 'error' \| 'question' \| 'loading'`。[详细类型定义](https://github.com/Tencent/tdesign-react/blob/develop/packages/components/message/type.ts) | N
 onClose | Function |  | TS 类型：`(context: { trigger: 'close-click' \| 'duration-end', e?: MouseEvent }) => void`<br/>关闭消息时触发 | N
 onCloseBtnClick | Function |  | TS 类型：`(context: { e: MouseEvent }) => void`<br/>当关闭按钮存在时，用户点击关闭按钮触发 | N

--- a/packages/components/message/type.ts
+++ b/packages/components/message/type.ts
@@ -4,8 +4,8 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
-import { TNode, AttachNode } from '../common';
-import { CSSProperties, MouseEvent } from 'react';
+import { TNode, AttachNode } from "../common";
+import { CSSProperties, MouseEvent } from "react";
 
 export interface TdMessageProps {
   /**
@@ -25,7 +25,7 @@ export interface TdMessageProps {
    * 用于自定义消息前面的图标，优先级大于 theme 设定的图标。值为 false 则不显示图标，值为 true 显示 theme 设定图标
    * @default true
    */
-  icon?: TNode;
+  icon?: boolean | TNode<{ theme: MessageThemeList }>;
   /**
    * 消息组件风格
    * @default info
@@ -34,11 +34,16 @@ export interface TdMessageProps {
   /**
    * 关闭消息时触发
    */
-  onClose?: (context: { trigger: 'close-click' | 'duration-end'; e?: MouseEvent<HTMLDivElement> }) => void;
+  onClose?: (context: {
+    trigger: "close-click" | "duration-end";
+    e?: MouseEvent<HTMLDivElement>;
+  }) => void;
   /**
    * 当关闭按钮存在时，用户点击关闭按钮触发
    */
-  onCloseBtnClick?: (context: { e: MouseEvent<SVGElement | HTMLElement> }) => void;
+  onCloseBtnClick?: (context: {
+    e: MouseEvent<SVGElement | HTMLElement>;
+  }) => void;
   /**
    * 计时结束后触发
    */
@@ -76,18 +81,24 @@ export interface MessageOptions extends TdMessageProps {
   zIndex?: number;
 }
 
-export type MessageThemeList = 'info' | 'success' | 'warning' | 'error' | 'question' | 'loading';
+export type MessageThemeList =
+  | "info"
+  | "success"
+  | "warning"
+  | "error"
+  | "question"
+  | "loading";
 
 export type MessagePlacementList =
-  | 'center'
-  | 'top'
-  | 'left'
-  | 'right'
-  | 'bottom'
-  | 'top-left'
-  | 'top-right'
-  | 'bottom-left'
-  | 'bottom-right';
+  | "center"
+  | "top"
+  | "left"
+  | "right"
+  | "bottom"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
 
 export interface MessageInstance {
   close: () => void;
@@ -96,39 +107,39 @@ export interface MessageInstance {
 export type MessageMethod = (
   theme: MessageThemeList,
   message: string | TNode | MessageOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
-export type MessageInfoOptions = Omit<MessageOptions, 'theme'>;
+export type MessageInfoOptions = Omit<MessageOptions, "theme">;
 
 export type MessageInfoMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageErrorMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageWarningMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageSuccessMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageLoadingMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageQuestionMethod = (
   message: string | TNode | MessageInfoOptions,
-  duration?: number,
+  duration?: number
 ) => Promise<MessageInstance>;
 
 export type MessageCloseAllMethod = () => void;


### PR DESCRIPTION
Allow `message.config` to accept icon callbacks that receive the current message theme, so global message icons can be customized dynamically per theme.

re #3804

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#3804
### 其他相关PR
https://github.com/TDesignOteam/tdesign-api/pull/909

### 💡 需求背景和解决方案



<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
Issue #3804 希望 message.config 的全局 icon 配置能够根据当前消息的 theme 动态切换，而不是只能使用单一静态图标。
本次改动在 Message 渲染 icon 时改为通过 parseTNode 解析，并向函数型 icon 传入当前 { theme }。这样既兼容原有用法，也支持按消息类型动态返回图标。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
<!--
- feat(组件名称): 处理问题或特性描述
--> 
feat(message): support theme-aware icon callbacks in message config

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
