### PR TITLE
refactor(chat): migrate to scoped web components

### DIFF
--- a/packages/pro-components/chat/attachments/index.ts
+++ b/packages/pro-components/chat/attachments/index.ts
@@ -1,8 +1,8 @@
-import 'tdesign-web-components/lib/attachments';
+import '@tdesign/web-components-chat/attachments';
 
 import reactify from '../_util/reactify';
 
-import type { TdAttachmentsProps } from 'tdesign-web-components';
+import type { TdAttachmentsProps } from '@tdesign/web-components-chat/attachments';
 
 export const Attachments: React.ForwardRefExoticComponent<
   Omit<TdAttachmentsProps, 'ref'> & React.RefAttributes<HTMLElement | undefined>
@@ -10,4 +10,5 @@ export const Attachments: React.ForwardRefExoticComponent<
 
 export default Attachments;
 
-export type { TdAttachmentItem, TdAttachmentsProps } from 'tdesign-web-components';
+export type { TdAttachmentsProps } from '@tdesign/web-components-chat/attachments';
+export type { TdAttachmentItem } from '@tdesign/web-components-chat/filecard';

--- a/packages/pro-components/chat/chat-actionbar/index.tsx
+++ b/packages/pro-components/chat/chat-actionbar/index.tsx
@@ -1,8 +1,8 @@
-import 'tdesign-web-components/lib/chat-action';
+import '@tdesign/web-components-chat/chat-action';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatActionProps } from 'tdesign-web-components';
+import type { TdChatActionProps } from '@tdesign/web-components-chat/chat-action';
 
 export const ChatActionBar: React.ForwardRefExoticComponent<
   Omit<TdChatActionProps, 'ref'> &
@@ -12,43 +12,4 @@ export const ChatActionBar: React.ForwardRefExoticComponent<
 > = reactify<TdChatActionProps>('t-chat-action');
 
 export default ChatActionBar;
-export type { TdChatActionProps, TdChatActionsName } from 'tdesign-web-components';
-
-// 方案1
-// import { reactifyLazy } from './_util/reactifyLazy';
-// const ChatActionBar = reactifyLazy<{
-//   size: 'small' | 'medium' | 'large',
-//   variant: 'primary' | 'secondary' | 'outline'
-// }>(
-//   't-chat-action',
-//   'tdesign-web-components/esm/chat-action'
-// );
-
-// import ChatAction from 'tdesign-web-components/esm/chat-action';
-// import React, { forwardRef, useEffect } from 'react';
-
-// // 注册Web Components组件
-// const registerChatAction = () => {
-//   if (!customElements.get('t-chat-action')) {
-//     customElements.define('t-chat-action', ChatAction);
-//   }
-// };
-
-// // 在组件挂载时注册
-// const useRegisterWebComponent = () => {
-//   useEffect(() => {
-//     registerChatAction();
-//   }, []);
-// };
-
-// // 使用reactify创建React组件
-// const BaseChatActionBar = reactify<TdChatActionProps>('t-chat-action');
-
-// // 包装组件，确保Web Components已注册
-// export const ChatActionBar2 = forwardRef<
-//   HTMLElement | undefined,
-//   Omit<TdChatActionProps, 'ref'> & { [key: string]: any }
-// >((props, ref) => {
-//   useRegisterWebComponent();
-//   return <BaseChatActionBar {...props} ref={ref} />;
-// });
+export type { TdChatActionProps, TdChatActionsName } from '@tdesign/web-components-chat/chat-action';

--- a/packages/pro-components/chat/chat-filecard/index.ts
+++ b/packages/pro-components/chat/chat-filecard/index.ts
@@ -1,12 +1,12 @@
-import 'tdesign-web-components/lib/filecard';
+import '@tdesign/web-components-chat/filecard';
 
 import reactify from '../_util/reactify';
 
-import type { TdFileCardProps } from 'tdesign-web-components';
+import type { TdFileCardProps } from '@tdesign/web-components-chat/filecard';
 
 export const Filecard: React.ForwardRefExoticComponent<
   Omit<TdFileCardProps, 'ref'> & React.RefAttributes<HTMLElement | undefined>
 > = reactify<TdFileCardProps>('t-filecard');
 
 export default Filecard;
-export type { TdFileCardProps } from 'tdesign-web-components';
+export type { TdFileCardProps } from '@tdesign/web-components-chat/filecard';

--- a/packages/pro-components/chat/chat-loading/index.ts
+++ b/packages/pro-components/chat/chat-loading/index.ts
@@ -1,12 +1,12 @@
-import 'tdesign-web-components/lib/chat-loading';
+import '@tdesign/web-components-chat/chat-loading';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatLoadingProps } from 'tdesign-web-components';
+import type { TdChatLoadingProps } from '@tdesign/web-components-chat/chat-loading';
 
 export const ChatLoading: React.ForwardRefExoticComponent<
   Omit<TdChatLoadingProps, 'ref'> & React.RefAttributes<HTMLElement | undefined>
 > = reactify<TdChatLoadingProps>('t-chat-loading');
 
 export default ChatLoading;
-export type { ChatLoadingAnimationType, TdChatLoadingProps } from 'tdesign-web-components';
+export type { ChatLoadingAnimationType, TdChatLoadingProps } from '@tdesign/web-components-chat/chat-loading';

--- a/packages/pro-components/chat/chat-markdown/index.ts
+++ b/packages/pro-components/chat/chat-markdown/index.ts
@@ -1,16 +1,13 @@
-import { TdMarkdownEngine } from 'tdesign-web-components';
+import { TdMarkdownEngine } from '@tdesign/web-components-chat/chat-message';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatMarkdownContentProps } from 'tdesign-web-components';
+import type { TdChatMarkdownContentProps } from '@tdesign/web-components-chat/chat-message';
 
 export const MarkdownEngine: typeof TdMarkdownEngine = TdMarkdownEngine;
 export const ChatMarkdown: React.ForwardRefExoticComponent<
   Omit<TdChatMarkdownContentProps, 'ref'> & React.RefAttributes<HTMLElement | undefined>
 > = reactify<TdChatMarkdownContentProps>('t-chat-md-content');
 
-// eslint-disable-next-line import/first
-import 'tdesign-web-components/lib/chat-message/content/markdown-content';
-
 export default ChatMarkdown;
-export type { TdChatMarkdownContentProps } from 'tdesign-web-components';
+export type { TdChatMarkdownContentProps } from '@tdesign/web-components-chat/chat-message';

--- a/packages/pro-components/chat/chat-message/index.ts
+++ b/packages/pro-components/chat/chat-message/index.ts
@@ -1,8 +1,8 @@
-import 'tdesign-web-components/lib/chat-message';
+import '@tdesign/web-components-chat/chat-message';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatMessageProps } from 'tdesign-web-components';
+import type { TdChatMessageProps } from '@tdesign/web-components-chat/chat-message';
 
 export const ChatMessage: React.ForwardRefExoticComponent<
   Omit<TdChatMessageProps & React.PropsWithChildren, 'ref'> & React.RefAttributes<HTMLElement | undefined>
@@ -10,4 +10,4 @@ export const ChatMessage: React.ForwardRefExoticComponent<
 
 export default ChatMessage;
 
-export type { TdChatMessageProps } from 'tdesign-web-components';
+export type { TdChatMessageProps } from '@tdesign/web-components-chat/chat-message';

--- a/packages/pro-components/chat/chat-sender/_example/custom.tsx
+++ b/packages/pro-components/chat/chat-sender/_example/custom.tsx
@@ -5,8 +5,8 @@ import { ChatSender } from '@tdesign-react/chat';
 
 import { useDynamicStyle } from '../../_util/useDynamicStyle';
 
+import type { TdAttachmentItem } from '@tdesign/web-components-chat/filecard';
 import type { UploadFile } from 'tdesign-react';
-import type { TdAttachmentItem } from 'tdesign-web-components';
 
 const options = [
   {

--- a/packages/pro-components/chat/chat-sender/index.ts
+++ b/packages/pro-components/chat/chat-sender/index.ts
@@ -1,12 +1,20 @@
-import 'tdesign-web-components/lib/chat-sender';
+import '@tdesign/web-components-chat/chat-sender';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatSenderProps } from 'tdesign-web-components';
+import type { TdChatSenderProps } from '@tdesign/web-components-chat/chat-sender';
 
 export const ChatSender: React.ForwardRefExoticComponent<
   Omit<TdChatSenderProps & React.PropsWithChildren, 'ref'> & React.RefAttributes<HTMLElement | undefined>
 > = reactify<TdChatSenderProps>('t-chat-sender');
 
 export default ChatSender;
-export type * from 'tdesign-web-components/lib/chat-sender/type';
+export type {
+  TdChatSenderAction,
+  TdChatSenderActionName,
+  TdChatSenderApi,
+  TdChatSenderParams,
+  TdChatSenderProps,
+  TdChatSenderUploadProps,
+  UploadActionType,
+} from '@tdesign/web-components-chat/chat-sender';

--- a/packages/pro-components/chat/chat-thinking/_example/style.tsx
+++ b/packages/pro-components/chat/chat-thinking/_example/style.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Space } from 'tdesign-react';
 import { ChatThinking } from '@tdesign-react/chat';
 
-import type { ChatMessageStatus, TdChatThinkContentProps } from 'tdesign-web-components';
+import type { ChatMessageStatus, TdChatThinkContentProps } from '@tdesign/web-components-chat';
 
 const fullText =
   '嗯，用户问牛顿第一定律是不是适用于所有参考系。首先，我得先回忆一下牛顿第一定律的内容。牛顿第一定律，也就是惯性定律，说物体在没有外力作用时会保持静止或匀速直线运动。也就是说，保持原来的运动状态。那问题来了，这个定律是否适用于所有参考系呢？记得以前学过的参考系分惯性系和非惯性系。惯性系里，牛顿定律成立；非惯性系里，可能需要引入惯性力之类的修正。所以牛顿第一定律应该只在惯性参考系中成立，而在非惯性系中不适用，比如加速的电梯或者旋转的参考系，这时候物体会有看似无外力下的加速度，所以必须引入假想的力来解释。';

--- a/packages/pro-components/chat/chat-thinking/index.ts
+++ b/packages/pro-components/chat/chat-thinking/index.ts
@@ -1,8 +1,8 @@
-import 'tdesign-web-components/lib/chat-message/content/thinking-content';
+import '@tdesign/web-components-chat/chat-message';
 
 import reactify from '../_util/reactify';
 
-import type { TdChatThinkContentProps } from 'tdesign-web-components';
+import type { TdChatThinkContentProps } from '@tdesign/web-components-chat/chat-message';
 
 const ChatThinkContent: React.ForwardRefExoticComponent<
   Omit<TdChatThinkContentProps, 'ref'> & React.RefAttributes<HTMLElement | undefined>
@@ -12,4 +12,4 @@ export const ChatThinking = ChatThinkContent;
 
 export default ChatThinking;
 
-export type { TdChatThinkContentProps } from 'tdesign-web-components';
+export type { TdChatThinkContentProps } from '@tdesign/web-components-chat/chat-message';

--- a/packages/pro-components/chat/chatbot/index.ts
+++ b/packages/pro-components/chat/chatbot/index.ts
@@ -1,18 +1,10 @@
-import 'tdesign-web-components/lib/chatbot';
-import 'tdesign-web-components/lib/chat-message/content/reasoning-content';
-import 'tdesign-web-components/lib/chat-message/content/search-content';
-import 'tdesign-web-components/lib/chat-message/content/suggestion-content';
+import '@tdesign/web-components-chat/chat-message';
+import '@tdesign/web-components-chat/chatbot';
 
 import reactify from '../_util/reactify';
 
-import type {
-  TdChatbotApi,
-  TdChatListApi,
-  TdChatListProps,
-  TdChatProps,
-  TdChatSearchContentProps,
-  TdChatSuggestionContentProps,
-} from 'tdesign-web-components';
+import type { TdChatSearchContentProps, TdChatSuggestionContentProps } from '@tdesign/web-components-chat/chat-message';
+import type { TdChatbotApi, TdChatListApi, TdChatListProps, TdChatProps } from '@tdesign/web-components-chat/chatbot';
 
 const ChatBot: React.ForwardRefExoticComponent<
   Omit<TdChatProps & Partial<TdChatbotApi>, 'ref'> & React.RefAttributes<HTMLElement | undefined>
@@ -34,4 +26,22 @@ const ChatList: React.ForwardRefExoticComponent<
 export { ChatBot, ChatList, ChatSearchContent, ChatSuggestionContent };
 
 // 导出类型和工具
-export type * from 'tdesign-web-components/lib/chatbot/type';
+export type {
+  BackBottomParams,
+  FetchSSEOptions,
+  Layout,
+  MetaData,
+  ModelRoleEnum,
+  ScrollPosition,
+  SSEEvent,
+  TdChatbotApi,
+  TdChatCodeProps,
+  TdChatInjectCSS,
+  TdChatListApi,
+  TdChatListProps,
+  TdChatListScrollToOptions,
+  TdChatMessageActionEvent,
+  TdChatMessageConfig,
+  TdChatMessageConfigItem,
+  TdChatProps,
+} from '@tdesign/web-components-chat/chatbot';

--- a/packages/pro-components/chat/style/index.js
+++ b/packages/pro-components/chat/style/index.js
@@ -1,1 +1,1 @@
-import 'tdesign-web-components/lib/style/index.css';
+import '@tdesign/web-components-chat/style/index.css';

--- a/packages/tdesign-react-aigc/package.json
+++ b/packages/tdesign-react-aigc/package.json
@@ -55,8 +55,8 @@
   },
   "dependencies": {
     "@babel/runtime": "~7.26.7",
-    "@tdesign/web-components": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components@409",
-    "@tdesign/web-components-chat": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components-chat@409",
+    "@tdesign/web-components": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components@46aedf9",
+    "@tdesign/web-components-chat": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components-chat@46aedf9",
     "classnames": "~2.5.1",
     "lodash-es": "^4.17.21",
     "react-fast-compare": "^3.2.2",

--- a/packages/tdesign-react-aigc/package.json
+++ b/packages/tdesign-react-aigc/package.json
@@ -55,10 +55,11 @@
   },
   "dependencies": {
     "@babel/runtime": "~7.26.7",
+    "@tdesign/web-components": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components@409",
+    "@tdesign/web-components-chat": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components-chat@409",
     "classnames": "~2.5.1",
     "lodash-es": "^4.17.21",
     "react-fast-compare": "^3.2.2",
-    "tdesign-web-components": "1.3.0-alpha.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- scoped 分包、公开入口和显式类型出口来自 [TDesignOteam/tdesign-web-components#409](https://github.com/TDesignOteam/tdesign-web-components/pull/409)；原 #414 已合并回 #409。

### 💡 需求背景和解决方案

React Chat 仍依赖旧的 `tdesign-web-components@1.3.0-alpha.2`，并直接访问 `lib/...` / `esm/...` 物理路径。本 PR 使用 WebC #409 的 scoped 包完成迁移：

- 迁移到 `@tdesign/web-components` 和 `@tdesign/web-components-chat`。
- 所有运行时和类型导入改用公开根入口或正式 subpath。
- Chat Sender、Chatbot 的 `export type *` 改为显式类型转发。
- 删除 Chat Markdown 的深层副作用导入及相应 `eslint-disable-next-line import/first`。
- 联调依赖固定到 WebC #409 提交 `46aedf9` 的不可变 pkg.pr.new 地址，避免动态 `@409` 地址与缓存、lockfile 产生不可复现结果。

改动前后：

- 前：旧单包、`lib/.../type` 深层路径、宽泛类型转发。
- 后：scoped UI/Chat 包、公开 subpath、显式类型清单、固定 WebC 联调基线。
- React Wrapper 的公开 Props 未主动改变。

重点关注：

- WebC #409 移除的是基础组件入口中重复的 `Td*Props`；本 PR 使用的 `TdChat*` 类型仍保留，因此不需要修改 React Chat Wrapper 源码。
- 首次 Chat Site Preview 发现 WebC 发布包缺失 `MessagePlugin` 运行时导出；已在 WebC #409 修复。
- 当前预览依赖锁定 `46aedf9` 仅用于联调，正式发布前需替换为 WebC scoped 包正式版本。
- 本 PR 不处理 Tree；现阶段继续保留 `tree-v1`，迁移到 common `tree` v2 由独立任务推进。
- Chat 目录目前没有专项单测文件；不将“没有匹配测试”表述为测试通过。

验证结果：

- 使用完整 workspace 安装识别私有 `@tdesign/ai-shared`，不将其错误添加为发布依赖。
- `pnpm run build:aigc` 使用 WebC `46aedf9` 构建通过。
- WebC #409 已验证 Vite `8.2.2` + rolldown-plugin-dts `0.28.2` 能正确生成 scoped 根入口和 subpath 类型。
- 本次推送后的远端 build、build-chat、test、Chat Site Preview、pkg.pr.new 和体积检查以 GitHub Checks 为准。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react

无变更。

#### @tdesign-react/chat

- fix(chat): 迁移到 WebC scoped UI/Chat 包并移除物理深层路径依赖

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
