### PR TITLE
fix(Form): `resetType="initial"` fails to reset without `initialData` to empty

### DIFF
--- a/packages/components/form/__tests__/form.test.tsx
+++ b/packages/components/form/__tests__/form.test.tsx
@@ -1,13 +1,15 @@
-/* eslint-disable */
-import { fireEvent, mockDelay, mockTimeout, render, vi } from '@test/utils';
 import React, { useEffect, useState } from 'react';
 import { HelpCircleIcon } from 'tdesign-icons-react';
+import { fireEvent, mockDelay, mockTimeout, render, vi } from '@test/utils';
+
 import Button from '../../button';
 import Checkbox from '../../checkbox';
 import Input from '../../input';
 import InputNumber from '../../input-number';
 import Radio from '../../radio';
-import Form, { type TdFormProps } from '../index';
+import Form from '../index';
+
+import type { TdFormProps } from '../index';
 
 const { FormItem, FormList } = Form;
 
@@ -58,7 +60,9 @@ describe('Form 组件测试', () => {
       }
 
       function setValidateMessage() {
-        form.setValidateMessage({ input1: [{ type: 'error', message: 'message: setValidateMessage' }] });
+        form.setValidateMessage({
+          input1: [{ type: 'error', message: 'message: setValidateMessage' }],
+        });
       }
 
       function validate() {
@@ -220,7 +224,9 @@ describe('Form 组件测试', () => {
     expect((getByPlaceholderText('input1') as HTMLInputElement).value).toEqual(initialVal);
 
     const inputThenReset = () => {
-      fireEvent.change(getByPlaceholderText('input1'), { target: { value: 'value1' } });
+      fireEvent.change(getByPlaceholderText('input1'), {
+        target: { value: 'value1' },
+      });
       expect((getByPlaceholderText('input1') as HTMLInputElement).value).toEqual('value1');
       fireEvent.click(getByText('reset'));
     };
@@ -242,7 +248,7 @@ describe('Form 组件测试', () => {
       useEffect(() => {
         form.setValidateMessage({
           notArray: {
-            //@ts-ignore
+            // @ts-ignore
             type: 'error',
             message: 'not array message',
           },
@@ -260,6 +266,7 @@ describe('Form 组件测试', () => {
             },
           ],
         });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
 
       return (
@@ -331,7 +338,13 @@ describe('Form 组件测试', () => {
               className="phone"
               label="phone"
               name="phone"
-              rules={[{ required: true, message: 'phone is required', type: 'warning' }]}
+              rules={[
+                {
+                  required: true,
+                  message: 'phone is required',
+                  type: 'warning',
+                },
+              ]}
             >
               <Input placeholder="phone" />
             </FormItem>
@@ -516,7 +529,16 @@ describe('Form 组件测试', () => {
     const TestForm = () => {
       return (
         <Form>
-          <FormItem name="username" rules={[{ required: true, trigger: 'blur', message: 'please input username' }]}>
+          <FormItem
+            name="username"
+            rules={[
+              {
+                required: true,
+                trigger: 'blur',
+                message: 'please input username',
+              },
+            ]}
+          >
             <Input placeholder="username" />
           </FormItem>
         </Form>
@@ -549,7 +571,7 @@ describe('Form 组件测试', () => {
         </Form>
       );
     };
-    const { container, getByText, getByPlaceholderText } = render(<TestForm />);
+    const { container, getByText } = render(<TestForm />);
     fireEvent.click(getByText('提交'));
     await mockDelay();
     expect(container.querySelectorAll('.t-form--has-error').length).toBe(2);
@@ -604,8 +626,8 @@ describe('Form 组件测试', () => {
     fireEvent.change(getByPlaceholderText('year6'), { target: { value: 4 } });
     fireEvent.click(getByText('提交'));
     await mockDelay();
-    const input__extraList = container.querySelectorAll('.t-input__extra');
-    input__extraList.forEach((item: { innerHTML: string }, index: number) => {
+    const inputExtra = container.querySelectorAll('.t-input__extra');
+    inputExtra.forEach((item: { innerHTML: string }, index: number) => {
       expect(item.innerHTML).toBe(`year${index + 1}  error`);
     });
   });
@@ -664,6 +686,52 @@ describe('Form 组件测试', () => {
     fireEvent.click(getByText('设置信息'));
 
     expect(container.querySelector('.radio-value-3')).toHaveClass('t-is-checked');
+  });
+
+  test('FormItem without initialData resets to empty on remount with resetType=initial', async () => {
+    const TestForm = () => {
+      const [form] = Form.useForm();
+      const [visible, setVisible] = useState(false);
+
+      return (
+        <div>
+          <Button onClick={() => setVisible(true)}>Open</Button>
+          {visible && (
+            <div>
+              <Form form={form} resetType="initial">
+                <FormItem name="tag">
+                  <Input placeholder="tag" />
+                </FormItem>
+                <Button type="reset">Reset</Button>
+              </Form>
+              <Button onClick={() => setVisible(false)}>close</Button>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    const { getByText, getByPlaceholderText, queryByPlaceholderText } = render(<TestForm />);
+
+    // First open: type a value then close
+    fireEvent.click(getByText('Open'));
+    fireEvent.change(getByPlaceholderText('tag'), {
+      target: { value: 'dirty' },
+    });
+    expect((getByPlaceholderText('tag') as HTMLInputElement).value).toBe('dirty');
+    fireEvent.click(getByText('close'));
+    expect(queryByPlaceholderText('tag')).toBeNull();
+
+    // Second open: field should start empty
+    fireEvent.click(getByText('Open'));
+    expect((getByPlaceholderText('tag') as HTMLInputElement).value).toBe('');
+
+    // reset should also produce empty
+    fireEvent.change(getByPlaceholderText('tag'), {
+      target: { value: 'dirty-again' },
+    });
+    fireEvent.click(getByText('Reset'));
+    expect((getByPlaceholderText('tag') as HTMLInputElement).value).toBe('');
   });
 
   test('FormItem setFields not trigger onValueChange', async () => {

--- a/packages/components/form/hooks/useFormItemInitialData.ts
+++ b/packages/components/form/hooks/useFormItemInitialData.ts
@@ -15,7 +15,7 @@ export default function useFormItemInitialData(
 ) {
   let hadReadFloatingFormData = false;
 
-  const { form, floatingFormDataRef, initialData: formContextInitialData } = useFormContext();
+  const { form, floatingFormDataRef, initialData: formContextInitialData, mountedFieldsRef } = useFormContext();
   const { name: rawFormListName, initialData: formListInitialData, form: formOfFormList } = useFormListContext();
 
   const isSameForm = isEqual(form, formOfFormList);
@@ -66,7 +66,9 @@ export default function useFormItemInitialData(
       }
     }
 
-    if (!isFormList && name && form?.store && has(form.store, fullPath)) {
+    const fieldKey = JSON.stringify(fullPath);
+    const isFirstMount = !(mountedFieldsRef?.current?.has(fieldKey) ?? false);
+    if (!isFormList && isFirstMount && name && form?.store && has(form.store, fullPath)) {
       const storeValue = get(form.store, fullPath);
       if (typeof storeValue !== 'undefined') {
         return storeValue;
@@ -91,7 +93,8 @@ export default function useFormItemInitialData(
       const childList = React.Children.toArray(children);
       const lastChild = childList[childList.length - 1];
       if (lastChild && React.isValidElement(lastChild)) {
-        const isMultiple = lastChild?.props?.multiple;
+        const childProps = lastChild.props as { multiple?: boolean };
+        const isMultiple = childProps.multiple;
         // @ts-ignore
         const componentName = lastChild.type.displayName;
         return isMultiple ? [] : TD_DEFAULT_VALUE_MAP.get(componentName);

--- a/packages/tdesign-react/.changelog/pr-4365.md
+++ b/packages/tdesign-react/.changelog/pr-4365.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4365
+contributor: RylanBot
+---
+
+- fix(Form): 修复重渲染时，`resetType="initial"` 无法将未设置 `initialData` 的字段重置为空的问题 @RylanBot ([#4365](https://github.com/Tencent/tdesign-react/pull/4365))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- https://codesandbox.io/p/sandbox/tdesign-react-demo-forked-fh43y9?file=%2Fpackage.json

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react

- fix(Form): 修复重渲染时，`resetType="initial"` 无法将未设置 `initialData` 的字段重置为空的问题

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
