### PR TITLE
fix(EnhancedTable): tree nodes being re-collapsed so children only render after scrolling

### DIFF
--- a/packages/components/table/hooks/useTreeDataExpand.ts
+++ b/packages/components/table/hooks/useTreeDataExpand.ts
@@ -122,8 +122,19 @@ export function useTreeDataExpand(
     if (!store.treeDataMap.size) return;
     if (changedExpandTreeNode.type === 'user-reaction-change') {
       const { row, rowIndex } = changedExpandTreeNode || {};
-      const newData = store.toggleExpandData({ row, rowIndex }, dataSource, rowDataKeys);
-      setDataSource([...newData]);
+      const rowValue = getUniqueRowValue(row, rowDataKeys.rowKey);
+      // 对比 store 当前状态与受控目标状态，仅在不一致时才执行切换
+      const isTargetExpanded = tExpandedTreeNode.includes(rowValue);
+      const currentStoreState = store.treeDataMap.get(rowValue);
+      if (currentStoreState && currentStoreState.expanded !== isTargetExpanded) {
+        const newData = store.toggleExpandData(
+          { row, rowIndex },
+          dataSource,
+          rowDataKeys,
+          isTargetExpanded ? 'expand' : 'fold',
+        );
+        setDataSource([...newData]);
+      }
     } else if (changedExpandTreeNode.type === 'props-change') {
       updateExpandState([...dataSource], tExpandedTreeNode, oldExpandedTreeNode);
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-react/pull/4104
- https://stackblitz.com/edit/qn8ixdg6?file=src%2Fdemo.tsx

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

受控模式下，一次点击会触发两个 effect：

1. `useTreeDataExpand` 的 `user-reaction-change` 分支直接调用 `store.toggleExpandData({ row, rowIndex }, dataSource)`，以 `visibleData` 切片中的局部下标（如 `3`）作为 `rowIndex`，将子节点 splice 到错误位置（如 `dataSource[4]`，而非真实的 `dataSource[51]`）。

2. `useTreeData` 的 `useEffect([data, expandedTreeNodes])` 随后执行 `resetData`，重建 store 并按 `expandedTreeNodes` 正确展开节点。

由于步骤 1 将子节点插入了视口之外的错误位置，虚拟滚动计算可视区切片时无法包含这些行，直到用户触发滚动重新计算才显现。

(无虚拟滚动时不触发：此时 `visibleData === dataSource`，局部下标与真实下标一致，splice 位置正确，表现正常)

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-react
- fix(EnhancedTable): 修复开启虚拟滚动且 `expandedTreeNodes` 受控时，展开的子节点无法正确渲染的问题

#### @tdesign-react/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
