### PR TITLE
fix(Select): synchronously derive filtered options

### DIFF
--- a/packages/components/input/Input.tsx
+++ b/packages/components/input/Input.tsx
@@ -348,6 +348,9 @@ const Input = forwardRefWithStatics(
       const {
         currentTarget: { value },
       } = e;
+      // 合成期间输入框展示的是 composingValue，而外部 value 可能已被程序清空（如 Select 选中选项后清空筛选词），
+      // 此时需要以输入框当前内容为起点重新累计，否则上一次的合成内容会被残留并累加
+      setComposingValue(value);
       onCompositionstart?.(value, { e });
     }
     function handleCompositionEnd(e: React.CompositionEvent<HTMLInputElement>) {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -89,9 +89,16 @@ describe('Input 组件测试', () => {
 
     const ControlledInput = () => {
       const [value, setValue] = React.useState('');
+      const [, setCompositionCount] = React.useState(0);
       return (
         <>
-          <Input placeholder={InputPlaceholder} value={value} onChange={(v) => setValue(v as string)} />
+          <Input
+            placeholder={InputPlaceholder}
+            value={value}
+            onChange={(v) => setValue(v as string)}
+            // 开始合成时触发重渲染，复现 SelectInput 的 setIsTyping 更新。
+            onCompositionstart={() => setCompositionCount((count) => count + 1)}
+          />
           <button type="button" onClick={() => setValue('')}>
             reset
           </button>

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -79,6 +79,42 @@ describe('Input 组件测试', () => {
     expect(onCompositionEndFn).toHaveBeenCalled();
     expect(InputDom.value).toBe([InputValue, InputValue, InputValue].join(''));
   });
+  test('composing value should not be kept when value is reset by outside', async () => {
+    // 模拟中文输入法的一次合成输入
+    const imeInput = (input: HTMLInputElement, value: string) => {
+      fireEvent.compositionStart(input, { target: { value: input.value } });
+      fireEvent.change(input, { target: { value } });
+      fireEvent.compositionEnd(input, { target: { value } });
+    };
+
+    const ControlledInput = () => {
+      const [value, setValue] = React.useState('');
+      return (
+        <>
+          <Input placeholder={InputPlaceholder} value={value} onChange={(v) => setValue(v as string)} />
+          <button type="button" onClick={() => setValue('')}>
+            reset
+          </button>
+        </>
+      );
+    };
+    const { queryByPlaceholderText, getByText } = render(<ControlledInput />);
+    const InputDom = queryByPlaceholderText(InputPlaceholder) as HTMLInputElement;
+
+    imeInput(InputDom, '苹');
+    expect(InputDom.value).toBe('苹');
+
+    // 外部清空输入框内容后，再次进入合成态不应残留上一次的输入
+    fireEvent.click(getByText('reset'));
+    expect(InputDom.value).toBe('');
+
+    fireEvent.compositionStart(InputDom, { target: { value: InputDom.value } });
+    expect(InputDom.value).toBe('');
+
+    fireEvent.change(InputDom, { target: { value: 'xiang' } });
+    fireEvent.compositionEnd(InputDom, { target: { value: '香' } });
+    expect(InputDom.value).toBe('香');
+  });
   test('keyDown', async () => {
     const user = userEvent.setup();
     const onEnterFn = vi.fn();

--- a/packages/components/select/__tests__/closing-animation.test.tsx
+++ b/packages/components/select/__tests__/closing-animation.test.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { act, fireEvent, render, vi } from '@test/utils';
+
+import Select from '../index';
+
+test.each([
+  { source: 'options', destroyOnClose: false },
+  { source: 'children', destroyOnClose: false },
+  { source: 'options', destroyOnClose: true },
+  { source: 'children', destroyOnClose: true },
+])('keeps the filtered list during exit: $source, destroyOnClose=$destroyOnClose', ({ source, destroyOnClose }) => {
+  vi.useFakeTimers();
+  const onChange = vi.fn();
+  const onInputChange = vi.fn();
+  const Demo = () => {
+    const [value, setValue] = useState('');
+    const options = [
+      { label: '选项一', value: '1' },
+      { label: '选项二', value: '2' },
+      { label: '选项三', value: '3' },
+    ];
+    return (
+      <Select
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setValue(String(next));
+        }}
+        onInputChange={onInputChange}
+        filterable
+        popupProps={{ destroyOnClose }}
+        options={source === 'options' ? options : undefined}
+      >
+        {source === 'children' ? options.map((option) => <Select.Option key={option.value} {...option} />) : undefined}
+      </Select>
+    );
+  };
+  const { getByRole, getByText, unmount } = render(<Demo />);
+  try {
+    const input = getByRole('textbox');
+    fireEvent.click(input);
+    act(() => vi.advanceTimersByTime(200));
+    fireEvent.change(input, { target: { value: '一' } });
+    const popup = document.querySelector('.t-popup');
+    expect(popup).toHaveTextContent('选项一');
+    expect(popup).not.toHaveTextContent('选项二');
+
+    fireEvent.click(getByText('选项一'));
+    expect(input).toHaveValue('选项一');
+    expect(onChange).toHaveBeenLastCalledWith('1');
+    expect(onInputChange).toHaveBeenLastCalledWith('', expect.objectContaining({ trigger: 'blur' }));
+    expect(popup).toHaveStyle({ display: 'block' });
+    expect(popup).not.toHaveTextContent('选项二');
+    expect(popup).not.toHaveTextContent('选项三');
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(popup).toHaveStyle({ display: 'block' });
+    expect(popup).not.toHaveTextContent('选项二');
+    act(() => vi.advanceTimersByTime(100));
+    if (destroyOnClose) expect(document.querySelector('.t-popup')).toBeNull();
+    else expect(popup).toHaveStyle({ display: 'none' });
+
+    fireEvent.click(input);
+    const reopenedPopup = document.querySelector('.t-popup');
+    expect(reopenedPopup).toHaveTextContent('选项一');
+    expect(reopenedPopup).toHaveTextContent('选项二');
+    expect(reopenedPopup).toHaveTextContent('选项三');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  } finally {
+    unmount();
+    vi.useRealTimers();
+  }
+});
+
+const options = [
+  { label: '选项一', value: '1' },
+  { label: '选项二', value: '2' },
+  { label: '选项三', value: '3' },
+];
+
+test('reopening during exit uses the latest options and cancels the pending close', () => {
+  vi.useFakeTimers();
+  const onChange = vi.fn();
+  const { getByRole, getByText, rerender, unmount } = render(
+    <Select filterable options={options} onChange={onChange} />,
+  );
+  try {
+    const input = getByRole('textbox');
+    fireEvent.click(input);
+    act(() => vi.advanceTimersByTime(200));
+    fireEvent.change(input, { target: { value: '一' } });
+    fireEvent.click(getByText('选项一'));
+    const popup = document.querySelector('.t-popup');
+    expect(popup).not.toHaveTextContent('选项二');
+
+    rerender(<Select filterable options={[...options, { label: '选项四', value: '4' }]} onChange={onChange} />);
+    expect(popup).not.toHaveTextContent('选项四');
+    fireEvent.click(input);
+    expect(input).toHaveValue('');
+    expect(popup).toHaveTextContent('选项二');
+    expect(popup).toHaveTextContent('选项四');
+    act(() => vi.advanceTimersByTime(200));
+    expect(popup).toHaveStyle({ display: 'block' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  } finally {
+    unmount();
+    vi.useRealTimers();
+  }
+});
+
+test.each([false, true])('multiple selection keeps the open list live: reserveKeyword=%s', (reserveKeyword) => {
+  const { getByRole, getByText } = render(
+    <Select multiple filterable options={options} reserveKeyword={reserveKeyword} />,
+  );
+  const input = getByRole('textbox');
+  fireEvent.click(input);
+  fireEvent.change(input, { target: { value: '一' } });
+  fireEvent.click(getByText('选项一'));
+  const popup = document.querySelector('.t-popup');
+  expect(popup).toHaveStyle({ display: 'block' });
+  if (reserveKeyword) {
+    expect(input).toHaveValue('一');
+    expect(popup).not.toHaveTextContent('选项二');
+  } else {
+    expect(input).toHaveValue('');
+    expect(popup).toHaveTextContent('选项二');
+  }
+});
+
+test('a controlled popup that stays open continues updating its list', () => {
+  const onPopupVisibleChange = vi.fn();
+  const { getByRole, getByText } = render(
+    <Select filterable options={options} popupVisible onPopupVisibleChange={onPopupVisibleChange} />,
+  );
+  const input = getByRole('textbox');
+  fireEvent.change(input, { target: { value: '一' } });
+  fireEvent.click(getByText('选项一'));
+  expect(onPopupVisibleChange).toHaveBeenLastCalledWith(false, expect.anything());
+  expect(document.querySelector('.t-popup')).toHaveStyle({ display: 'block' });
+  expect(document.querySelector('.t-popup')).toHaveTextContent('选项二');
+  fireEvent.change(input, { target: { value: '三' } });
+  expect(document.querySelector('.t-popup')).toHaveTextContent('选项三');
+  expect(document.querySelector('.t-popup')).not.toHaveTextContent('选项二');
+});

--- a/packages/components/select/__tests__/filtering.test.tsx
+++ b/packages/components/select/__tests__/filtering.test.tsx
@@ -1,0 +1,231 @@
+import React, { Profiler, useState } from 'react';
+import { fireEvent, render, vi } from '@test/utils';
+
+import Select from '../index';
+
+// 记录真实 DOM commit，而不是仅检查 act 刷新全部 effects 后的最终结果。
+test.each(['options', 'children'] as const)('keeps an unchanged filter across parent rerenders: %s', (source) => {
+  const committedLists: string[] = [];
+  const readOptions = () =>
+    Array.from(document.querySelectorAll('.t-popup .t-select-option'))
+      .map((option) => option.textContent)
+      .join('|');
+  const Demo = () => {
+    const [, setRevision] = useState(0);
+    // 与官网 Demo 一样，在父组件 render 中创建 options / Option children。
+    const options = [
+      { label: '选项一', value: '1' },
+      { label: '选项二', value: '2' },
+      { label: '选项三', value: '3' },
+    ];
+    return (
+      <>
+        <button type="button" onClick={() => setRevision((revision) => revision + 1)}>
+          rerender
+        </button>
+        <Select filterable defaultInputValue="二" popupVisible options={source === 'options' ? options : undefined}>
+          {source === 'children'
+            ? options.map((option) => <Select.Option key={option.value} {...option} />)
+            : undefined}
+        </Select>
+      </>
+    );
+  };
+  const { getByRole } = render(
+    <Profiler
+      id="select"
+      onRender={() => {
+        const list = readOptions();
+        if (committedLists[committedLists.length - 1] !== list) committedLists.push(list);
+      }}
+    >
+      <Demo />
+    </Profiler>,
+  );
+  expect(readOptions()).toBe('选项二');
+  committedLists.length = 0;
+  fireEvent.click(getByRole('button', { name: 'rerender' }));
+  expect(getByRole('textbox')).toHaveValue('二');
+  expect(readOptions()).toBe('选项二');
+  expect(committedLists).toEqual(['选项二']);
+});
+
+const options = [
+  { label: '选项一', value: '1' },
+  { label: '选项二', value: '2' },
+  { label: '选项三', value: '3' },
+];
+
+const readOptions = () =>
+  Array.from(document.querySelectorAll('.t-popup .t-select-option')).map((option) => option.textContent);
+
+test('commits only the new filtered list when the controlled query and options change together', () => {
+  const committedLists: string[][] = [];
+  const demo = (inputValue: string, items: typeof options) => (
+    <Profiler id="select" onRender={() => committedLists.push(readOptions())}>
+      <Select filterable popupVisible inputValue={inputValue} options={items} />
+    </Profiler>
+  );
+  const { rerender } = render(demo('一', options));
+  committedLists.length = 0;
+  rerender(demo('四', [...options, { label: '选项四', value: '4' }]));
+  expect(committedLists.length).toBeGreaterThan(0);
+  committedLists.forEach((list) => expect(list).toEqual(['选项四']));
+});
+
+test.each(['options', 'children'] as const)(
+  'reserveKeyword preserves selection and query without freezing new %s',
+  (source) => {
+    const demo = (items: typeof options) => (
+      <Select multiple filterable reserveKeyword options={source === 'options' ? items : undefined}>
+        {source === 'children' ? items.map((option) => <Select.Option key={option.value} {...option} />) : undefined}
+      </Select>
+    );
+    const { getByRole, getByText, rerender, container } = render(demo(options));
+    const input = getByRole('textbox');
+    fireEvent.click(input);
+    fireEvent.change(input, { target: { value: '一' } });
+    fireEvent.click(getByText('选项一'));
+    rerender(demo([...options, { label: '选项十一', value: '11' }]));
+    expect(input).toHaveValue('一');
+    expect(readOptions()).toEqual(['选项一', '选项十一']);
+    expect(container.querySelector('.t-tag')).toHaveTextContent('选项一');
+  },
+);
+
+test('remote search uses server options and retains labels of selections absent from the response', () => {
+  const onSearch = vi.fn();
+  const filter = vi.fn(() => false);
+  const demo = (items: typeof options) => (
+    <Select multiple filterable defaultValue={['1']} options={items} onSearch={onSearch} filter={filter} popupVisible />
+  );
+  const { getByRole, rerender, container } = render(demo(options));
+  fireEvent.change(getByRole('textbox'), { target: { value: 'remote query' } });
+  rerender(demo([options[1]]));
+  expect(onSearch).toHaveBeenCalledTimes(1);
+  expect(onSearch).toHaveBeenLastCalledWith('remote query', expect.anything());
+  expect(filter).not.toHaveBeenCalled();
+  expect(readOptions()).toEqual(['选项二']);
+  expect(container.querySelector('.t-tag')).toHaveTextContent('选项一');
+});
+
+test('recomputes filtering when a custom predicate changes with an unchanged query', () => {
+  const { rerender } = render(
+    <Select
+      filterable
+      popupVisible
+      inputValue="query"
+      options={options}
+      filter={(_, option) => option.value === '1'}
+    />,
+  );
+  expect(readOptions()).toEqual(['选项一']);
+  rerender(
+    <Select
+      filterable
+      popupVisible
+      inputValue="query"
+      options={options}
+      filter={(_, option) => option.value === '2'}
+    />,
+  );
+  expect(readOptions()).toEqual(['选项二']);
+});
+
+test('updates a creatable candidate without changing the query', () => {
+  const { rerender } = render(<Select filterable popupVisible inputValue="四" options={options} />);
+  expect(readOptions()).toEqual([]);
+  rerender(<Select filterable creatable popupVisible inputValue="四" options={options} />);
+  expect(readOptions()).toEqual(['四']);
+  rerender(
+    <Select filterable creatable popupVisible inputValue="四" options={[...options, { label: '四', value: '4' }]} />,
+  );
+  expect(readOptions()).toEqual(['四']);
+});
+
+test('filters grouped options while resolving selected labels from the full source', () => {
+  const { container } = render(
+    <Select
+      multiple
+      filterable
+      popupVisible
+      defaultValue={['1']}
+      inputValue="二"
+      options={[{ group: '分组', children: options }]}
+    />,
+  );
+  expect(readOptions()).toEqual(['选项二']);
+  expect(container.querySelector('.t-tag')).toHaveTextContent('选项一');
+});
+
+test('filters mapped labels without losing the selected object', () => {
+  const items = [
+    { id: '1', name: '选项一' },
+    { id: '2', name: '选项二' },
+  ];
+  const { container } = render(
+    <Select
+      multiple
+      filterable
+      popupVisible
+      keys={{ value: 'id', label: 'name' }}
+      valueType="object"
+      value={[items[0]]}
+      inputValue="二"
+      options={items}
+    />,
+  );
+  expect(readOptions()).toEqual(['选项二']);
+  expect(container.querySelector('.t-tag')).toHaveTextContent('选项一');
+});
+
+test('keyboard selection uses the current filtered group after an options update', () => {
+  const onChange = vi.fn();
+  const { getByRole, rerender } = render(
+    <Select
+      filterable
+      popupVisible
+      inputValue="二"
+      options={[{ group: '分组', children: options }]}
+      onChange={onChange}
+    />,
+  );
+  rerender(
+    <Select
+      filterable
+      popupVisible
+      inputValue="四"
+      options={[{ group: '分组', children: [...options, { label: '选项四', value: '4' }] }]}
+      onChange={onChange}
+    />,
+  );
+  const popup = document.querySelector('.t-popup__content') as HTMLElement;
+  popup.scrollTo = vi.fn();
+  fireEvent.keyDown(getByRole('textbox'), { key: 'ArrowDown', code: 'ArrowDown' });
+  fireEvent.keyDown(getByRole('textbox'), { key: 'Enter', code: 'Enter' });
+  expect(onChange).toHaveBeenLastCalledWith('4', expect.objectContaining({ trigger: 'check' }));
+});
+
+test('filters a virtual list down to a non-virtual result and back', () => {
+  const items = Array.from({ length: 120 }, (_, index) => ({ label: `选项${index}`, value: String(index) }));
+  const { getByRole } = render(<Select filterable popupVisible options={items} scroll={{ type: 'virtual' }} />);
+  const initialList = readOptions();
+  expect(initialList.length).toBeGreaterThan(0);
+  expect(initialList.length).toBeLessThan(items.length);
+  fireEvent.change(getByRole('textbox'), { target: { value: '选项119' } });
+  expect(readOptions()).toEqual(['选项119']);
+  fireEvent.change(getByRole('textbox'), { target: { value: '' } });
+  const restoredList = readOptions();
+  expect(restoredList.length).toBeGreaterThan(0);
+  expect(restoredList.length).toBeLessThan(items.length);
+  expect(restoredList).toEqual(items.slice(0, restoredList.length).map((item) => item.label));
+});
+
+test('keeps custom children when no option source is provided', () => {
+  render(
+    <Select popupVisible>
+      <div>自定义面板内容</div>
+    </Select>,
+  );
+  expect(document.querySelector('.t-popup')).toHaveTextContent('自定义面板内容');
+});

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -359,6 +359,57 @@ describe('Select 组件测试', () => {
     expect(document.querySelector(popupSelector)).toHaveTextContent('无数据');
   });
 
+  test('可过滤选择器中文输入法测试', async () => {
+    const testId = 'test-id-ime';
+    // 模拟中文输入法的一次合成输入
+    const imeInput = (input: HTMLInputElement, value: string) => {
+      fireEvent.compositionStart(input, { target: { value: input.value } });
+      fireEvent.change(input, { target: { value } });
+      fireEvent.compositionEnd(input, { target: { value } });
+    };
+    const cnOptions = [
+      { label: '苹果', value: 'apple' },
+      { label: '香蕉', value: 'banana' },
+      { label: '橙子', value: 'orange' },
+    ];
+
+    const FilterableSelect = () => {
+      const [value, setValue] = useState();
+      const onChange = (value) => {
+        setValue(value);
+      };
+
+      return (
+        <Select filterable value={value} onChange={onChange} placeholder={testId}>
+          {cnOptions.map((item, index) => (
+            <Option key={index} label={item.label} value={item.value} />
+          ))}
+        </Select>
+      );
+    };
+    const { getByPlaceholderText, getByText } = render(<FilterableSelect />);
+    const input = getByPlaceholderText(testId) as HTMLInputElement;
+
+    // 中文输入法输入“苹”，筛选出“苹果”
+    fireEvent.click(input);
+    imeInput(input, '苹');
+    expect(input).toHaveValue('苹');
+    expect(document.querySelector(popupSelector)).toHaveTextContent('苹果');
+
+    // 选中“苹果”后，输入框展示选中项
+    fireEvent.click(getByText('苹果'));
+    expect(input).toHaveValue('苹果');
+
+    // 再次聚焦并输入，不应保留上一次的筛选内容
+    fireEvent.click(input);
+    expect(input).toHaveValue('');
+    fireEvent.compositionStart(input, { target: { value: input.value } });
+    expect(input).toHaveValue('');
+    fireEvent.change(input, { target: { value: 'xiang' } });
+    fireEvent.compositionEnd(input, { target: { value: '香' } });
+    expect(input).toHaveValue('香');
+  });
+
   test('远程搜索测试', async () => {
     const user = userEvent.setup();
     render(<RemoteSearchSelect />);

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { act, fireEvent, mockTimeout, render } from '@test/utils';
+import { act, fireEvent, mockTimeout, render, vi } from '@test/utils';
 import userEvent from '@testing-library/user-event';
 
 import Popup from '../../popup';
@@ -361,6 +361,7 @@ describe('Select 组件测试', () => {
 
   test('可过滤选择器中文输入法测试', async () => {
     const testId = 'test-id-ime';
+    const onSelectedChange = vi.fn();
     // 模拟中文输入法的一次合成输入
     const imeInput = (input: HTMLInputElement, value: string) => {
       fireEvent.compositionStart(input, { target: { value: input.value } });
@@ -376,6 +377,7 @@ describe('Select 组件测试', () => {
     const FilterableSelect = () => {
       const [value, setValue] = useState();
       const onChange = (value) => {
+        onSelectedChange(value);
         setValue(value);
       };
 
@@ -395,10 +397,15 @@ describe('Select 组件测试', () => {
     imeInput(input, '苹');
     expect(input).toHaveValue('苹');
     expect(document.querySelector(popupSelector)).toHaveTextContent('苹果');
+    expect(document.querySelector(popupSelector)).not.toHaveTextContent('香蕉');
+    expect(document.querySelector(popupSelector)).not.toHaveTextContent('橙子');
+    expect(onSelectedChange).not.toHaveBeenCalled();
 
     // 选中“苹果”后，输入框展示选中项
     fireEvent.click(getByText('苹果'));
     expect(input).toHaveValue('苹果');
+    expect(onSelectedChange).toHaveBeenCalledTimes(1);
+    expect(onSelectedChange).toHaveBeenLastCalledWith('apple');
 
     // 再次聚焦并输入，不应保留上一次的筛选内容
     fireEvent.click(input);
@@ -406,8 +413,21 @@ describe('Select 组件测试', () => {
     fireEvent.compositionStart(input, { target: { value: input.value } });
     expect(input).toHaveValue('');
     fireEvent.change(input, { target: { value: 'xiang' } });
+    expect(input).toHaveValue('xiang');
+    // 合成期间不提交筛选词，面板仍展示上一次已提交筛选词（此时为空）对应的结果。
+    expect(document.querySelector(popupSelector)).toHaveTextContent('苹果');
+    expect(document.querySelector(popupSelector)).toHaveTextContent('香蕉');
+    expect(document.querySelector(popupSelector)).toHaveTextContent('橙子');
     fireEvent.compositionEnd(input, { target: { value: '香' } });
     expect(input).toHaveValue('香');
+    expect(document.querySelector(popupSelector)).toHaveTextContent('香蕉');
+    expect(document.querySelector(popupSelector)).not.toHaveTextContent('苹果');
+    expect(document.querySelector(popupSelector)).not.toHaveTextContent('橙子');
+    // 筛选不会清除或替换已选值；收起时仍显示原来的选中项。
+    expect(onSelectedChange).toHaveBeenCalledTimes(1);
+    fireEvent.mouseDown(document.body);
+    expect(input).toHaveValue('苹果');
+    expect(onSelectedChange).toHaveBeenCalledTimes(1);
   });
 
   test('远程搜索测试', async () => {

--- a/packages/components/select/base/Select.tsx
+++ b/packages/components/select/base/Select.tsx
@@ -1,13 +1,4 @@
-import React, {
-  Children,
-  cloneElement,
-  isValidElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { Children, cloneElement, isValidElement, useCallback, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { debounce, get, isFunction } from 'lodash-es';
 
@@ -27,7 +18,7 @@ import SelectInput from '../../select-input';
 import Tag from '../../tag';
 import { selectDefaultProps } from '../defaultProps';
 import useKeyboardControl from '../hooks/useKeyboardControl';
-import useOptions, { isSelectOptionGroup } from '../hooks/useOptions';
+import useOptions, { flattenOptions, isSelectOptionGroup } from '../hooks/useOptions';
 import { getKeyMapping, getSelectedOptions, getSelectValueArr } from '../util/helper';
 import Option from './Option';
 import OptionGroup from './OptionGroup';
@@ -122,10 +113,60 @@ const Select = forwardRefWithStatics(
       setInnerPopupVisible(visible, ctx);
     };
 
-    const { currentOptions, setCurrentOptions, tmpPropOptions, valueToOption, selectedOptions, flattenedOptions } =
-      useOptions(keys, options, children, valueType, value, reserveKeyword);
+    const { normalizedOptions, valueToOption, selectedOptions } = useOptions(keys, options, children, valueType, value);
 
-    // 清空筛选词时浮层仍在执行退出动画，保留关闭前的列表，避免提前展示全部选项。
+    /**
+     * 同步计算过滤结果，避免先展示完整列表、再由 effect 过滤造成闪动。
+     * 自定义 filter 在渲染阶段执行，应保持无副作用。
+     */
+    const currentOptions = useMemo(() => {
+      const value = inputValue === undefined ? '' : String(inputValue);
+      let filteredOptions: SelectOption[] = [];
+      if ((filterable && isFunction(onSearch)) || !value) {
+        return normalizedOptions;
+      }
+
+      const filterLabels = [];
+      const filterMethods = (option: SelectOption) => {
+        if (filter && isFunction(filter)) {
+          return filter(value, option);
+        }
+        const upperValue = value.toUpperCase();
+        const searchableText = extractTextFromTNode(option.label);
+        return searchableText.toUpperCase().includes(upperValue);
+      };
+
+      normalizedOptions?.forEach((option) => {
+        if (isSelectOptionGroup(option)) {
+          filteredOptions.push({
+            ...option,
+            children: option.children?.filter((child) => {
+              if (filterMethods(child)) {
+                filterLabels.push(child.label);
+                return true;
+              }
+              return false;
+            }),
+          });
+        } else if (filterMethods(option)) {
+          filterLabels.push(option.label);
+          filteredOptions.push(option);
+        }
+      });
+      const isSameLabelOptionExist = filterLabels.includes(value);
+      if (creatable && !isSameLabelOptionExist) {
+        filteredOptions = filteredOptions.concat([{ label: value, value }]);
+      }
+      return filteredOptions;
+    }, [normalizedOptions, inputValue, filterable, onSearch, filter, creatable]);
+
+    // 键盘导航与展示列表使用同一轮过滤结果。
+    const flattenedOptions = useMemo(() => flattenOptions(currentOptions), [currentOptions]);
+
+    /**
+     * 关闭时关键词已清空，但退出动画尚未结束，继续展示关闭前的列表以避免闪动。
+     * 快照仅在面板打开时更新；再次打开使用最新列表，不影响已选值。
+     */
     const lastVisibleOptionsRef = useRef(currentOptions);
     useLayoutEffect(() => {
       if (innerPopupVisible) lastVisibleOptionsRef.current = currentOptions;
@@ -313,51 +354,6 @@ const Select = forwardRefWithStatics(
       toggleIsScrolling,
     });
 
-    // 处理filter逻辑
-    const handleFilter = (value: string) => {
-      let filteredOptions: SelectOption[] = [];
-      if (filterable && isFunction(onSearch)) {
-        return;
-      }
-      if (!value) {
-        setCurrentOptions(tmpPropOptions);
-        return;
-      }
-
-      const filterLabels = [];
-      const filterMethods = (option: SelectOption) => {
-        if (filter && isFunction(filter)) {
-          return filter(value, option);
-        }
-        const upperValue = value.toUpperCase();
-        const searchableText = extractTextFromTNode(option.label);
-        return searchableText.toUpperCase().includes(upperValue);
-      };
-
-      tmpPropOptions?.forEach((option) => {
-        if (isSelectOptionGroup(option)) {
-          filteredOptions.push({
-            ...option,
-            children: option.children?.filter((child) => {
-              if (filterMethods(child)) {
-                filterLabels.push(child.label);
-                return true;
-              }
-              return false;
-            }),
-          });
-        } else if (filterMethods(option)) {
-          filterLabels.push(option.label);
-          filteredOptions.push(option);
-        }
-      });
-      const isSameLabelOptionExist = filterLabels.includes(value);
-      if (creatable && !isSameLabelOptionExist) {
-        filteredOptions = filteredOptions.concat([{ label: value, value }]);
-      }
-      setCurrentOptions(filteredOptions);
-    };
-
     // 处理输入框逻辑
     const handleInputChange = (value: string, context: SelectInputValueChangeContext) => {
       if (context.trigger !== 'clear') {
@@ -383,13 +379,6 @@ const Select = forwardRefWithStatics(
       }
       onClear(context);
     };
-
-    useEffect(() => {
-      if (typeof inputValue !== 'undefined') {
-        handleFilter(String(inputValue));
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [inputValue, tmpPropOptions]);
 
     // 渲染后置图标
     const renderSuffixIcon = () => {

--- a/packages/components/select/base/Select.tsx
+++ b/packages/components/select/base/Select.tsx
@@ -20,6 +20,7 @@ import FakeArrow from '../../common/FakeArrow';
 import useConfig from '../../hooks/useConfig';
 import useControlled from '../../hooks/useControlled';
 import useDefaultProps from '../../hooks/useDefaultProps';
+import useLayoutEffect from '../../hooks/useLayoutEffect';
 import Loading from '../../loading';
 import { useLocaleReceiver } from '../../locale/LocalReceiver';
 import SelectInput from '../../select-input';
@@ -123,6 +124,12 @@ const Select = forwardRefWithStatics(
 
     const { currentOptions, setCurrentOptions, tmpPropOptions, valueToOption, selectedOptions, flattenedOptions } =
       useOptions(keys, options, children, valueType, value, reserveKeyword);
+
+    // 清空筛选词时浮层仍在执行退出动画，保留关闭前的列表，避免提前展示全部选项。
+    const lastVisibleOptionsRef = useRef(currentOptions);
+    useLayoutEffect(() => {
+      if (innerPopupVisible) lastVisibleOptionsRef.current = currentOptions;
+    }, [innerPopupVisible, currentOptions]);
 
     const onCheckAllChange = useCallback(
       (checkAll: boolean, e: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLInputElement>) => {
@@ -419,7 +426,7 @@ const Select = forwardRefWithStatics(
         showPopup: innerPopupVisible,
         // popup弹出层内容只会在点击事件之后触发 并且无任何透传参数
         setShowPopup: (show: boolean) => handlePopupVisibleChange(show, {}),
-        options: currentOptions,
+        options: innerPopupVisible ? currentOptions : lastVisibleOptionsRef.current,
         empty,
         max,
         loadingText,

--- a/packages/components/select/hooks/useOptions.ts
+++ b/packages/components/select/hooks/useOptions.ts
@@ -7,13 +7,13 @@ import { getKeyMapping, getValueToOption } from '../util/helper';
 
 import type { ReactElement, ReactNode } from 'react';
 import type { SelectKeysType, SelectOption, SelectOptionGroup, SelectValue, TdOptionProps } from '../type';
-import type { ValueToOption } from '../util/helper';
 
 // 针对分组的相关判断和扁平处理
 export function isSelectOptionGroup(option: SelectOption): option is SelectOptionGroup {
   return !!option && 'group' in option && 'children' in option;
 }
 
+// 按展示顺序展开分组选项，供键盘导航使用。
 export const flattenOptions = (options: SelectOption[] = []) => {
   const flattened = [];
   options.forEach((option) => {
@@ -30,34 +30,31 @@ export const flattenOptions = (options: SelectOption[] = []) => {
 
 type OptionValueType = SelectValue<SelectOption>;
 
-// 处理 options 的逻辑
+/**
+ * 整理完整候选项并维护已选项回显，关键词过滤由 Select 负责。
+ * 已选项查询不依赖过滤结果，避免筛选后丢失标签。
+ */
 function useOptions(
   keys: SelectKeysType,
   options: SelectOption[],
   children: ReactNode,
   valueType: 'object' | 'value',
   value: OptionValueType,
-  reserveKeyword: boolean,
 ) {
-  const [valueToOption, setValueToOption] = useState<ValueToOption>({});
-  const [currentOptions, setCurrentOptions] = useState<SelectOption[]>([]);
-  const [flattenedOptions, setFlattenedOptions] = useState<SelectOption[]>([]);
-  const [tmpPropOptions, setTmpPropOptions] = useState<SelectOption[]>([]);
   const [selectedOptions, setSelectedOptions] = useState<SelectOption[]>([]);
 
   const { valueKey, labelKey } = useMemo(() => getKeyMapping(keys), [keys]);
 
-  useEffect(() => {
-    setFlattenedOptions(flattenOptions(currentOptions));
-  }, [currentOptions]);
-  // 处理设置 option 的逻辑
-  useEffect(() => {
+  /**
+   * 同步整理 options / 选项子节点，让过滤直接使用最新数据。
+   * 无选项时保留 undefined，以支持自定义 children 渲染。
+   */
+  const normalizedOptions = useMemo(() => {
     let transformedOptions = options;
 
     const arrayChildren = React.Children.toArray(children);
     const optionChildren = arrayChildren.filter((v: ReactElement) => v.type === Option || v.type === OptionGroup);
     const isChildrenFilterable = arrayChildren.length > 0 && optionChildren.length === arrayChildren.length;
-    if (reserveKeyword && currentOptions.length && isChildrenFilterable) return;
 
     if (isChildrenFilterable) {
       const handlerOptionElement = (v) => {
@@ -86,14 +83,19 @@ function useOptions(
         label: get(option, labelKey),
       }));
     }
-    setCurrentOptions(transformedOptions);
-    setTmpPropOptions(transformedOptions);
+    return transformedOptions;
+  }, [options, keys, children, valueKey, labelKey]);
 
-    setValueToOption(getValueToOption(children as ReactElement, options as TdOptionProps[], keys) || {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options, keys, children, reserveKeyword]);
+  // 使用完整数据解析已选标签及事件中的选项信息。
+  const valueToOption = useMemo(
+    () => getValueToOption(children as ReactElement, options as TdOptionProps[], keys) || {},
+    [children, options, keys],
+  );
 
-  // 同步 value 对应的 options
+  /**
+   * 远程结果可能不包含已选值，因此保留历史选项作为标签回显的兜底。
+   * 已选项仍以当前 value 为准，不保留已取消选中的条目。
+   */
   useEffect(() => {
     setSelectedOptions((oldSelectedOptions: SelectOption[]) => {
       const createOptionFromValue = (item: OptionValueType) => {
@@ -128,15 +130,9 @@ function useOptions(
   }, [value, keys, valueType, valueToOption, valueKey, labelKey, setSelectedOptions]);
 
   return {
-    currentOptions,
-    setCurrentOptions,
-    tmpPropOptions,
-    setTmpPropOptions,
+    normalizedOptions,
     valueToOption,
-    setValueToOption,
     selectedOptions,
-    setSelectedOptions,
-    flattenedOptions,
   };
 }
 

--- a/packages/tdesign-react/.changelog/pr-4388.md
+++ b/packages/tdesign-react/.changelog/pr-4388.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4388
+contributor: RSS1102
+---
+
+- fix(Select): 修复 `filterable` 下中文输入法筛选选中后再次输入会残留上次筛选内容的问题 @RSS1102 ([#4388](https://github.com/Tencent/tdesign-react/pull/4388))

--- a/packages/tdesign-react/CHANGELOG.en-US.md
+++ b/packages/tdesign-react/CHANGELOG.en-US.md
@@ -26,6 +26,7 @@ spline: explain
 - `Form`: Fixed the issue where nested forms lost their numerical values after the `validate` function was triggered, resulting in re-rendering @RylanBot ([#4350](https://github.com/Tencent/tdesign-react/pull/4350))
 - `Popup`: Fixed the problem where the popup would not close automatically when the mouse button was held down or clicked right on it after leaving the popup area @RylanBot ([#4287](https://github.com/Tencent/tdesign-react/pull/4287))
 - `SelectInput`: Fixed issues caused by adjustments in version `1.18.1`, which led to changes in the DOM structure when using a single-selection option without `filterable` enabled and a custom `valueDisplay` string being used @RylanBot ([#4351](https://github.com/Tencent/tdesign-react/pull/4351))
+- `Select`: Fixed the issue where the complete option list was briefly displayed when closing the panel after selecting an option with `filterable` enabled @RSS1102 ([#4388](https://github.com/Tencent/tdesign-react/pull/4388))
 - `Steps`: 
   - Fixed issues with alignment of connection lines and inconsistent distances from the surrounding icons when `layout='vertical'` was used @RylanBot ([common#2670](https://github.com/Tencent/tdesign-common/pull/2670))
   - Fixed the connection line thickness inconsistency between the default and selected states @RylanBot ([common#2670](https://github.com/Tencent/tdesign-common/pull/2670))

--- a/packages/tdesign-react/CHANGELOG.md
+++ b/packages/tdesign-react/CHANGELOG.md
@@ -26,6 +26,7 @@ spline: explain
 - `Form`: 修复嵌套表单在触发 `validate` 后重渲染导致数值丢失的问题 @RylanBot ([#4350](https://github.com/Tencent/tdesign-react/pull/4350))
 - `Popup`: 修复鼠标在浮层上左键长按或右键点击后，移出浮层无法自动关闭的问题 @RylanBot ([#4287](https://github.com/Tencent/tdesign-react/pull/4287))
 - `SelectInput`: 修复 `1.18.1` 的调整，导致单选且未开启 `filterable` 时，`valueDisplay` 为自定义字符串导致的 DOM 结构变更问题 @RylanBot ([#4351](https://github.com/Tencent/tdesign-react/pull/4351))
+- `Select`: 修复 `filterable` 选择选项后关闭面板时短暂显示完整列表的问题 @RSS1102 ([#4388](https://github.com/Tencent/tdesign-react/pull/4388))
 - `Steps`: 
   - 修复 `layout='vertical'` 时，连接线不对齐和上下图标距离不一致的问题 @RylanBot ([common#2670](https://github.com/Tencent/tdesign-common/pull/2670))
   - 修复默认和选中态的连接线粗细不一致的问题 @RylanBot ([common#2670](https://github.com/Tencent/tdesign-common/pull/2670))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 组件样式/交互改进
- [ ] 重构

### 🔗 相关 Issue

https://tdesign.tencent.com/react/components/select#可过滤的选择器

#4382

 perf #4388

### 💡 需求背景和解决方案

Select 的 `filterable` 面板在选中选项时会立即清空筛选词，但浮层仍处于关闭动画中。原实现通过 effect 更新候选列表，因此可能先提交完整列表，再提交筛选结果，造成“完整列表 → 筛选列表”的短暂闪动。

本次修复将候选项标准化和本地过滤结果改为同步派生，保证同一次渲染使用最新的筛选列表；同时保留关闭动画期间的最后一份可见列表，避免清空关键词时提前显示全部选项。已选项映射仍基于完整候选数据，避免筛选或远程搜索后丢失已选标签。

### 📝 更新日志

#### tdesign-react

- fix(Select): 修复 `filterable` 选择选项后关闭面板时短暂显示完整列表的问题
- fix(Select): 修复 `filterable` 下中文输入法筛选选中后再次输入会残留上次筛选内容的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
